### PR TITLE
유저 정보를 불러오는 패치 api 함수 구현 및 msw mocking 구현

### DIFF
--- a/frontend/__test__/api/user.test.ts
+++ b/frontend/__test__/api/user.test.ts
@@ -1,0 +1,11 @@
+import { getUserInfo, transformUserInfoResponse } from '@api/wus/userInfo';
+
+import { MOCK_USER_INFO } from '@mocks/mockData/user';
+
+describe('서버와 통신하여 유저의 정보를 불러올 수 있어야 한다.', () => {
+  test('유저의 정보를 불러온다', async () => {
+    const data = await getUserInfo();
+
+    expect(data).toEqual(transformUserInfoResponse(MOCK_USER_INFO));
+  });
+});

--- a/frontend/__test__/api/user.test.ts
+++ b/frontend/__test__/api/user.test.ts
@@ -8,4 +8,12 @@ describe('서버와 통신하여 유저의 정보를 불러올 수 있어야 한
 
     expect(data).toEqual(transformUserInfoResponse(MOCK_USER_INFO));
   });
+
+  test('클라이언트에서 사용하는 유저 정보 API 명세가 [nickname, postCount, userPoint, userPoint, badge]으로 존재해야한다', async () => {
+    const data = await getUserInfo();
+
+    const userInfoKeys = Object.keys(data);
+
+    expect(userInfoKeys).toEqual(['nickname', 'postCount', 'userPoint', 'voteCount', 'badge']);
+  });
 });

--- a/frontend/src/api/wus/userInfo.ts
+++ b/frontend/src/api/wus/userInfo.ts
@@ -1,8 +1,8 @@
-import { ServerUser, User } from '@type/user';
+import type { UserInfoResponse, User } from '@type/user';
 
 import { getFetch } from '@utils/fetch';
 
-export const transformUserInfoResponse = (userInfo: ServerUser): User => {
+export const transformUserInfoResponse = (userInfo: UserInfoResponse): User => {
   const { nickname, postCount, userPoint, voteCount, badge } = userInfo;
 
   return {
@@ -15,7 +15,7 @@ export const transformUserInfoResponse = (userInfo: ServerUser): User => {
 };
 
 export const getUserInfo = async () => {
-  const userInfo = await getFetch<ServerUser>('/members/me');
+  const userInfo = await getFetch<UserInfoResponse>('/members/me');
 
   return transformUserInfoResponse(userInfo);
 };

--- a/frontend/src/api/wus/userInfo.ts
+++ b/frontend/src/api/wus/userInfo.ts
@@ -1,0 +1,21 @@
+import { ServerUser, User } from '@type/user';
+
+import { getFetch } from '@utils/fetch';
+
+export const transformUserInfoResponse = (userInfo: ServerUser): User => {
+  const { nickname, postCount, userPoint, voteCount, badge } = userInfo;
+
+  return {
+    nickname,
+    postCount,
+    userPoint,
+    voteCount,
+    badge,
+  };
+};
+
+export const getUserInfo = async () => {
+  const userInfo = await getFetch<ServerUser>('/members/me');
+
+  return transformUserInfoResponse(userInfo);
+};

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,7 +1,7 @@
 import { example } from './example/get';
-
 import { mockVoteResult } from './getVoteDetail';
 import { mockPost } from './post';
 import { mockVote } from './vote';
+import { mockUserInfo } from './wus/userInfo';
 
-export const handlers = [...example, ...mockPost, ...mockVoteResult, ...mockVote];
+export const handlers = [...example, ...mockPost, ...mockVoteResult, ...mockVote, ...mockUserInfo];

--- a/frontend/src/mocks/mockData/user.ts
+++ b/frontend/src/mocks/mockData/user.ts
@@ -1,6 +1,6 @@
-import { User } from '@type/user';
+import { UserInfoResponse } from '@type/user';
 
-export const MOCK_USER_INFO: User = {
+export const MOCK_USER_INFO: UserInfoResponse = {
   nickname: '우아한 코끼리',
   postCount: 4,
   voteCount: 128,

--- a/frontend/src/mocks/wus/userInfo.ts
+++ b/frontend/src/mocks/wus/userInfo.ts
@@ -1,0 +1,9 @@
+import { rest } from 'msw';
+
+import { MOCK_USER_INFO } from '@mocks/mockData/user';
+
+export const mockUserInfo = [
+  rest.get('/members/me', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(MOCK_USER_INFO));
+  }),
+];

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -5,3 +5,11 @@ export interface User {
   voteCount: number;
   badge?: string;
 }
+
+export interface ServerUser {
+  nickname: string;
+  userPoint: number;
+  postCount: number;
+  voteCount: number;
+  badge?: string;
+}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -6,7 +6,7 @@ export interface User {
   badge?: string;
 }
 
-export interface ServerUser {
+export interface UserInfoResponse {
   nickname: string;
   userPoint: number;
   postCount: number;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #63 

## 소요 시간

1시간

## 📝 작업 요약

- 유저 정보를 불러오는 패치 함수 (/members/me) 구현
- 이를 모킹할 수 있는 msw 코드 구현

## 🔎 작업 상세 설명

아래와 같이 서버에서 받아온 데이터를 클라이언트에서 사용하는 api 명세로 바꾸었습니다. 하지만 서버에서 받아온 것이나 클라이언트에서 받아온 것이나 똑같이 보이는데요. 이렇게 한 이유는 아래와 같이 백앤드에서 보내줄 데이터의 이름이 변경이 많이 될 것이 예상되었기 때문입니다 👍

![image](https://github.com/woowacourse-teams/2023-votogether/assets/80146176/cc5671ea-0c7b-40d3-89bb-dadb61e12036)


```tsx
import { ServerUser, User } from '@type/user';

import { getFetch } from '@utils/fetch';

export const transformUserInfoResponse = (userInfo: ServerUser): User => {
  const { nickname, postCount, userPoint, voteCount, badge } = userInfo;

  return {
    nickname,
    postCount,
    userPoint,
    voteCount,
    badge,
  };
};

export const getUserInfo = async () => {
  const userInfo = await getFetch<ServerUser>('/members/me');

  return transformUserInfoResponse(userInfo);
};

```


