### PR TITLE
Swagger 페이지에 정상적으로 접근할 수 없는 오류

### DIFF
--- a/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
@@ -19,9 +19,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/health-check",
             "/auth/kakao/callback",
             "/categories/guest",
-            "/swagger-ui.html",
-            "/v3/api-docs/**",
-            "/swagger-ui/**"
+            "/swagger-ui.html"
+    );
+
+    private static final List<String> ALLOWED_START_URIS = List.of(
+            "/v3/api-docs",
+            "/swagger-ui"
     );
 
     private final TokenProcessor tokenProcessor;
@@ -40,8 +43,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        return ALLOWED_URIS.stream()
-                .anyMatch(url -> request.getRequestURI().contains(url));
+        return ALLOWED_URIS.stream().anyMatch(url -> request.getRequestURI().contains(url))
+                || ALLOWED_START_URIS.stream().anyMatch(url -> request.getRequestURI().startsWith(url));
     }
 
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #138

## 📝 작업 요약

Swagger 사용을 위해 Swagger URI로 시작하는 경로는 허용하도록 수정하였습니다.

## 🔎 작업 상세 설명

- `contains`로는 모든 하위 경로를 확인할 수 없습니다. 따라서 `startsWith`를 통해 하위 경로를 허용하도록 수정하였습니다.

## 🌟 논의 사항