### PR TITLE
다중 선택 컴포넌트 구현

### DIFF
--- a/frontend/src/components/common/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/src/components/common/MultiSelect/MultiSelect.stories.tsx
@@ -90,8 +90,8 @@ export const CategoryNotSelected = () => {
 
 export const CategorySelected = () => {
   const CATEGORY_COUNT_LIMIT = 3;
-  const initialSelectedOptionList = MOCK_OPTION_LIST.filter(
-    option => option.name === '옵션1' || option.name === '옵션7'
+  const initialSelectedOptionList = MOCK_CATEGORY_LIST.filter(
+    option => option.id === 7 || option.id === 9
   );
 
   const { selectedOptionList, handleOptionAdd, handleOptionDelete } = useMultiSelect(

--- a/frontend/src/components/common/MultiSelect/MultiSelect.stories.tsx
+++ b/frontend/src/components/common/MultiSelect/MultiSelect.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta } from '@storybook/react';
+
+import { useMultiSelect } from '@hooks/useMultiSelect';
+
+import MultiSelect from '.';
+
+const meta: Meta<typeof MultiSelect> = {
+  component: MultiSelect,
+  decorators: [storyFn => storyFn()],
+};
+
+export default meta;
+
+const MOCK_OPTION_LIST = [
+  { id: 1, name: '옵션1' },
+  { id: 2, name: '옵션2' },
+  { id: 5, name: '옵션3' },
+  { id: 7, name: '옵션4' },
+  { id: 9, name: '옵션5' },
+  { id: 10, name: '옵션6' },
+  { id: 11, name: '옵션7' },
+  { id: 13, name: '옵션8' },
+  { id: 15, name: '옵션9' },
+  { id: 16, name: '매우 긴----------~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~옵션10' },
+];
+
+const MOCK_CATEGORY_LIST = [
+  { id: 1, name: '음식' },
+  { id: 2, name: '패션' },
+  { id: 5, name: '금융' },
+  { id: 7, name: '게임' },
+  { id: 9, name: '개발' },
+  { id: 10, name: '연애' },
+  { id: 11, name: '취미' },
+  { id: 13, name: '주식' },
+  { id: 15, name: '연예' },
+  { id: 16, name: '정치' },
+];
+
+export const NotSelected = () => {
+  const { selectedOptionList, handleOptionAdd, handleOptionDelete } = useMultiSelect([]);
+
+  return (
+    <MultiSelect
+      selectedOptionList={selectedOptionList}
+      optionList={MOCK_OPTION_LIST}
+      handleOptionAdd={handleOptionAdd}
+      handleOptionDelete={handleOptionDelete}
+      placeholder="여러 개의 옵션을 선택해주세요."
+    />
+  );
+};
+
+export const Selected = () => {
+  const initialSelectedOptionList = MOCK_OPTION_LIST.filter(
+    option => option.name === '옵션1' || option.name === '옵션7'
+  );
+
+  const { selectedOptionList, handleOptionAdd, handleOptionDelete } =
+    useMultiSelect(initialSelectedOptionList);
+
+  return (
+    <MultiSelect
+      selectedOptionList={selectedOptionList}
+      optionList={MOCK_OPTION_LIST}
+      handleOptionAdd={handleOptionAdd}
+      handleOptionDelete={handleOptionDelete}
+    />
+  );
+};
+
+export const CategoryNotSelected = () => {
+  const CATEGORY_COUNT_LIMIT = 3;
+
+  const { selectedOptionList, handleOptionAdd, handleOptionDelete } = useMultiSelect(
+    [],
+    CATEGORY_COUNT_LIMIT
+  );
+
+  return (
+    <MultiSelect
+      selectedOptionList={selectedOptionList}
+      optionList={MOCK_CATEGORY_LIST}
+      handleOptionAdd={handleOptionAdd}
+      handleOptionDelete={handleOptionDelete}
+      placeholder="카테고리를 선택해주세요."
+    />
+  );
+};
+
+export const CategorySelected = () => {
+  const CATEGORY_COUNT_LIMIT = 3;
+  const initialSelectedOptionList = MOCK_OPTION_LIST.filter(
+    option => option.name === '옵션1' || option.name === '옵션7'
+  );
+
+  const { selectedOptionList, handleOptionAdd, handleOptionDelete } = useMultiSelect(
+    initialSelectedOptionList,
+    CATEGORY_COUNT_LIMIT
+  );
+
+  return (
+    <MultiSelect
+      selectedOptionList={selectedOptionList}
+      optionList={MOCK_CATEGORY_LIST}
+      handleOptionAdd={handleOptionAdd}
+      handleOptionDelete={handleOptionDelete}
+    />
+  );
+};

--- a/frontend/src/components/common/MultiSelect/index.tsx
+++ b/frontend/src/components/common/MultiSelect/index.tsx
@@ -62,15 +62,14 @@ export default function MultiSelect({
   }, [selectedOptionList, optionList, closeComponent]);
 
   const filteredOptionList = optionList.filter(
-    option => selectedOptionList.findIndex(selected => selected.id === option.id) === -1
+    option => !selectedOptionList.some(selected => selected.id === option.id)
   );
-
   return (
     <S.Wrapper onClick={handleToggleWrapper} ref={wrapperRef}>
       <S.Container>
         {selectedOptionList.length === 0 && <span>{placeholder} </span>}
         {selectedOptionList.map(({ id, name }) => (
-          <S.Chip key={id} onClick={(e: React.MouseEvent) => e.stopPropagation()}>
+          <S.SelectedOption key={id} onClick={(e: React.MouseEvent) => e.stopPropagation()}>
             <span>{name}</span>
             <OptionCancelButton
               onClick={(e: React.MouseEvent) => {
@@ -78,7 +77,7 @@ export default function MultiSelect({
                 handleOptionDelete(id);
               }}
             />
-          </S.Chip>
+          </S.SelectedOption>
         ))}
       </S.Container>
       <S.SelectIcon>

--- a/frontend/src/components/common/MultiSelect/index.tsx
+++ b/frontend/src/components/common/MultiSelect/index.tsx
@@ -32,7 +32,7 @@ export default function MultiSelect({
   const { isOpen, openComponent, closeComponent } = useToggle();
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const [wrapperClientHeight, setWrapperClientHeight] = useState(40);
+  const [wrapperClientHeight, setWrapperClientHeight] = useState(45);
 
   const handleToggleWrapper = () => {
     if (isOpen) {
@@ -45,11 +45,12 @@ export default function MultiSelect({
   useEffect(() => {
     if (wrapperRef) {
       if (selectedOptionList.length > 0) {
+        window.console.log(wrapperRef.current);
         const newClientHeight = wrapperRef.current ? wrapperRef.current.clientHeight : 25;
 
         setWrapperClientHeight(newClientHeight);
       } else {
-        setWrapperClientHeight(40);
+        setWrapperClientHeight(45);
       }
     }
   }, [selectedOptionList]);

--- a/frontend/src/components/common/MultiSelect/index.tsx
+++ b/frontend/src/components/common/MultiSelect/index.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import { useToggle } from '@hooks/useToggle';
+
+import OptionCancelButton from '@components/optionList/WritingVoteOptionList/WritingVoteOption/OptionCancelButton';
+
+import chevronDown from '@assets/chevron-down.svg';
+import chevronUp from '@assets/chevron-up.svg';
+
+import * as S from './style';
+
+interface Option {
+  id: number;
+  name: string;
+}
+
+interface MultiSelectProps {
+  selectedOptionList: Option[];
+  optionList: Option[];
+  handleOptionAdd: (newItem: Option) => void;
+  handleOptionDelete: (optionId: number) => void;
+  placeholder?: string;
+}
+
+export default function MultiSelect({
+  selectedOptionList,
+  optionList,
+  handleOptionAdd,
+  handleOptionDelete,
+  placeholder = '여러 개의 옵션을 선택해주세요',
+}: MultiSelectProps) {
+  const { isOpen, openComponent, closeComponent } = useToggle();
+
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [wrapperClientHeight, setWrapperClientHeight] = useState(40);
+
+  const handleToggleWrapper = () => {
+    if (isOpen) {
+      closeComponent();
+      return;
+    }
+    openComponent();
+  };
+
+  useEffect(() => {
+    if (wrapperRef) {
+      if (selectedOptionList.length > 0) {
+        const newClientHeight = wrapperRef.current ? wrapperRef.current.clientHeight : 25;
+
+        setWrapperClientHeight(newClientHeight);
+      } else {
+        setWrapperClientHeight(40);
+      }
+    }
+  }, [selectedOptionList]);
+
+  useEffect(() => {
+    if (selectedOptionList.length === optionList.length) {
+      closeComponent();
+    }
+  }, [selectedOptionList, optionList, closeComponent]);
+
+  const filteredOptionList = optionList.filter(
+    option => selectedOptionList.findIndex(selected => selected.id === option.id) === -1
+  );
+
+  return (
+    <S.Wrapper onClick={handleToggleWrapper} ref={wrapperRef}>
+      <S.Container>
+        {selectedOptionList.length === 0 && <span>{placeholder} </span>}
+        {selectedOptionList.map(({ id, name }) => (
+          <S.Chip key={id} onClick={(e: React.MouseEvent) => e.stopPropagation()}>
+            <span>{name}</span>
+            <OptionCancelButton
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                handleOptionDelete(id);
+              }}
+            />
+          </S.Chip>
+        ))}
+      </S.Container>
+      <S.SelectIcon>
+        <S.Image src={isOpen ? chevronUp : chevronDown} alt="" $isSelected={isOpen} />
+      </S.SelectIcon>
+      {filteredOptionList.length > 0 && (
+        <S.DropDown opened={isOpen} wrapperClientHeight={wrapperClientHeight}>
+          {filteredOptionList.map(({ id, name }) => (
+            <li
+              key={id}
+              onClick={e => {
+                e.stopPropagation();
+                handleOptionAdd({ id, name });
+              }}
+            >
+              {name}
+            </li>
+          ))}
+        </S.DropDown>
+      )}
+    </S.Wrapper>
+  );
+}

--- a/frontend/src/components/common/MultiSelect/index.tsx
+++ b/frontend/src/components/common/MultiSelect/index.tsx
@@ -31,9 +31,6 @@ export default function MultiSelect({
 }: MultiSelectProps) {
   const { isOpen, openComponent, closeComponent } = useToggle();
 
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const [wrapperClientHeight, setWrapperClientHeight] = useState(40);
-
   const filteredOptionList = optionList.filter(
     option => !selectedOptionList.some(selected => selected.id === option.id)
   );
@@ -46,38 +43,29 @@ export default function MultiSelect({
     openComponent();
   };
 
-  useEffect(() => {
-    if (wrapperRef) {
-      if (selectedOptionList.length > 0 && wrapperRef.current) {
-        setWrapperClientHeight(wrapperRef.current.clientHeight);
-
-        return;
-      }
-      setWrapperClientHeight(40);
-    }
-  }, [selectedOptionList]);
-
   return (
-    <S.Wrapper onClick={handleToggleWrapper} ref={wrapperRef}>
-      <S.SelectedOptionListContainer>
-        {selectedOptionList.length === 0 && <span>{placeholder} </span>}
-        {selectedOptionList.map(({ id, name }) => (
-          <S.SelectedOption key={id} onClick={(e: React.MouseEvent) => e.stopPropagation()}>
-            <span>{name}</span>
-            <OptionCancelButton
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation();
-                handleOptionDelete(id);
-              }}
-            />
-          </S.SelectedOption>
-        ))}
-      </S.SelectedOptionListContainer>
-      <S.SelectIcon>
-        <S.Image src={isOpen ? chevronUp : chevronDown} alt="" $isSelected={isOpen} />
-      </S.SelectIcon>
+    <S.Container>
+      <S.Wrapper onClick={handleToggleWrapper}>
+        <S.SelectedOptionListContainer>
+          {selectedOptionList.length === 0 && <span>{placeholder} </span>}
+          {selectedOptionList.map(({ id, name }) => (
+            <S.SelectedOption key={id} onClick={(e: React.MouseEvent) => e.stopPropagation()}>
+              <span>{name}</span>
+              <OptionCancelButton
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  handleOptionDelete(id);
+                }}
+              />
+            </S.SelectedOption>
+          ))}
+        </S.SelectedOptionListContainer>
+        <S.SelectIcon>
+          <S.Image src={isOpen ? chevronUp : chevronDown} alt="" $isSelected={isOpen} />
+        </S.SelectIcon>
+      </S.Wrapper>
       {filteredOptionList.length > 0 && (
-        <S.DropDown opened={isOpen} wrapperClientHeight={wrapperClientHeight}>
+        <S.DropDown opened={isOpen}>
           {filteredOptionList.map(({ id, name }) => (
             <li
               key={id}
@@ -91,6 +79,6 @@ export default function MultiSelect({
           ))}
         </S.DropDown>
       )}
-    </S.Wrapper>
+    </S.Container>
   );
 }

--- a/frontend/src/components/common/MultiSelect/index.tsx
+++ b/frontend/src/components/common/MultiSelect/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import type { Option } from './types';
 
-import { useToggle } from '@hooks/useToggle';
+import { useState, MouseEvent } from 'react';
 
 import OptionCancelButton from '@components/optionList/WritingVoteOptionList/WritingVoteOption/OptionCancelButton';
 
@@ -8,11 +8,6 @@ import chevronDown from '@assets/chevron-down.svg';
 import chevronUp from '@assets/chevron-up.svg';
 
 import * as S from './style';
-
-interface Option {
-  id: number;
-  name: string;
-}
 
 interface MultiSelectProps {
   selectedOptionList: Option[];
@@ -29,18 +24,14 @@ export default function MultiSelect({
   handleOptionDelete,
   placeholder = '여러 개의 옵션을 선택해주세요',
 }: MultiSelectProps) {
-  const { isOpen, openComponent, closeComponent } = useToggle();
+  const [isOpen, setIsOpen] = useState(false);
 
   const filteredOptionList = optionList.filter(
     option => !selectedOptionList.some(selected => selected.id === option.id)
   );
 
   const handleToggleWrapper = () => {
-    if (isOpen) {
-      closeComponent();
-      return;
-    }
-    openComponent();
+    setIsOpen(!isOpen);
   };
 
   return (
@@ -49,10 +40,10 @@ export default function MultiSelect({
         <S.SelectedOptionListContainer>
           {selectedOptionList.length === 0 && <span>{placeholder} </span>}
           {selectedOptionList.map(({ id, name }) => (
-            <S.SelectedOption key={id} onClick={(e: React.MouseEvent) => e.stopPropagation()}>
+            <S.SelectedOption key={id} onClick={(e: MouseEvent) => e.stopPropagation()}>
               <span>{name}</span>
               <OptionCancelButton
-                onClick={(e: React.MouseEvent) => {
+                onClick={(e: MouseEvent) => {
                   e.stopPropagation();
                   handleOptionDelete(id);
                 }}
@@ -65,7 +56,7 @@ export default function MultiSelect({
         </S.SelectIcon>
       </S.Wrapper>
       {filteredOptionList.length > 0 && (
-        <S.DropDown opened={isOpen}>
+        <S.DropDown $isOpened={isOpen}>
           {filteredOptionList.map(({ id, name }) => (
             <li
               key={id}

--- a/frontend/src/components/common/MultiSelect/index.tsx
+++ b/frontend/src/components/common/MultiSelect/index.tsx
@@ -32,7 +32,11 @@ export default function MultiSelect({
   const { isOpen, openComponent, closeComponent } = useToggle();
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const [wrapperClientHeight, setWrapperClientHeight] = useState(45);
+  const [wrapperClientHeight, setWrapperClientHeight] = useState(40);
+
+  const filteredOptionList = optionList.filter(
+    option => !selectedOptionList.some(selected => selected.id === option.id)
+  );
 
   const handleToggleWrapper = () => {
     if (isOpen) {
@@ -44,29 +48,18 @@ export default function MultiSelect({
 
   useEffect(() => {
     if (wrapperRef) {
-      if (selectedOptionList.length > 0) {
-        window.console.log(wrapperRef.current);
-        const newClientHeight = wrapperRef.current ? wrapperRef.current.clientHeight : 25;
+      if (selectedOptionList.length > 0 && wrapperRef.current) {
+        setWrapperClientHeight(wrapperRef.current.clientHeight);
 
-        setWrapperClientHeight(newClientHeight);
-      } else {
-        setWrapperClientHeight(45);
+        return;
       }
+      setWrapperClientHeight(40);
     }
   }, [selectedOptionList]);
 
-  useEffect(() => {
-    if (selectedOptionList.length === optionList.length) {
-      closeComponent();
-    }
-  }, [selectedOptionList, optionList, closeComponent]);
-
-  const filteredOptionList = optionList.filter(
-    option => !selectedOptionList.some(selected => selected.id === option.id)
-  );
   return (
     <S.Wrapper onClick={handleToggleWrapper} ref={wrapperRef}>
-      <S.Container>
+      <S.SelectedOptionListContainer>
         {selectedOptionList.length === 0 && <span>{placeholder} </span>}
         {selectedOptionList.map(({ id, name }) => (
           <S.SelectedOption key={id} onClick={(e: React.MouseEvent) => e.stopPropagation()}>
@@ -79,7 +72,7 @@ export default function MultiSelect({
             />
           </S.SelectedOption>
         ))}
-      </S.Container>
+      </S.SelectedOptionListContainer>
       <S.SelectIcon>
         <S.Image src={isOpen ? chevronUp : chevronDown} alt="" $isSelected={isOpen} />
       </S.SelectIcon>

--- a/frontend/src/components/common/MultiSelect/style.ts
+++ b/frontend/src/components/common/MultiSelect/style.ts
@@ -69,7 +69,7 @@ export const DropDown = styled.ul<{
   }
 `;
 
-export const Chip = styled.span`
+export const SelectedOption = styled.span`
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/frontend/src/components/common/MultiSelect/style.ts
+++ b/frontend/src/components/common/MultiSelect/style.ts
@@ -38,7 +38,7 @@ export const SelectIcon = styled.span`
 `;
 
 export const DropDown = styled.ul<{
-  opened: boolean;
+  $isOpened: boolean;
 }>`
   width: 100%;
   border: 1px solid #e4e5e7;
@@ -47,8 +47,8 @@ export const DropDown = styled.ul<{
 
   position: absolute;
 
-  opacity: ${({ opened }) => (opened ? 1 : 0)};
-  visibility: ${({ opened }) => (opened ? 'visible' : 'hidden')};
+  opacity: ${({ $isOpened }) => ($isOpened ? 1 : 0)};
+  visibility: ${({ $isOpened }) => ($isOpened ? 'visible' : 'hidden')};
 
   transition: all 0.2s linear 0.1s;
 

--- a/frontend/src/components/common/MultiSelect/style.ts
+++ b/frontend/src/components/common/MultiSelect/style.ts
@@ -1,0 +1,92 @@
+import { styled } from 'styled-components';
+
+import { theme } from '@styles/theme';
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 80%;
+  height: auto;
+  border: 1px solid var(--slate);
+  border-radius: 6px;
+  padding: 7px;
+
+  position: relative;
+
+  font: var(--text-caption);
+
+  cursor: pointer;
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    font: var(--text-body);
+  }
+
+  @media (min-width: ${theme.breakpoint.md}) {
+    width: 50%;
+  }
+`;
+
+export const Container = styled.div`
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: wrap;
+`;
+
+export const SelectIcon = styled.span`
+  display: 'inline-block';
+  width: 20px;
+`;
+
+export const DropDown = styled.ul<{
+  opened: boolean;
+  wrapperClientHeight: number;
+}>`
+  width: 100%;
+  border-radius: 6px;
+  margin-top: 10px;
+
+  position: absolute;
+  top: ${({ wrapperClientHeight }) => wrapperClientHeight - 10}px;
+  left: 0px;
+
+  opacity: ${({ opened }) => (opened ? 1 : 0)};
+  visibility: ${({ opened }) => (opened ? 'visible' : 'hidden')};
+
+  transition: all 0.2s linear 0.1s;
+
+  & > li {
+    list-style: none;
+    padding: 10px 0px 10px 15px;
+    border-bottom: 1px solid #e4e5e7;
+    border-left: 1px solid #e4e5e7;
+    border-right: 1px solid #e4e5e7;
+
+    &:hover {
+      background-color: #ffefd5;
+    }
+  }
+`;
+
+export const Chip = styled.span`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  border-radius: 4px;
+  padding: 10px;
+  margin: 2px 4px 2px 2px;
+  & > span {
+    margin-right: 8px;
+  }
+
+  background: #e8f7f6;
+`;
+
+export const Image = styled.img<{ $isSelected: boolean }>`
+  width: 20px;
+  height: 20px;
+  border-left: 1px solid var(--slate);
+  padding-left: 8px;
+`;

--- a/frontend/src/components/common/MultiSelect/style.ts
+++ b/frontend/src/components/common/MultiSelect/style.ts
@@ -28,14 +28,13 @@ export const Wrapper = styled.div`
   }
 `;
 
-export const Container = styled.div`
+export const SelectedOptionListContainer = styled.div`
   display: flex;
   flex-grow: 1;
   flex-wrap: wrap;
 `;
 
 export const SelectIcon = styled.span`
-  display: 'inline-block';
   width: 20px;
 `;
 
@@ -48,7 +47,7 @@ export const DropDown = styled.ul<{
   margin-top: 10px;
 
   position: absolute;
-  top: ${({ wrapperClientHeight }) => wrapperClientHeight - 10}px;
+  top: ${({ wrapperClientHeight }) => wrapperClientHeight}px;
   left: 0px;
 
   opacity: ${({ opened }) => (opened ? 1 : 0)};

--- a/frontend/src/components/common/MultiSelect/style.ts
+++ b/frontend/src/components/common/MultiSelect/style.ts
@@ -2,12 +2,21 @@ import { styled } from 'styled-components';
 
 import { theme } from '@styles/theme';
 
+export const Container = styled.div`
+  position: relative;
+
+  font: var(--text-caption);
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    font: var(--text-body);
+  }
+`;
+
 export const Wrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr 20px;
   align-items: center;
 
-  width: 80%;
   height: auto;
   border: 1px solid var(--slate);
   border-radius: 6px;
@@ -15,17 +24,7 @@ export const Wrapper = styled.div`
 
   position: relative;
 
-  font: var(--text-caption);
-
   cursor: pointer;
-
-  @media (min-width: ${theme.breakpoint.sm}) {
-    font: var(--text-body);
-  }
-
-  @media (min-width: ${theme.breakpoint.md}) {
-    width: 50%;
-  }
 `;
 
 export const SelectedOptionListContainer = styled.div`
@@ -40,15 +39,13 @@ export const SelectIcon = styled.span`
 
 export const DropDown = styled.ul<{
   opened: boolean;
-  wrapperClientHeight: number;
 }>`
   width: 100%;
+  border: 1px solid #e4e5e7;
   border-radius: 6px;
   margin-top: 10px;
 
   position: absolute;
-  top: ${({ wrapperClientHeight }) => wrapperClientHeight}px;
-  left: 0px;
 
   opacity: ${({ opened }) => (opened ? 1 : 0)};
   visibility: ${({ opened }) => (opened ? 'visible' : 'hidden')};
@@ -59,11 +56,12 @@ export const DropDown = styled.ul<{
     list-style: none;
     padding: 10px 0px 10px 15px;
     border-bottom: 1px solid #e4e5e7;
-    border-left: 1px solid #e4e5e7;
-    border-right: 1px solid #e4e5e7;
 
     &:hover {
       background-color: #ffefd5;
+    }
+    &:last-child {
+      border-bottom: none;
     }
   }
 `;

--- a/frontend/src/components/common/MultiSelect/types.ts
+++ b/frontend/src/components/common/MultiSelect/types.ts
@@ -1,0 +1,4 @@
+export interface Option {
+  id: number;
+  name: string;
+}

--- a/frontend/src/hooks/useMultiSelect.ts
+++ b/frontend/src/hooks/useMultiSelect.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+interface Option {
+  id: number;
+  name: string;
+}
+
+export const useMultiSelect = (initialSelectedOptionList: Option[], optionCountLimit?: number) => {
+  const [selectedOptionList, setSelectedOptionList] = useState(initialSelectedOptionList);
+
+  const handleOptionAdd = (newItem: Option) => {
+    if (optionCountLimit && optionCountLimit === selectedOptionList.length) {
+      alert(`${optionCountLimit}개까지 선택 가능합니다!`);
+      return;
+    }
+    setSelectedOptionList([...selectedOptionList, newItem]);
+  };
+
+  const handleOptionDelete = (optionId: number) => {
+    setSelectedOptionList(selectedOptionList.filter(option => option.id !== optionId));
+  };
+
+  return { selectedOptionList, handleOptionAdd, handleOptionDelete };
+};

--- a/frontend/src/hooks/useMultiSelect.ts
+++ b/frontend/src/hooks/useMultiSelect.ts
@@ -1,9 +1,6 @@
 import { useState } from 'react';
 
-interface Option {
-  id: number;
-  name: string;
-}
+import type { Option } from '@components/common/MultiSelect/types';
 
 export const useMultiSelect = (initialSelectedOptionList: Option[], optionCountLimit?: number) => {
   const [selectedOptionList, setSelectedOptionList] = useState(initialSelectedOptionList);


### PR DESCRIPTION
## 🔥 연관 이슈

close: #44 

## 📝 작업 요약
### 1. MultiSelect 컴포넌트 UI 구현
```TypeScript
interface MultiSelectProps {
  selectedOptionList: Option[];  // 선택된 옵션 리스트 
  optionList: Option[];  // 모든 옵션 리스트 (ex. 카테고리 목록)
  handleOptionAdd: (newItem: Option) => void; // selectedOptionList 에 클릭한 옵션 추가하는 함수
  handleOptionDelete: (optionId: number) => void; // selectedOptionList 에서 클릭한 옵션 제거하는 함수
  placeholder?: string; // 선택된 옵션이 아무것도 없는 경우 
}
```
### 2. useMultiSelect 커스텀 훅 구현
### 3. MultiSelect 스토리 작성
* 스토리는 총 4개입니다.
  * 기존에 선택한 옵션들이 없는 경우
  * 기존에 선택한 옵션들이 있는 경우
  * 기존에 선택한 카테고리 옵션이 없는 경우
  * 기존에 선택한 카테고리 옵션이 있는 경우

## 🔎 작업 상세 설명
* `useRef` 를 이용하여, 옵션 개수에 따라 DropDown(미선택된 옵션들을 감싸는 div)의 높이(clientHeight)를 조절합니다. -> 이 부분은 코멘트로 자세히 설명해보겠습니다!
* `useMultiSelect` 라는 커스텀 훅은, 기존에 선택한 옵션 리스트(initialOptionList)와 옵션 개수 제한값(optionCountLimit)을 매개변수로 받습니다.

## 🌟 논의 사항
* 매우 긴 텍스트의 옵션을 클릭하면, up down (위아래 svg 아이콘)이 가려지는데 어떻게 해결해야 할지 CSS 팁 알려주시면 감사하겠습니다🥺 (Wrapper 클릭하면, 열고 닫히는 기능은 작동하긴 합니다..)