### PR TITLE
PR 진행 시 테스트 통과 선행 기능 구현

### DIFF
--- a/.github/workflows/backend-pr-test.yml
+++ b/.github/workflows/backend-pr-test.yml
@@ -1,0 +1,71 @@
+name: Backend Test When Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - 'backend/**'
+      - '.github/**'
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: 레포지토리 체크아웃
+        uses: actions/checkout@v3
+
+      - name: JDK 17 환경 설정
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Gradle 캐시
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Gradle 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: Gradle 테스트 실행
+        run: ./gradlew --info test
+
+      - name: 테스트 결과 PR 코멘트 등록
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+
+      - name: 테스트 실패 시 해당 코드 라인에 Check 등록
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+      - name: 테스트 실패 시 Slack 알림
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: 백엔드 테스트 실패 알림
+          fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # Mac
 .DS_Store
+
+# IntelliJ
+.idea
+
+# vscode
+.vscode


### PR DESCRIPTION
## 🔥 연관 이슈

close: #33

## 📝 작업 요약

PR 진행 시 테스트를 진행하고, 테스트 성공 시 merge가 가능하도록 하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

### 주요 작업

- `main`, `dev` 브랜치에 PR 진행 시 테스트를 선행으로 진행합니다.
- 테스트 결과가 PR 코멘트로 등록됩니다.
- 실패하는 테스트가 존재하는 경우
  - merge 동작을 수행할 수 없습니다.
  - files changed에 실패하는 코드 라인에 check가 등록됩니다. 해당 체크는 테스트가 통과하면 자동으로 사라집니다.
  - Slack 채널을 통해 알림이 발생합니다.
- 오류를 수정 후 해당 PR에 다시 커밋하게 되면 workflow가 자동으로 다시 실행됩니다.

### 서브 작업

- 슬랙 앱을 통해 채널 웹훅을 설정합니다.
- 레포지토리의 시크릿 값을 입력합니다.
- 워크플로우가 통과되지 않으면 merge가 되지 않도록 브랜치 정책을 설정합니다.

## 🌟 논의 사항

현재 백엔드 프로젝트에 대해서만 설정한 workflow가 동작하도록 되어있습니다. workflow가 정상적으로 통과되지 않으면 merge가 되지 않도록 설정하고자 했는데 그럴 경우 프론트 PR에 대해서는 workflow가 동작하지 않아 merge를 할 수 없는 문제가 발생합니다. 이 부분을 어떻게 하면 좋을지 의논해보고 싶어요 :)