### PR TITLE
카카오에 엑세스 토큰 요청 시 타입 설정 및 회원 닉네임 반환 오류 수정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
         final Member member = Member.from(response);
         final Member registeredMember = memberService.register(member);
         final String token = tokenProcessor.generateToken(registeredMember);
-        return new LoginResponse(token, member.getNickname());
+        return new LoginResponse(token, registeredMember.getNickname());
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/auth/service/KakaoOAuthClient.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/KakaoOAuthClient.java
@@ -26,11 +26,16 @@ public class KakaoOAuthClient {
         info.remove("code");
         info.add("code", code);
 
-        final OAuthAccessTokenResponse response = restTemplate.postForObject(
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        final HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(info, headers);
+
+        final OAuthAccessTokenResponse response = restTemplate.postForEntity(
                 "https://kauth.kakao.com/oauth/token",
-                info,
+                httpEntity,
                 OAuthAccessTokenResponse.class
-        );
+        ).getBody();
         return response.accessToken();
     }
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #121 

## 📝 작업 요약

엑세서 토큰 요청 시 헤더 타입을 명시해줬습니다.
회원 닉네임이 잘못나오는 버그를 수정했습니다.

## 🔎 작업 상세 설명

없음.

## 🌟 논의 사항

없음.
