### PR TITLE
레이아웃 컴포넌트 구현

### DIFF
--- a/frontend/src/components/common/Dashboard/style.ts
+++ b/frontend/src/components/common/Dashboard/style.ts
@@ -1,5 +1,7 @@
 import { styled } from 'styled-components';
 
+import { theme } from '@styles/theme';
+
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -9,6 +11,10 @@ export const Container = styled.div`
   height: 100vh;
   padding: 20px;
   border-right: 2px solid var(--gray);
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    height: 100%;
+  }
 `;
 
 export const ContentContainer = styled.div`

--- a/frontend/src/components/common/Layout/Layout.stories.tsx
+++ b/frontend/src/components/common/Layout/Layout.stories.tsx
@@ -43,7 +43,7 @@ const MOCK_FAVORITE_CATEGORIES: Category[] = [
 export const VisibleCategory: Story = {
   render: () => (
     <Layout
-      isVisibleCategory={true}
+      isSidebarVisible={true}
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_FAVORITE_CATEGORIES}
       handleFavoriteClick={() => {}}
@@ -66,7 +66,7 @@ export const VisibleCategory: Story = {
 export const HiddenCategory: Story = {
   render: () => (
     <Layout
-      isVisibleCategory={false}
+      isSidebarVisible={false}
       categoryList={MOCK_FAVORITE_CATEGORIES}
       handleFavoriteClick={() => {}}
       handleLogoutClick={() => {}}

--- a/frontend/src/components/common/Layout/Layout.stories.tsx
+++ b/frontend/src/components/common/Layout/Layout.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Category } from '@type/category';
+import type { User } from '@type/user';
+
+import Skeleton from '../Skeleton';
+
+import Layout from '.';
+
+const meta: Meta<typeof Layout> = {
+  component: Layout,
+};
+
+export default meta;
+type Story = StoryObj<typeof Layout>;
+
+const MOCK_USER_INFO: User = {
+  nickname: '우아한 코끼리',
+  postCount: 4,
+  voteCount: 128,
+  userPoint: 200,
+};
+
+const MOCK_FAVORITE_CATEGORIES: Category[] = [
+  { id: 12312, name: '음식', isFavorite: false },
+  { id: 12, name: '연애', isFavorite: true },
+  { id: 13, name: '패션', isFavorite: true },
+  { id: 14, name: '금융', isFavorite: false },
+  { id: 12312, name: '음식', isFavorite: false },
+  { id: 12, name: '연애', isFavorite: true },
+  { id: 13, name: '패션', isFavorite: true },
+  { id: 14, name: '금융', isFavorite: false },
+  { id: 12312, name: '음식', isFavorite: false },
+  { id: 12, name: '연애', isFavorite: true },
+  { id: 13, name: '패션', isFavorite: true },
+  { id: 14, name: '금융', isFavorite: false },
+  { id: 12312, name: '음식', isFavorite: false },
+  { id: 12, name: '연애', isFavorite: true },
+  { id: 13, name: '패션', isFavorite: true },
+  { id: 14, name: '금융', isFavorite: false },
+];
+
+export const VisibleCategory: Story = {
+  render: () => (
+    <Layout
+      isVisibleCategory={true}
+      userInfo={MOCK_USER_INFO}
+      categoryList={MOCK_FAVORITE_CATEGORIES}
+      handleFavoriteClick={() => {}}
+      handleLogoutClick={() => {}}
+    >
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+    </Layout>
+  ),
+};
+
+export const HiddenCategory: Story = {
+  render: () => (
+    <Layout
+      isVisibleCategory={false}
+      categoryList={MOCK_FAVORITE_CATEGORIES}
+      handleFavoriteClick={() => {}}
+      handleLogoutClick={() => {}}
+    >
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+    </Layout>
+  ),
+};

--- a/frontend/src/components/common/Layout/index.tsx
+++ b/frontend/src/components/common/Layout/index.tsx
@@ -12,7 +12,7 @@ interface LayoutProps extends PropsWithChildren {
   userInfo?: User;
   categoryList: Category[];
   selectedCategory?: string;
-  isVisibleCategory: boolean;
+  isSidebarVisible: boolean;
   handleFavoriteClick: (categoryId: number) => void;
   handleLogoutClick: () => void;
 }
@@ -21,7 +21,7 @@ export default function Layout({
   userInfo,
   categoryList,
   selectedCategory,
-  isVisibleCategory,
+  isSidebarVisible,
   handleFavoriteClick,
   handleLogoutClick,
   children,
@@ -32,7 +32,7 @@ export default function Layout({
         <WideHeader />
       </S.WideHeaderWrapper>
       <S.ContentContainer>
-        {isVisibleCategory && (
+        {isSidebarVisible && (
           <S.DashboardWrapper>
             <Dashboard
               userInfo={userInfo}
@@ -43,8 +43,8 @@ export default function Layout({
             />
           </S.DashboardWrapper>
         )}
-        <S.MainContainer $isVisibleCategory={isVisibleCategory}>
-          <S.ChildrenWrapper $isVisibleCategory={isVisibleCategory}>{children}</S.ChildrenWrapper>
+        <S.MainContainer $isSidebarVisible={isSidebarVisible}>
+          <S.ChildrenWrapper $isSidebarVisible={isSidebarVisible}>{children}</S.ChildrenWrapper>
         </S.MainContainer>
       </S.ContentContainer>
     </S.Container>

--- a/frontend/src/components/common/Layout/index.tsx
+++ b/frontend/src/components/common/Layout/index.tsx
@@ -1,0 +1,52 @@
+import React, { PropsWithChildren } from 'react';
+
+import type { Category } from '@type/category';
+import type { User } from '@type/user';
+
+import Dashboard from '@components/common/Dashboard';
+import WideHeader from '@components/common/WideHeader';
+
+import * as S from './style';
+
+interface LayoutProps extends PropsWithChildren {
+  userInfo?: User;
+  categoryList: Category[];
+  selectedCategory?: string;
+  isVisibleCategory: boolean;
+  handleFavoriteClick: (categoryId: number) => void;
+  handleLogoutClick: () => void;
+}
+
+export default function Layout({
+  userInfo,
+  categoryList,
+  selectedCategory,
+  isVisibleCategory,
+  handleFavoriteClick,
+  handleLogoutClick,
+  children,
+}: LayoutProps) {
+  return (
+    <S.Container>
+      <S.WideHeaderWrapper>
+        <WideHeader />
+      </S.WideHeaderWrapper>
+      <S.ContentContainer>
+        {isVisibleCategory && (
+          <S.DashboardWrapper>
+            <Dashboard
+              userInfo={userInfo}
+              categoryList={categoryList}
+              selectedCategory={selectedCategory}
+              handleFavoriteClick={handleFavoriteClick}
+              handleLogoutClick={handleLogoutClick}
+            />
+          </S.DashboardWrapper>
+        )}
+        <S.MainContainer $isVisibleCategory={isVisibleCategory}>
+          <S.ChildrenWrapper $isVisibleCategory={isVisibleCategory}>{children}</S.ChildrenWrapper>
+        </S.MainContainer>
+      </S.ContentContainer>
+    </S.Container>
+  );
+}

--- a/frontend/src/components/common/Layout/style.ts
+++ b/frontend/src/components/common/Layout/style.ts
@@ -39,17 +39,17 @@ export const DashboardWrapper = styled.aside`
   }
 `;
 
-export const MainContainer = styled.main<{ $isVisibleCategory: boolean }>`
+export const MainContainer = styled.main<{ $isSidebarVisible: boolean }>`
   display: flex;
   justify-content: center;
 
   width: 100%;
   @media (min-width: ${theme.breakpoint.sm}) {
-    padding-left: ${({ $isVisibleCategory }) => $isVisibleCategory && '225px'};
+    padding-left: ${({ $isSidebarVisible }) => $isSidebarVisible && '225px'};
   }
 `;
 
-export const ChildrenWrapper = styled.div<{ $isVisibleCategory: boolean }>`
+export const ChildrenWrapper = styled.div<{ $isSidebarVisible: boolean }>`
   width: 100%;
-  max-width: ${({ $isVisibleCategory }) => $isVisibleCategory && '500px'};
+  max-width: ${({ $isSidebarVisible }) => $isSidebarVisible && '500px'};
 `;

--- a/frontend/src/components/common/Layout/style.ts
+++ b/frontend/src/components/common/Layout/style.ts
@@ -1,0 +1,55 @@
+import { styled } from 'styled-components';
+
+import { theme } from '@styles/theme';
+
+export const Container = styled.div`
+  height: 100vh;
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    padding-top: 70px;
+  }
+`;
+
+export const WideHeaderWrapper = styled.div`
+  width: 100%;
+
+  position: fixed;
+  top: 0;
+
+  @media (max-width: ${theme.breakpoint.sm}) {
+    display: none;
+    visibility: hidden;
+  }
+`;
+
+export const DashboardWrapper = styled.aside`
+  height: 90vh;
+
+  position: fixed;
+  left: 0;
+
+  @media (max-width: ${theme.breakpoint.sm}) {
+    display: none;
+    visibility: hidden;
+  }
+`;
+
+export const MainContainer = styled.main<{ $isVisibleCategory: boolean }>`
+  display: flex;
+  justify-content: center;
+
+  width: 100%;
+  @media (min-width: ${theme.breakpoint.sm}) {
+    padding-left: ${({ $isVisibleCategory }) => $isVisibleCategory && '225px'};
+  }
+`;
+
+export const ChildrenWrapper = styled.div<{ $isVisibleCategory: boolean }>`
+  width: 100%;
+  max-width: ${({ $isVisibleCategory }) => $isVisibleCategory && '500px'};
+`;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #62 

## 소요시간

1시간 30분

## 폴더 구조

📦Layout
 ┣ 📜Layout.stories.tsx
 ┣ 📜index.tsx
 ┗ 📜style.ts

## props 설명

```tsx
interface LayoutProps extends PropsWithChildren {
  userInfo?: User; // 유저 정보
  categoryList: Category[]; // 카테고리 리스트
  selectedCategory?: string; // 선택된 카테고리
  isSidebarVisible: boolean; // 사이드바를 보일지 유무 
  handleFavoriteClick: (categoryId: number) => void; // 즐겨찾기 클릭
  handleLogoutClick: () => void; // 로그아웃 클릭
}
```

## 📝 작업 요약

- 모바일 화면에서는 와이드 헤더와 사이드바가 보이지 않음
- 모바일 이상에서는 와이드 헤더와 사이드바가 보임
- 사이드바를 isSidebarVisible 이라는 props로 숨기거나 보이게 함
- 콘텐츠가 보이는 곳에 사이드바가 있다면 max-width :500px, 없다면 max-width를 설정하지 않음
- 사이드바엔 aside 태그, children이 들어갈 곳엔 main 태그를 두어 의미있는 태그를 사용하고자 함


## 🌟 논의 사항

Layout와 같은 컴포넌트를  common 폴더에서 관리했는지 혹은 layout 폴더를 따로 만들어 관리했는지 궁금합니다

저는 layout 폴더를 따로 만들었던 것 같아서요
