### PR TITLE
카테고리별 게시글 조회 기능을 위해 getPostList 함수 수정 이후 usePostList 훅 추가 기능 구현

### DIFF
--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -20,4 +20,15 @@ describe('전체 게시글 목록을 패치하는 로직이 의도한대로 작�
 
     expect(data.pageNumber).toEqual(3);
   });
+
+  test('카테고리별 게시글 페이지의 정보를 불러온다.', async () => {
+    const data = await getPostList({
+      postStatus: 'closed',
+      postSorting: 'popular',
+      pageNumber: 3,
+      categoryId: 1,
+    });
+
+    expect(data.postList).toEqual(MOCK_POST_LIST[3]);
+  });
 });

--- a/frontend/__test__/hooks/query/usePostList.test.tsx
+++ b/frontend/__test__/hooks/query/usePostList.test.tsx
@@ -14,9 +14,20 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 );
 
 describe('usePostList 훅이 의도한대로 작동하는 지 확인한다.', () => {
-  test('게시글 목록을 불러온다.', async () => {
+  test('전체 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
       () => usePostList({ postSorting: 'popular', postStatus: 'all' }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.data?.pages[0].postList).toEqual(MOCK_POST_LIST[0]));
+  });
+
+  test('카테고리별 게시글 목록을 불러온다.', async () => {
+    const { result } = renderHook(
+      () => usePostList({ postSorting: 'popular', postStatus: 'all', categoryId: 1 }),
       {
         wrapper,
       }

--- a/frontend/src/api/wus/postList.ts
+++ b/frontend/src/api/wus/postList.ts
@@ -13,7 +13,7 @@ interface PostListByOption {
   categoryId?: number;
 }
 
-export const getPostListUrl = ({
+export const makePostListUrl = ({
   categoryId,
   postStatus,
   postSorting,
@@ -22,11 +22,13 @@ export const getPostListUrl = ({
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
+  const OPTION_URL = `status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
+
   if (categoryId) {
-    return `/posts?categoryId=${categoryId}&status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
+    return `/posts?categoryId=${categoryId}&${OPTION_URL}`;
   }
 
-  return `/posts?status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
+  return `/posts?${OPTION_URL}`;
 };
 
 export const getPostList = async ({
@@ -35,7 +37,7 @@ export const getPostList = async ({
   pageNumber,
   categoryId,
 }: PostListByOption) => {
-  const postListUrl = getPostListUrl({ pageNumber, postSorting, postStatus, categoryId });
+  const postListUrl = makePostListUrl({ pageNumber, postSorting, postStatus, categoryId });
 
   const postList = await getFetch<PostInfo[]>(postListUrl);
 

--- a/frontend/src/api/wus/postList.ts
+++ b/frontend/src/api/wus/postList.ts
@@ -13,6 +13,8 @@ interface PostListByOption {
   categoryId?: number;
 }
 
+const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
+
 export const makePostListUrl = ({
   categoryId,
   postStatus,
@@ -22,13 +24,14 @@ export const makePostListUrl = ({
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
+  const POST_BASE_URL = `${BASE_URL}/posts`;
   const OPTION_URL = `status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
 
   if (categoryId) {
-    return `/posts?categoryId=${categoryId}&${OPTION_URL}`;
+    return `${POST_BASE_URL}?categoryId=${categoryId}&${OPTION_URL}`;
   }
 
-  return `/posts?${OPTION_URL}`;
+  return `${POST_BASE_URL}?${OPTION_URL}`;
 };
 
 export const getPostList = async ({

--- a/frontend/src/api/wus/postList.ts
+++ b/frontend/src/api/wus/postList.ts
@@ -4,10 +4,11 @@ import type { PostSorting, PostStatus } from '@components/post/PostListPage/type
 
 import { getFetch } from '@utils/fetch';
 
-interface GetPostList {
+interface PostListByOption {
   postStatus: PostStatus;
   postSorting: PostSorting;
   pageNumber: number;
+  categoryId?: number;
 }
 
 const REQUEST_STATUS_OPTION: Record<PostStatus, string> = {
@@ -21,13 +22,27 @@ const REQUEST_SORTING_OPTION: Record<PostSorting, string> = {
   popular: 'HOT',
 };
 
-export const getPostList = async ({ postStatus, postSorting, pageNumber }: GetPostList) => {
+const getPostListUrl = ({ categoryId, postStatus, postSorting, pageNumber }: PostListByOption) => {
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
-  const postList = await getFetch<PostInfo[]>(
-    `/posts?status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`
-  );
+  if (categoryId) {
+    return `/posts?categoryId=${categoryId}&status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
+  }
+
+  return `/posts?status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
+};
+
+export const getPostList = async ({
+  postStatus,
+  postSorting,
+  pageNumber,
+  categoryId,
+}: PostListByOption) => {
+  const postListUrl = getPostListUrl({ pageNumber, postSorting, postStatus, categoryId });
+
+  const postList = await getFetch<PostInfo[]>(postListUrl);
+
   return {
     pageNumber,
     postList,

--- a/frontend/src/components/post/PostList/constants.ts
+++ b/frontend/src/components/post/PostList/constants.ts
@@ -1,0 +1,1 @@
+export const CATEGORY_ID = 'categoryId';

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -10,6 +10,8 @@ import Skeleton from '@components/common/Skeleton';
 import { SORTING_OPTION, STATUS_OPTION } from '@components/post/PostListPage/constants';
 import type { PostSorting, PostStatus } from '@components/post/PostListPage/types';
 
+import { CATEGORY_ID } from '@constants/post';
+
 import * as S from './style';
 
 export default function PostList() {
@@ -23,9 +25,14 @@ export default function PostList() {
   const { selectedOption: selectedSortingOption, handleOptionChange: handleSortingOptionChange } =
     useSelect<PostSorting>('latest');
 
+  const URL = new URLSearchParams(window.location.search);
+
+  const categoryId = URL.get(CATEGORY_ID);
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList({
     postSorting: selectedSortingOption,
     postStatus: selectedStatusOption,
+    categoryId: Number(categoryId),
   });
 
   useEffect(() => {

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import { usePostList } from '@hooks/query/usePostList';
 import { useIntersectionObserver } from '@hooks/useIntersectionObserver';
@@ -11,11 +11,10 @@ import Skeleton from '@components/common/Skeleton';
 import { SORTING_OPTION, STATUS_OPTION } from '@components/post/PostListPage/constants';
 import type { PostSorting, PostStatus } from '@components/post/PostListPage/types';
 
-import { CATEGORY_ID } from './constants';
 import * as S from './style';
 
 export default function PostList() {
-  const [searchParams] = useSearchParams();
+  const { categoryId } = useParams<{ categoryId?: string }>();
   const { targetRef, isIntersecting } = useIntersectionObserver({
     root: null,
     rootMargin: '',
@@ -25,8 +24,6 @@ export default function PostList() {
     useSelect<PostStatus>('progress');
   const { selectedOption: selectedSortingOption, handleOptionChange: handleSortingOptionChange } =
     useSelect<PostSorting>('latest');
-
-  const categoryId = searchParams.get(CATEGORY_ID);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList({
     postSorting: selectedSortingOption,

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import { usePostList } from '@hooks/query/usePostList';
 import { useIntersectionObserver } from '@hooks/useIntersectionObserver';
@@ -10,11 +11,11 @@ import Skeleton from '@components/common/Skeleton';
 import { SORTING_OPTION, STATUS_OPTION } from '@components/post/PostListPage/constants';
 import type { PostSorting, PostStatus } from '@components/post/PostListPage/types';
 
-import { CATEGORY_ID } from '@constants/post';
-
+import { CATEGORY_ID } from './constants';
 import * as S from './style';
 
 export default function PostList() {
+  const [searchParams] = useSearchParams();
   const { targetRef, isIntersecting } = useIntersectionObserver({
     root: null,
     rootMargin: '',
@@ -25,9 +26,7 @@ export default function PostList() {
   const { selectedOption: selectedSortingOption, handleOptionChange: handleSortingOptionChange } =
     useSelect<PostSorting>('latest');
 
-  const URL = new URLSearchParams(window.location.search);
-
-  const categoryId = URL.get(CATEGORY_ID);
+  const categoryId = searchParams.get(CATEGORY_ID);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList({
     postSorting: selectedSortingOption,

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -1,3 +1,5 @@
 export const POST = {
   NOT_VOTE: 0,
 };
+
+export const CATEGORY_ID = 'categoryId';

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -14,5 +14,3 @@ export const REQUEST_SORTING_OPTION: Record<PostSorting, string> = {
   latest: 'LATEST',
   popular: 'HOT',
 };
-
-export const CATEGORY_ID = 'categoryId';

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -9,15 +9,17 @@ import { PostSorting, PostStatus } from '@components/post/PostListPage/types';
 interface UsePostList {
   postSorting: PostSorting;
   postStatus: PostStatus;
+  categoryId?: number;
 }
 
 const MAX_LIST_LENGTH = 10;
 
-export const usePostList = ({ postSorting, postStatus }: UsePostList) => {
+export const usePostList = ({ postSorting, postStatus, categoryId }: UsePostList) => {
   const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<PostList>(
-      ['posts', postSorting, postStatus],
-      ({ pageParam = 0 }) => getPostList({ postSorting, postStatus, pageNumber: pageParam }),
+      ['posts', postSorting, postStatus, categoryId],
+      ({ pageParam = 0 }) =>
+        getPostList({ postSorting, postStatus, pageNumber: pageParam, categoryId }),
       {
         getNextPageParam: lastPage => {
           if (lastPage.postList.length !== MAX_LIST_LENGTH) return;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,7 +1,7 @@
 import { example } from './example/get';
-
 import { mockVoteResult } from './getVoteDetail';
 import { mockPost } from './post';
 import { mockVote } from './vote';
+import { mockPostList } from './wus/post';
 
-export const handlers = [...example, ...mockPost, ...mockVoteResult, ...mockVote];
+export const handlers = [...example, ...mockPost, ...mockVoteResult, ...mockVote, ...mockPostList];

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { example } from './example/get';
 import { mockVoteResult } from './getVoteDetail';
 import { mockPost } from './post';
 import { mockVote } from './vote';
+import { mockCategoryHandlers } from './wus/categoryList';
 import { mockPostList } from './wus/post';
 import { mockUserInfo } from './wus/userInfo';
 
@@ -11,5 +12,6 @@ export const handlers = [
   ...mockVoteResult,
   ...mockVote,
   ...mockPostList,
+  ...mockCategoryHandlers,
   ...mockUserInfo,
 ];

--- a/frontend/src/mocks/wus/post.ts
+++ b/frontend/src/mocks/wus/post.ts
@@ -2,7 +2,7 @@ import { rest } from 'msw';
 
 import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
-export const postListHandlers = [
+export const mockPostList = [
   rest.get('/posts', (req, res, ctx) => {
     const pages = Number(req.url.searchParams.get('pages'));
 

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -27,6 +27,7 @@ const router = createBrowserRouter([
         path: 'posts/result/:postId',
         element: <VoteStatisticsPage />,
       },
+      { path: 'posts/category/:categoryId', element: <Home /> },
     ],
   },
 ]);


### PR DESCRIPTION
## 🔥 연관 이슈

close: #110 

## 소요 시간

약 1시간

## 📝 작업 요약

- 카테고리별 게시글 조회 기능 패치 함수 구현
- usePostList에서 전체 게시글 조회뿐만 아니라 카테고리별 게시글 조회 기능도 추가
- PostList 컴포넌트에서 주소에 categoryId가 있다면 카테고리별 게시글 조회를 하도록 구현

## 🔎 작업 상세 설명

window.location.search로 `?categoryId=1` 과 같이 뒤에 붙은 url을 가져왔음

그리고 URLSearchParams를 통해 categoryId의 값을 구해 카테고리별 글 목록을 요청함

```tsx
  const URL = new URLSearchParams(window.location.search);

  const categoryId = URL.get(CATEGORY_ID);
```
