### PR TITLE
멤버의 Entity, Repository 구현

### DIFF
--- a/backend/src/main/java/com/votogether/domain/member/entity/Gender.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Gender.java
@@ -1,0 +1,9 @@
+package com.votogether.domain.member.entity;
+
+public enum Gender {
+
+    MALE,
+    FEMALE,
+    ;
+
+}

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -1,0 +1,62 @@
+package com.votogether.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 15, nullable = false)
+    private String nickname;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private Gender gender;
+
+    @Column(nullable = false)
+    private LocalDateTime birthDate;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private SocialType socialType;
+
+    @Column(nullable = false)
+    private String socialId;
+
+    @Column(nullable = false)
+    private Integer point;
+
+    @Builder
+    private Member(
+            final String nickname,
+            final LocalDateTime birthDate,
+            final Gender gender,
+            final SocialType socialType,
+            final String socialId,
+            final Integer point
+    ) {
+        this.nickname = nickname;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.socialType = socialType;
+        this.socialId = socialId;
+        this.point = point;
+    }
+
+}

--- a/backend/src/main/java/com/votogether/domain/member/entity/MemberCategory.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/MemberCategory.java
@@ -1,0 +1,36 @@
+package com.votogether.domain.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class MemberCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private Long categoryId;
+
+    @Builder
+    private MemberCategory(final Member member, final Long categoryId) {
+        this.member = member;
+        this.categoryId = categoryId;
+    }
+
+}

--- a/backend/src/main/java/com/votogether/domain/member/entity/SocialType.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/SocialType.java
@@ -1,0 +1,8 @@
+package com.votogether.domain.member.entity;
+
+public enum SocialType {
+
+    GOOGLE,
+    ;
+
+}

--- a/backend/src/main/java/com/votogether/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/votogether/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.votogether.domain.member.repository;
+
+import com.votogether.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/backend/src/main/java/com/votogether/domain/vote/entity/Vote.java
+++ b/backend/src/main/java/com/votogether/domain/vote/entity/Vote.java
@@ -1,0 +1,37 @@
+package com.votogether.domain.vote.entity;
+
+import com.votogether.domain.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Vote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private Long postOptionId;
+
+    @Builder
+    private Vote(final Member member, final Long postOptionId) {
+        this.member = member;
+        this.postOptionId = postOptionId;
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #7 

## 📝 작업 요약

Member, MemberCategory, Vote 엔티티 구현했습니다.

## 🔎 작업 상세 설명

- 각각 엔티티 구현하고 연관관계 매핑은 전부 진행하지 않았습니다.
- Vote와 MemberCategory는 필요에 따라 Repository를 만드는 것으로 결정하여
Repository를 생성하지 않았습니다.

## 🌟 논의 사항

크루들과 이야기 해보고 싶은 부분을 적어주세요.

없음
