### PR TITLE
Jpa Auditing, Swagger 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,36 +1,40 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.1'
-	id 'io.spring.dependency-management' version '1.1.0'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.1'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'com'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+    runtimeOnly 'com.h2database:h2'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/backend/src/main/java/com/votogether/VotogetherApplication.java
+++ b/backend/src/main/java/com/votogether/VotogetherApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class VotogetherApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(VotogetherApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(VotogetherApplication.class, args);
+    }
 
 }

--- a/backend/src/main/java/com/votogether/config/JpaConfig.java
+++ b/backend/src/main/java/com/votogether/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.votogether.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/backend/src/main/java/com/votogether/config/OpenAPIConfig.java
+++ b/backend/src/main/java/com/votogether/config/OpenAPIConfig.java
@@ -1,0 +1,40 @@
+package com.votogether.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+
+    @Value("${votogether.openapi.dev-url}")
+    private String devUrl;
+
+    @Value("${votogether.openapi.prod-url}")
+    private String prodUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        final Server devServer = new Server();
+        devServer.setUrl(devUrl);
+        devServer.description("개발 환경 서버 URL");
+
+        final Server prodServer = new Server();
+        prodServer.setUrl(prodUrl);
+        prodServer.description("운영 환경 서버 URL");
+
+        final Info info = new Info()
+                .title("VoTogether API")
+                .version("v1.0.0")
+                .description("보투게더 API");
+
+        return new OpenAPI()
+                .info(info)
+                .servers(List.of(devServer, prodServer));
+    }
+
+}

--- a/backend/src/main/java/com/votogether/config/OpenAPIConfig.java
+++ b/backend/src/main/java/com/votogether/config/OpenAPIConfig.java
@@ -11,11 +11,16 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenAPIConfig {
 
-    @Value("${votogether.openapi.dev-url}")
-    private String devUrl;
+    private final String devUrl;
+    private final String prodUrl;
 
-    @Value("${votogether.openapi.prod-url}")
-    private String prodUrl;
+    public OpenAPIConfig(
+            @Value("${votogether.openapi.dev-url}") final String devUrl,
+            @Value("${votogether.openapi.prod-url}") final String prodUrl
+    ) {
+        this.devUrl = devUrl;
+        this.prodUrl = prodUrl;
+    }
 
     @Bean
     public OpenAPI openAPI() {

--- a/backend/src/main/java/com/votogether/domain/common/BaseEntity.java
+++ b/backend/src/main/java/com/votogether/domain/common/BaseEntity.java
@@ -15,11 +15,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(columnDefinition="datetime(2)", updatable = false, nullable = false)
+    @Column(columnDefinition = "datetime(2)", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(columnDefinition="datetime(2)", nullable = false)
+    @Column(columnDefinition = "datetime(2)", nullable = false)
     private LocalDateTime updatedAt;
 
 }

--- a/backend/src/main/java/com/votogether/domain/healthcheck/controller/HealthCheckController.java
+++ b/backend/src/main/java/com/votogether/domain/healthcheck/controller/HealthCheckController.java
@@ -1,0 +1,29 @@
+package com.votogether.domain.healthcheck.controller;
+
+import com.votogether.domain.healthcheck.service.HealthCheckService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "헬스 체크", description = "헬스 체크 API")
+@RequiredArgsConstructor
+@RequestMapping("/health-check")
+@RestController
+public class HealthCheckController {
+
+    private final HealthCheckService healthCheckService;
+
+    @Operation(summary = "헬스 체크 조회", description = "서버의 작동 여부 확인을 위해 헬스 체크를 조회한다.")
+    @ApiResponse(responseCode = "200", description = "헬스 체크 조회 성공")
+    @GetMapping
+    public ResponseEntity<String> check() {
+        final String response = healthCheckService.check();
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/backend/src/main/java/com/votogether/domain/healthcheck/service/HealthCheckService.java
+++ b/backend/src/main/java/com/votogether/domain/healthcheck/service/HealthCheckService.java
@@ -1,0 +1,12 @@
+package com.votogether.domain.healthcheck.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class HealthCheckService {
+
+    public String check() {
+        return "health-check";
+    }
+
+}

--- a/backend/src/main/java/com/votogether/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/Post.java
@@ -35,7 +35,7 @@ public class Post extends BaseEntity {
     @Column(length = 1000, nullable = false)
     private String content;
 
-    @Column(columnDefinition="datetime(2)", nullable = false)
+    @Column(columnDefinition = "datetime(2)", nullable = false)
     private LocalDateTime deadline;
 
     @Builder

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,3 +21,8 @@ logging:
           descriptor:
             sql:
               BasicBinder: TRACE
+
+votogether:
+  openapi:
+    dev-url: http://localhost:8080
+    prod-url: http://votogether.com

--- a/backend/src/test/java/com/votogether/VotogetherApplicationTests.java
+++ b/backend/src/test/java/com/votogether/VotogetherApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class VotogetherApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #26

## 📝 작업 요약

JPA Auditing 설정과 Swagger 설정을 진행하였습니다.

## 🔎 작업 상세 설명

- @EnableJpaAuditing을 통해 Auditing 동작이 수행되도록 하였습니다.
- Swagger 사용을 위한 openapi 의존성을 추가하고 OpenAPI 설정을 수행하였습니다.
- 서버의 정상 작동 여부를 확인하고 서버의 상태를 주기적으로 확인하는 헬스 체크 기능을 구현하여 Swagger 예시 코드를 작성해보았습니다.

## 🌟 논의 사항

백엔드 화이팅 🔥