### PR TITLE
내가 작성한 게시글 조회, 내가 투표한 게시글 조회 기능 구현

### DIFF
--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -1,14 +1,16 @@
 import { getPostList } from '@api/postList';
 
+import { POST_CONTENT, SORTING, STATUS } from '@constants/post';
+
 import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
 describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확인한다.', () => {
   test('게시글 목록의 개수는 10개씩 불러온다.', async () => {
     const data = await getPostList({
-      postStatus: 'all',
-      postSorting: 'popular',
+      postStatus: STATUS.ALL,
+      postSorting: SORTING.POPULAR,
       pageNumber: 0,
-      content: 'all',
+      content: POST_CONTENT.ALL,
     });
 
     expect(data.postList.length).toBe(10);
@@ -16,10 +18,10 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
 
   test('게시글 목록을 불러온다.', async () => {
     const data = await getPostList({
-      postStatus: 'closed',
-      postSorting: 'popular',
+      postStatus: STATUS.CLOSED,
+      postSorting: SORTING.POPULAR,
       pageNumber: 0,
-      content: 'all',
+      content: POST_CONTENT.ALL,
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -27,10 +29,10 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
 
   test('게시글 페이지의 정보를 불러온다.', async () => {
     const data = await getPostList({
-      postStatus: 'closed',
-      postSorting: 'popular',
+      postStatus: STATUS.CLOSED,
+      postSorting: SORTING.POPULAR,
       pageNumber: 3,
-      content: 'all',
+      content: POST_CONTENT.ALL,
     });
 
     expect(data.pageNumber).toEqual(3);
@@ -38,11 +40,11 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
 
   test('카테고리별 게시글 페이지의 정보를 불러온다.', async () => {
     const data = await getPostList({
-      postStatus: 'closed',
-      postSorting: 'popular',
+      postStatus: STATUS.CLOSED,
+      postSorting: SORTING.POPULAR,
       pageNumber: 0,
       categoryId: 1,
-      content: 'category',
+      content: POST_CONTENT.CATEGORY,
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -50,11 +52,11 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
 
   test('내가 작성한 게시글 페이지의 정보를 불러온다.', async () => {
     const data = await getPostList({
-      postStatus: 'closed',
-      postSorting: 'popular',
+      postStatus: STATUS.CLOSED,
+      postSorting: SORTING.POPULAR,
       pageNumber: 0,
       categoryId: 1,
-      content: 'myPost',
+      content: POST_CONTENT.MY_POST,
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -62,11 +64,11 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
 
   test('내가 투표한 게시글 페이지의 정보를 불러온다.', async () => {
     const data = await getPostList({
-      postStatus: 'closed',
-      postSorting: 'popular',
+      postStatus: STATUS.CLOSED,
+      postSorting: SORTING.POPULAR,
       pageNumber: 0,
       categoryId: 1,
-      content: 'myVote',
+      content: POST_CONTENT.MY_VOTE,
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);

--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -54,7 +54,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: 'popular',
       pageNumber: 3,
       categoryId: 1,
-      requestKind: 'category',
+      requestKind: 'myPost',
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);

--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -8,7 +8,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postStatus: 'all',
       postSorting: 'popular',
       pageNumber: 0,
-      requestKind: 'all',
+      content: 'all',
     });
 
     expect(data.postList.length).toBe(10);
@@ -19,7 +19,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postStatus: 'closed',
       postSorting: 'popular',
       pageNumber: 0,
-      requestKind: 'all',
+      content: 'all',
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -30,7 +30,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postStatus: 'closed',
       postSorting: 'popular',
       pageNumber: 3,
-      requestKind: 'all',
+      content: 'all',
     });
 
     expect(data.pageNumber).toEqual(3);
@@ -42,7 +42,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: 'popular',
       pageNumber: 0,
       categoryId: 1,
-      requestKind: 'category',
+      content: 'category',
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -54,7 +54,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: 'popular',
       pageNumber: 0,
       categoryId: 1,
-      requestKind: 'myPost',
+      content: 'myPost',
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -66,7 +66,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: 'popular',
       pageNumber: 0,
       categoryId: 1,
-      requestKind: 'myVote',
+      content: 'myVote',
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);

--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -1,22 +1,37 @@
-import { getPostList } from '@api/wus/postList';
+import { getPostList } from '@api/postList';
 
 import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
 describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확인한다.', () => {
   test('게시글 목록의 개수는 10개씩 불러온다.', async () => {
-    const data = await getPostList({ postStatus: 'all', postSorting: 'popular', pageNumber: 0 });
+    const data = await getPostList({
+      postStatus: 'all',
+      postSorting: 'popular',
+      pageNumber: 0,
+      requestKind: 'all',
+    });
 
     expect(data.postList.length).toBe(10);
   });
 
   test('게시글 목록을 불러온다.', async () => {
-    const data = await getPostList({ postStatus: 'closed', postSorting: 'popular', pageNumber: 0 });
+    const data = await getPostList({
+      postStatus: 'closed',
+      postSorting: 'popular',
+      pageNumber: 0,
+      requestKind: 'all',
+    });
 
-    expect(data.postList).toEqual(MOCK_POST_LIST[0]);
+    expect(data.postList).toEqual(MOCK_POST_LIST);
   });
 
   test('게시글 페이지의 정보를 불러온다.', async () => {
-    const data = await getPostList({ postStatus: 'closed', postSorting: 'popular', pageNumber: 3 });
+    const data = await getPostList({
+      postStatus: 'closed',
+      postSorting: 'popular',
+      pageNumber: 3,
+      requestKind: 'all',
+    });
 
     expect(data.pageNumber).toEqual(3);
   });
@@ -27,8 +42,33 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: 'popular',
       pageNumber: 3,
       categoryId: 1,
+      requestKind: 'category',
     });
 
-    expect(data.postList).toEqual(MOCK_POST_LIST[3]);
+    expect(data.postList).toEqual(MOCK_POST_LIST);
+  });
+
+  test('내가 작성한 게시글 페이지의 정보를 불러온다.', async () => {
+    const data = await getPostList({
+      postStatus: 'closed',
+      postSorting: 'popular',
+      pageNumber: 3,
+      categoryId: 1,
+      requestKind: 'category',
+    });
+
+    expect(data.postList).toEqual(MOCK_POST_LIST);
+  });
+
+  test('내가 투표한 게시글 페이지의 정보를 불러온다.', async () => {
+    const data = await getPostList({
+      postStatus: 'closed',
+      postSorting: 'popular',
+      pageNumber: 3,
+      categoryId: 1,
+      requestKind: 'myVote',
+    });
+
+    expect(data.postList).toEqual(MOCK_POST_LIST);
   });
 });

--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -40,7 +40,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
     const data = await getPostList({
       postStatus: 'closed',
       postSorting: 'popular',
-      pageNumber: 3,
+      pageNumber: 0,
       categoryId: 1,
       requestKind: 'category',
     });
@@ -52,7 +52,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
     const data = await getPostList({
       postStatus: 'closed',
       postSorting: 'popular',
-      pageNumber: 3,
+      pageNumber: 0,
       categoryId: 1,
       requestKind: 'myPost',
     });
@@ -64,7 +64,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
     const data = await getPostList({
       postStatus: 'closed',
       postSorting: 'popular',
-      pageNumber: 3,
+      pageNumber: 0,
       categoryId: 1,
       requestKind: 'myVote',
     });

--- a/frontend/__test__/getPathFragment.test.ts
+++ b/frontend/__test__/getPathFragment.test.ts
@@ -1,0 +1,21 @@
+import { getPathFragment } from '@utils/getPathFragment';
+
+describe('useUrlDetection를 사용했을 때 path의 값만 나오도록 한다.', () => {
+  test('/posts/category/12인 경우, /posts/category를 반환한다.', () => {
+    const result = getPathFragment('/posts/category/12');
+
+    expect(result).toBe('/posts/category');
+  });
+
+  test('/인 경우, /를 반환한다.', () => {
+    const result = getPathFragment('/');
+
+    expect(result).toBe('/');
+  });
+
+  test('/users/posts인 경우, /users/posts를 반환한다.', () => {
+    const result = getPathFragment('/users/posts');
+
+    expect(result).toBe('/users/posts');
+  });
+});

--- a/frontend/__test__/hooks/query/usePostList.test.tsx
+++ b/frontend/__test__/hooks/query/usePostList.test.tsx
@@ -16,23 +16,63 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.', () => {
   test('전체 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
-      () => usePostList({ postSorting: 'popular', postStatus: 'all' }),
+      () => usePostList({ postSorting: 'popular', postStatus: 'all', requestKind: 'all' }),
       {
         wrapper,
       }
     );
 
-    await waitFor(() => expect(result.current.data?.pages[0].postList).toEqual(MOCK_POST_LIST[0]));
+    await waitFor(() => expect(result.current.data?.pages[0].postList).toEqual(MOCK_POST_LIST));
   });
 
   test('카테고리별 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
-      () => usePostList({ postSorting: 'popular', postStatus: 'all', categoryId: 1 }),
+      () =>
+        usePostList({
+          postSorting: 'popular',
+          postStatus: 'all',
+          categoryId: 1,
+          requestKind: 'category',
+        }),
       {
         wrapper,
       }
     );
 
-    await waitFor(() => expect(result.current.data?.pages[0].postList).toEqual(MOCK_POST_LIST[0]));
+    await waitFor(() => expect(result.current.data?.pages[0].postList).toEqual(MOCK_POST_LIST));
+  });
+
+  test('내가 작성한 게시글 목록을 불러온다.', async () => {
+    const { result } = renderHook(
+      () =>
+        usePostList({
+          postSorting: 'popular',
+          postStatus: 'all',
+          categoryId: 1,
+          requestKind: 'myPost',
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.data?.pages[0].postList).toEqual(MOCK_POST_LIST));
+  });
+
+  test('내가 투표한 게시글 목록을 불러온다.', async () => {
+    const { result } = renderHook(
+      () =>
+        usePostList({
+          postSorting: 'popular',
+          postStatus: 'all',
+          categoryId: 1,
+          requestKind: 'myVote',
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.data?.pages[0].postList).toEqual(MOCK_POST_LIST));
   });
 });

--- a/frontend/__test__/hooks/query/usePostList.test.tsx
+++ b/frontend/__test__/hooks/query/usePostList.test.tsx
@@ -16,7 +16,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.', () => {
   test('전체 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
-      () => usePostList({ postSorting: 'popular', postStatus: 'all', requestKind: 'all' }),
+      () => usePostList({ postSorting: 'popular', postStatus: 'all', content: 'all' }),
       {
         wrapper,
       }
@@ -32,7 +32,7 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
           postSorting: 'popular',
           postStatus: 'all',
           categoryId: 1,
-          requestKind: 'category',
+          content: 'category',
         }),
       {
         wrapper,
@@ -49,7 +49,7 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
           postSorting: 'popular',
           postStatus: 'all',
           categoryId: 1,
-          requestKind: 'myPost',
+          content: 'myPost',
         }),
       {
         wrapper,
@@ -66,7 +66,7 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
           postSorting: 'popular',
           postStatus: 'all',
           categoryId: 1,
-          requestKind: 'myVote',
+          content: 'myVote',
         }),
       {
         wrapper,

--- a/frontend/__test__/hooks/query/usePostList.test.tsx
+++ b/frontend/__test__/hooks/query/usePostList.test.tsx
@@ -5,6 +5,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 
 import { usePostList } from '@hooks/query/usePostList';
 
+import { POST_CONTENT, SORTING, STATUS } from '@constants/post';
+
 import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
 const queryClient = new QueryClient();
@@ -16,7 +18,12 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.', () => {
   test('전체 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
-      () => usePostList({ postSorting: 'popular', postStatus: 'all', content: 'all' }),
+      () =>
+        usePostList({
+          postSorting: SORTING.POPULAR,
+          postStatus: STATUS.ALL,
+          content: POST_CONTENT.ALL,
+        }),
       {
         wrapper,
       }
@@ -29,10 +36,10 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
     const { result } = renderHook(
       () =>
         usePostList({
-          postSorting: 'popular',
-          postStatus: 'all',
+          postSorting: SORTING.POPULAR,
+          postStatus: STATUS.ALL,
           categoryId: 1,
-          content: 'category',
+          content: POST_CONTENT.CATEGORY,
         }),
       {
         wrapper,
@@ -46,10 +53,10 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
     const { result } = renderHook(
       () =>
         usePostList({
-          postSorting: 'popular',
-          postStatus: 'all',
+          postSorting: SORTING.POPULAR,
+          postStatus: STATUS.ALL,
           categoryId: 1,
-          content: 'myPost',
+          content: POST_CONTENT.MY_POST,
         }),
       {
         wrapper,
@@ -63,10 +70,10 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
     const { result } = renderHook(
       () =>
         usePostList({
-          postSorting: 'popular',
-          postStatus: 'all',
+          postSorting: SORTING.POPULAR,
+          postStatus: STATUS.ALL,
           categoryId: 1,
-          content: 'myVote',
+          content: POST_CONTENT.MY_VOTE,
         }),
       {
         wrapper,

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,8 +1,11 @@
 import 'whatwg-fetch';
 
+import dotenv from 'dotenv';
 import { setupServer } from 'msw/node';
 
 import { handlers } from './src/mocks/handlers';
+
+dotenv.config({ path: './.env.test' });
 
 export const server = setupServer(...handlers);
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --cache .",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "DOTENV_CONFIG_PATH=.env.test jest --setupFiles=dotenv/config jest --setupFiles=dotenv/config"
+    "test": "jest"
   },
   "dependencies": {
     "@tanstack/react-query": "^4.29.19",

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -11,7 +11,7 @@ import {
 import { getFetch } from '@utils/fetch';
 
 interface PostListByOption {
-  requestKind: PostRequestKind;
+  content: PostRequestKind;
   postStatus: PostStatus;
   postSorting: PostSorting;
   pageNumber: number;
@@ -21,7 +21,7 @@ interface PostListByOption {
 const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
 
 export const makePostListUrl = ({
-  requestKind,
+  content,
   categoryId,
   postStatus,
   postSorting,
@@ -30,10 +30,10 @@ export const makePostListUrl = ({
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
-  const POST_BASE_URL = `${BASE_URL}/${REQUEST_POST_KIND_URL[requestKind]}`;
+  const POST_BASE_URL = `${BASE_URL}/${REQUEST_POST_KIND_URL[content]}`;
   const OPTION_URL = `postClosingType=${requestedStatus}&postSortType=${requestedSorting}&page=${pageNumber}`;
 
-  if (categoryId && requestKind === 'category') {
+  if (categoryId && content === 'category') {
     return `${POST_BASE_URL}/${categoryId}?${OPTION_URL}`;
   }
 
@@ -41,14 +41,14 @@ export const makePostListUrl = ({
 };
 
 export const getPostList = async ({
-  requestKind,
+  content,
   postStatus,
   postSorting,
   pageNumber,
   categoryId,
 }: PostListByOption) => {
   const postListUrl = makePostListUrl({
-    requestKind,
+    content,
     pageNumber,
     postSorting,
     postStatus,

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -31,7 +31,7 @@ export const makePostListUrl = ({
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
   const POST_BASE_URL = `${BASE_URL}/${REQUEST_POST_KIND_URL[requestKind]}`;
-  const OPTION_URL = `status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
+  const OPTION_URL = `postClosingType=${requestedStatus}&postSortType=${requestedSorting}&page=${pageNumber}`;
 
   if (categoryId && requestKind === 'category') {
     return `${POST_BASE_URL}/${categoryId}?${OPTION_URL}`;

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -1,6 +1,4 @@
-import { PostInfo } from '@type/post';
-
-import type { PostRequestKind, PostSorting, PostStatus } from '@components/post/PostListPage/types';
+import { PostInfo, PostListByOption } from '@type/post';
 
 import {
   REQUEST_STATUS_OPTION,
@@ -9,14 +7,6 @@ import {
 } from '@constants/post';
 
 import { getFetch } from '@utils/fetch';
-
-interface PostListByOption {
-  content: PostRequestKind;
-  postStatus: PostStatus;
-  postSorting: PostSorting;
-  pageNumber: number;
-  categoryId?: number;
-}
 
 const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
 

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -1,27 +1,22 @@
 import { PostInfo } from '@type/post';
 
-import type { PostSorting, PostStatus } from '@components/post/PostListPage/types';
+import type { PostRequestKind, PostSorting, PostStatus } from '@components/post/PostListPage/types';
 
-import { REQUEST_STATUS_OPTION, REQUEST_SORTING_OPTION } from '@constants/post';
+import {
+  REQUEST_STATUS_OPTION,
+  REQUEST_SORTING_OPTION,
+  REQUEST_POST_KIND_URL,
+} from '@constants/post';
 
 import { getFetch } from '@utils/fetch';
 
 interface PostListByOption {
-  requestKind: RequestKind;
+  requestKind: PostRequestKind;
   postStatus: PostStatus;
   postSorting: PostSorting;
   pageNumber: number;
   categoryId?: number;
 }
-
-const REQUEST_KIND = {
-  all: 'posts',
-  myPost: 'posts/me',
-  myVote: 'posts/votes/me',
-  category: 'posts/categories',
-} as const;
-
-type RequestKind = keyof typeof REQUEST_KIND;
 
 const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
 
@@ -35,7 +30,7 @@ export const makePostListUrl = ({
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
-  const POST_BASE_URL = `${BASE_URL}/${REQUEST_KIND[requestKind]}`;
+  const POST_BASE_URL = `${BASE_URL}/${REQUEST_POST_KIND_URL[requestKind]}`;
   const OPTION_URL = `status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
 
   if (categoryId && requestKind === 'category') {

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -7,15 +7,26 @@ import { REQUEST_STATUS_OPTION, REQUEST_SORTING_OPTION } from '@constants/post';
 import { getFetch } from '@utils/fetch';
 
 interface PostListByOption {
+  requestKind: RequestKind;
   postStatus: PostStatus;
   postSorting: PostSorting;
   pageNumber: number;
   categoryId?: number;
 }
 
+const REQUEST_KIND = {
+  all: 'posts',
+  myPost: 'posts/me',
+  myVote: 'posts/votes/me',
+  category: 'posts/categories',
+} as const;
+
+type RequestKind = keyof typeof REQUEST_KIND;
+
 const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
 
 export const makePostListUrl = ({
+  requestKind,
   categoryId,
   postStatus,
   postSorting,
@@ -24,23 +35,30 @@ export const makePostListUrl = ({
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
-  const POST_BASE_URL = `${BASE_URL}/posts`;
+  const POST_BASE_URL = `${BASE_URL}/${REQUEST_KIND[requestKind]}`;
   const OPTION_URL = `status=${requestedStatus}&sorting=${requestedSorting}&pages=${pageNumber}`;
 
-  if (categoryId) {
-    return `${POST_BASE_URL}?categoryId=${categoryId}&${OPTION_URL}`;
+  if (categoryId && requestKind === 'category') {
+    return `${POST_BASE_URL}/${categoryId}?${OPTION_URL}`;
   }
 
   return `${POST_BASE_URL}?${OPTION_URL}`;
 };
 
 export const getPostList = async ({
+  requestKind,
   postStatus,
   postSorting,
   pageNumber,
   categoryId,
 }: PostListByOption) => {
-  const postListUrl = makePostListUrl({ pageNumber, postSorting, postStatus, categoryId });
+  const postListUrl = makePostListUrl({
+    requestKind,
+    pageNumber,
+    postSorting,
+    postStatus,
+    categoryId,
+  });
 
   const postList = await getFetch<PostInfo[]>(postListUrl);
 

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
 
+import { usePostListKind } from '@hooks/query/post/usePostListKind';
 import { usePostList } from '@hooks/query/usePostList';
 import { useIntersectionObserver } from '@hooks/useIntersectionObserver';
 import { useSelect } from '@hooks/useSelect';
@@ -14,7 +14,7 @@ import type { PostSorting, PostStatus } from '@components/post/PostListPage/type
 import * as S from './style';
 
 export default function PostList() {
-  const { categoryId } = useParams<{ categoryId?: string }>();
+  const { categoryId, requestKind } = usePostListKind();
   const { targetRef, isIntersecting } = useIntersectionObserver({
     root: null,
     rootMargin: '',
@@ -26,9 +26,10 @@ export default function PostList() {
     useSelect<PostSorting>('latest');
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList({
+    requestKind,
+    categoryId,
     postSorting: selectedSortingOption,
     postStatus: selectedStatusOption,
-    categoryId: Number(categoryId),
   });
 
   useEffect(() => {

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 
-import { usePostListKind } from '@hooks/query/post/usePostListKind';
 import { usePostList } from '@hooks/query/usePostList';
 import { useIntersectionObserver } from '@hooks/useIntersectionObserver';
+import { usePostRequestInfo } from '@hooks/usePostRequestInfo';
 import { useSelect } from '@hooks/useSelect';
 
 import Post from '@components/common/Post';
@@ -16,7 +16,7 @@ import { SORTING, STATUS } from '@constants/post';
 import * as S from './style';
 
 export default function PostList() {
-  const { categoryId, content } = usePostListKind();
+  const { categoryId, content } = usePostRequestInfo();
   const { targetRef, isIntersecting } = useIntersectionObserver({
     root: null,
     rootMargin: '',

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -11,6 +11,8 @@ import Skeleton from '@components/common/Skeleton';
 import { SORTING_OPTION, STATUS_OPTION } from '@components/post/PostListPage/constants';
 import type { PostSorting, PostStatus } from '@components/post/PostListPage/types';
 
+import { SORTING, STATUS } from '@constants/post';
+
 import * as S from './style';
 
 export default function PostList() {
@@ -21,9 +23,9 @@ export default function PostList() {
     thresholds: 0.1,
   });
   const { selectedOption: selectedStatusOption, handleOptionChange: handleStatusOptionChange } =
-    useSelect<PostStatus>('progress');
+    useSelect<PostStatus>(STATUS.PROGRESS);
   const { selectedOption: selectedSortingOption, handleOptionChange: handleSortingOptionChange } =
-    useSelect<PostSorting>('latest');
+    useSelect<PostSorting>(SORTING.LATEST);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList({
     content,

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -14,7 +14,7 @@ import type { PostSorting, PostStatus } from '@components/post/PostListPage/type
 import * as S from './style';
 
 export default function PostList() {
-  const { categoryId, requestKind } = usePostListKind();
+  const { categoryId, content } = usePostListKind();
   const { targetRef, isIntersecting } = useIntersectionObserver({
     root: null,
     rootMargin: '',
@@ -26,7 +26,7 @@ export default function PostList() {
     useSelect<PostSorting>('latest');
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList({
-    requestKind,
+    content,
     categoryId,
     postSorting: selectedSortingOption,
     postStatus: selectedStatusOption,

--- a/frontend/src/components/post/PostListPage/constants.ts
+++ b/frontend/src/components/post/PostListPage/constants.ts
@@ -1,12 +1,14 @@
+import { SORTING, STATUS } from '@constants/post';
+
 import { PostSorting, PostStatus } from './types';
 
 export const STATUS_OPTION: Record<PostStatus, string> = {
-  all: '전체',
-  progress: '진행중',
-  closed: '마감완료',
+  [STATUS.ALL]: '전체',
+  [STATUS.PROGRESS]: '진행중',
+  [STATUS.CLOSED]: '마감완료',
 };
 
 export const SORTING_OPTION: Record<PostSorting, string> = {
-  popular: '인기순',
-  latest: '최신순',
+  [SORTING.POPULAR]: '인기순',
+  [SORTING.LATEST]: '최신순',
 };

--- a/frontend/src/components/post/PostListPage/types.ts
+++ b/frontend/src/components/post/PostListPage/types.ts
@@ -1,5 +1,9 @@
-const POST_STATUS_LIST = ['all', 'progress', 'closed'] as const;
-const POST_SORTING_LIST = ['popular', 'latest'] as const;
+import {
+  REQUEST_POST_KIND_URL,
+  REQUEST_SORTING_OPTION,
+  REQUEST_STATUS_OPTION,
+} from '@constants/post';
 
-export type PostStatus = (typeof POST_STATUS_LIST)[number];
-export type PostSorting = (typeof POST_SORTING_LIST)[number];
+export type PostStatus = keyof typeof REQUEST_STATUS_OPTION;
+export type PostSorting = keyof typeof REQUEST_SORTING_OPTION;
+export type PostRequestKind = keyof typeof REQUEST_POST_KIND_URL;

--- a/frontend/src/constants/path.ts
+++ b/frontend/src/constants/path.ts
@@ -11,10 +11,8 @@ export const BASE_PATH = {
 export const PATH = {
   ...BASE_PATH,
   POST_WRITE: `${BASE_PATH.POST}/write`,
-  POST_WRITE_EDIT: `${BASE_PATH.POST}/write/:postId`,
-  POST_DETAIL: `${BASE_PATH.POST}/:postId`,
-  POST_VOTE_RESULT: `${BASE_PATH.POST}/result/:postId`,
-  POST_CATEGORY: `${BASE_PATH.POST}/category/:categoryId`,
+  POST_VOTE_RESULT: `${BASE_PATH.POST}/result`,
+  POST_CATEGORY: `${BASE_PATH.POST}/category`,
   USER_POST: `${BASE_PATH.USER}/posts`,
   USER_VOTE: `${BASE_PATH.USER}/votes`,
   USER_INFO: `${BASE_PATH.USER}/myPage`,

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -2,20 +2,38 @@ export const POST = {
   NOT_VOTE: 0,
 };
 
+export const STATUS = {
+  ALL: 'all',
+  PROGRESS: 'progress',
+  CLOSED: 'closed',
+} as const;
+
+export const SORTING = {
+  LATEST: 'latest',
+  POPULAR: 'popular',
+} as const;
+
+export const POST_CONTENT = {
+  ALL: 'posts',
+  MY_POST: 'myPost',
+  MY_VOTE: 'myVote',
+  CATEGORY: 'category',
+} as const;
+
 export const REQUEST_STATUS_OPTION = {
-  all: 'ALL',
-  progress: 'PROGRESS',
-  closed: 'CLOSED',
+  [STATUS.ALL]: 'ALL',
+  [STATUS.PROGRESS]: 'PROGRESS',
+  [STATUS.CLOSED]: 'CLOSED',
 } as const;
 
 export const REQUEST_SORTING_OPTION = {
-  latest: 'LATEST',
-  popular: 'HOT',
+  [SORTING.LATEST]: 'LATEST',
+  [SORTING.POPULAR]: 'HOT',
 } as const;
 
 export const REQUEST_POST_KIND_URL = {
-  all: 'posts',
-  myPost: 'posts/me',
-  myVote: 'posts/votes/me',
-  category: 'posts/categories',
+  [POST_CONTENT.ALL]: 'posts',
+  [POST_CONTENT.MY_POST]: 'posts/me',
+  [POST_CONTENT.MY_VOTE]: 'posts/votes/me',
+  [POST_CONTENT.CATEGORY]: 'posts/categories',
 } as const;

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -1,16 +1,21 @@
-import { PostSorting, PostStatus } from '@components/post/PostListPage/types';
-
 export const POST = {
   NOT_VOTE: 0,
 };
 
-export const REQUEST_STATUS_OPTION: Record<PostStatus, string> = {
+export const REQUEST_STATUS_OPTION = {
   all: 'ALL',
   progress: 'PROGRESS',
   closed: 'CLOSED',
-};
+} as const;
 
-export const REQUEST_SORTING_OPTION: Record<PostSorting, string> = {
+export const REQUEST_SORTING_OPTION = {
   latest: 'LATEST',
   popular: 'HOT',
-};
+} as const;
+
+export const REQUEST_POST_KIND_URL = {
+  all: 'posts',
+  myPost: 'posts/me',
+  myVote: 'posts/votes/me',
+  category: 'posts/categories',
+} as const;

--- a/frontend/src/hooks/query/post/usePostListKind.ts
+++ b/frontend/src/hooks/query/post/usePostListKind.ts
@@ -18,5 +18,5 @@ export const usePostListKind = () => {
 
   const convertedPathname = getPathFragment(pathname);
 
-  return { categoryId: Number(categoryId), requestKind: REQUEST_URL[convertedPathname] };
+  return { categoryId: Number(categoryId), content: REQUEST_URL[convertedPathname] };
 };

--- a/frontend/src/hooks/query/post/usePostListKind.ts
+++ b/frontend/src/hooks/query/post/usePostListKind.ts
@@ -1,0 +1,22 @@
+import { useLocation, useParams } from 'react-router-dom';
+
+import { PostRequestKind } from '@components/post/PostListPage/types';
+
+import { getPathFragment } from '@utils/getPathFragment';
+
+const REQUEST_URL: Record<string, PostRequestKind> = {
+  '/': 'all',
+  '/posts/category': 'category',
+  '/users/posts': 'myPost',
+  '/users/votes': 'myVote',
+};
+
+export const usePostListKind = () => {
+  const { categoryId } = useParams<{ categoryId?: string }>();
+
+  const { pathname } = useLocation();
+
+  const convertedPathname = getPathFragment(pathname);
+
+  return { categoryId: Number(categoryId), requestKind: REQUEST_URL[convertedPathname] };
+};

--- a/frontend/src/hooks/query/post/usePostListKind.ts
+++ b/frontend/src/hooks/query/post/usePostListKind.ts
@@ -2,13 +2,15 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import { PostRequestKind } from '@components/post/PostListPage/types';
 
+import { POST_CONTENT } from '@constants/post';
+
 import { getPathFragment } from '@utils/getPathFragment';
 
 const REQUEST_URL: Record<string, PostRequestKind> = {
-  '/': 'all',
-  '/posts/category': 'category',
-  '/users/posts': 'myPost',
-  '/users/votes': 'myVote',
+  '/': POST_CONTENT.ALL,
+  '/posts/category': POST_CONTENT.CATEGORY,
+  '/users/posts': POST_CONTENT.MY_POST,
+  '/users/votes': POST_CONTENT.MY_VOTE,
 };
 
 export const usePostListKind = () => {

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -2,7 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { PostList } from '@type/post';
 
-import { getPostList } from '@api/wus/postList';
+import { getPostList } from '@api/postList';
 
 import { PostSorting, PostStatus } from '@components/post/PostListPage/types';
 

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -7,7 +7,7 @@ import { getPostList } from '@api/postList';
 import { PostRequestKind, PostSorting, PostStatus } from '@components/post/PostListPage/types';
 
 interface UsePostList {
-  requestKind: PostRequestKind;
+  content: PostRequestKind;
   postSorting: PostSorting;
   postStatus: PostStatus;
   categoryId?: number;
@@ -15,12 +15,12 @@ interface UsePostList {
 
 const MAX_LIST_LENGTH = 10;
 
-export const usePostList = ({ requestKind, postSorting, postStatus, categoryId }: UsePostList) => {
+export const usePostList = ({ content, postSorting, postStatus, categoryId }: UsePostList) => {
   const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<PostList>(
       ['posts', postSorting, postStatus, categoryId],
       ({ pageParam = 0 }) =>
-        getPostList({ requestKind, postSorting, postStatus, pageNumber: pageParam, categoryId }),
+        getPostList({ content, postSorting, postStatus, pageNumber: pageParam, categoryId }),
       {
         getNextPageParam: lastPage => {
           if (lastPage.postList.length !== MAX_LIST_LENGTH) return;

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -4,9 +4,10 @@ import { PostList } from '@type/post';
 
 import { getPostList } from '@api/postList';
 
-import { PostSorting, PostStatus } from '@components/post/PostListPage/types';
+import { PostRequestKind, PostSorting, PostStatus } from '@components/post/PostListPage/types';
 
 interface UsePostList {
+  requestKind: PostRequestKind;
   postSorting: PostSorting;
   postStatus: PostStatus;
   categoryId?: number;
@@ -14,12 +15,12 @@ interface UsePostList {
 
 const MAX_LIST_LENGTH = 10;
 
-export const usePostList = ({ postSorting, postStatus, categoryId }: UsePostList) => {
+export const usePostList = ({ requestKind, postSorting, postStatus, categoryId }: UsePostList) => {
   const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<PostList>(
       ['posts', postSorting, postStatus, categoryId],
       ({ pageParam = 0 }) =>
-        getPostList({ postSorting, postStatus, pageNumber: pageParam, categoryId }),
+        getPostList({ requestKind, postSorting, postStatus, pageNumber: pageParam, categoryId }),
       {
         getNextPageParam: lastPage => {
           if (lastPage.postList.length !== MAX_LIST_LENGTH) return;

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -1,21 +1,17 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import { PostList } from '@type/post';
+import { PostList, PostListByOption } from '@type/post';
 
 import { getPostList } from '@api/postList';
 
-import { PostRequestKind, PostSorting, PostStatus } from '@components/post/PostListPage/types';
-
-interface UsePostList {
-  content: PostRequestKind;
-  postSorting: PostSorting;
-  postStatus: PostStatus;
-  categoryId?: number;
-}
-
 const MAX_LIST_LENGTH = 10;
 
-export const usePostList = ({ content, postSorting, postStatus, categoryId }: UsePostList) => {
+export const usePostList = ({
+  content,
+  postSorting,
+  postStatus,
+  categoryId,
+}: Omit<PostListByOption, 'pageNumber'>) => {
   const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<PostList>(
       ['posts', postSorting, postStatus, categoryId],

--- a/frontend/src/hooks/usePostRequestInfo.ts
+++ b/frontend/src/hooks/usePostRequestInfo.ts
@@ -2,15 +2,16 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import { PostRequestKind } from '@components/post/PostListPage/types';
 
+import { PATH } from '@constants/path';
 import { POST_CONTENT } from '@constants/post';
 
 import { getPathFragment } from '@utils/getPathFragment';
 
 const REQUEST_URL: Record<string, PostRequestKind> = {
-  '/': POST_CONTENT.ALL,
-  '/posts/category': POST_CONTENT.CATEGORY,
-  '/users/posts': POST_CONTENT.MY_POST,
-  '/users/votes': POST_CONTENT.MY_VOTE,
+  [PATH.HOME]: POST_CONTENT.ALL,
+  [PATH.POST_CATEGORY]: POST_CONTENT.CATEGORY,
+  [PATH.USER_POST]: POST_CONTENT.MY_POST,
+  [PATH.USER_VOTE]: POST_CONTENT.MY_VOTE,
 };
 
 export const usePostRequestInfo = () => {

--- a/frontend/src/hooks/usePostRequestInfo.ts
+++ b/frontend/src/hooks/usePostRequestInfo.ts
@@ -13,7 +13,7 @@ const REQUEST_URL: Record<string, PostRequestKind> = {
   '/users/votes': POST_CONTENT.MY_VOTE,
 };
 
-export const usePostListKind = () => {
+export const usePostRequestInfo = () => {
   const { categoryId } = useParams<{ categoryId?: string }>();
 
   const { pathname } = useLocation();

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -8,10 +8,10 @@ import { mockUserInfo } from './wus/userInfo';
 
 export const handlers = [
   ...example,
+  ...mockPostList,
   ...mockPost,
   ...mockVoteResult,
   ...mockVote,
-  ...mockPostList,
   ...mockCategoryHandlers,
   ...mockUserInfo,
 ];

--- a/frontend/src/mocks/mockData/postList.ts
+++ b/frontend/src/mocks/mockData/postList.ts
@@ -1,6 +1,6 @@
 import { PostInfo } from '@type/post';
 
-export const MOCK_POST_LIST: PostInfo[][] = [];
+export const MOCK_POST_LIST: PostInfo[] = [];
 
 const getMockPost = () => ({
   postId: Math.floor(Math.random() * 100000),
@@ -61,12 +61,6 @@ const getMockPost = () => ({
   },
 });
 
-for (let page = 0; page < 10; page += 1) {
-  const postList = [];
-
-  for (let index = 0; index < 10; index += 1) {
-    postList.push(getMockPost());
-  }
-
-  MOCK_POST_LIST.push(postList);
+for (let index = 0; index < 10; index += 1) {
+  MOCK_POST_LIST.push(getMockPost());
 }

--- a/frontend/src/mocks/wus/post.ts
+++ b/frontend/src/mocks/wus/post.ts
@@ -9,9 +9,57 @@ export const mockPostList = [
     if (pages === null) return;
 
     if (pages > 0) {
-      return res(ctx.status(200), ctx.json(MOCK_POST_LIST[pages]), ctx.delay(2000));
+      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
     }
 
-    return res(ctx.status(200), ctx.json(MOCK_POST_LIST[pages]));
+    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+  }),
+
+  rest.get('/posts/categories/:categoryId', (req, res, ctx) => {
+    const pages = Number(req.url.searchParams.get('pages'));
+
+    if (pages === null) return;
+
+    if (pages > 0) {
+      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
+    }
+
+    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+  }),
+
+  rest.get('/members/me/', (req, res, ctx) => {
+    const pages = Number(req.url.searchParams.get('pages'));
+
+    if (pages === null) return;
+
+    if (pages > 0) {
+      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
+    }
+
+    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+  }),
+
+  rest.get('/posts/me/:categoryId', (req, res, ctx) => {
+    const pages = Number(req.url.searchParams.get('pages'));
+
+    if (pages === null) return;
+
+    if (pages > 0) {
+      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
+    }
+
+    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+  }),
+
+  rest.get('/posts/votes/me', (req, res, ctx) => {
+    const pages = Number(req.url.searchParams.get('pages'));
+
+    if (pages === null) return;
+
+    if (pages > 0) {
+      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
+    }
+
+    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
   }),
 ];

--- a/frontend/src/mocks/wus/post.ts
+++ b/frontend/src/mocks/wus/post.ts
@@ -27,19 +27,7 @@ export const mockPostList = [
     return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
   }),
 
-  rest.get('/members/me/', (req, res, ctx) => {
-    const pages = Number(req.url.searchParams.get('pages'));
-
-    if (pages === null) return;
-
-    if (pages > 0) {
-      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
-    }
-
-    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
-  }),
-
-  rest.get('/posts/me/:categoryId', (req, res, ctx) => {
+  rest.get('/posts/me', (req, res, ctx) => {
     const pages = Number(req.url.searchParams.get('pages'));
 
     if (pages === null) return;

--- a/frontend/src/mocks/wus/post.ts
+++ b/frontend/src/mocks/wus/post.ts
@@ -4,11 +4,11 @@ import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
 export const mockPostList = [
   rest.get('/posts', (req, res, ctx) => {
-    const pages = Number(req.url.searchParams.get('pages'));
+    const page = Number(req.url.searchParams.get('page'));
 
-    if (pages === null) return;
+    if (page === null) return;
 
-    if (pages > 0) {
+    if (page > 0) {
       return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
     }
 
@@ -16,11 +16,11 @@ export const mockPostList = [
   }),
 
   rest.get('/posts/categories/:categoryId', (req, res, ctx) => {
-    const pages = Number(req.url.searchParams.get('pages'));
+    const page = Number(req.url.searchParams.get('page'));
 
-    if (pages === null) return;
+    if (page === null) return;
 
-    if (pages > 0) {
+    if (page > 0) {
       return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
     }
 
@@ -28,11 +28,11 @@ export const mockPostList = [
   }),
 
   rest.get('/posts/me', (req, res, ctx) => {
-    const pages = Number(req.url.searchParams.get('pages'));
+    const page = Number(req.url.searchParams.get('page'));
 
-    if (pages === null) return;
+    if (page === null) return;
 
-    if (pages > 0) {
+    if (page > 0) {
       return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
     }
 
@@ -40,11 +40,11 @@ export const mockPostList = [
   }),
 
   rest.get('/posts/votes/me', (req, res, ctx) => {
-    const pages = Number(req.url.searchParams.get('pages'));
+    const page = Number(req.url.searchParams.get('page'));
 
-    if (pages === null) return;
+    if (page === null) return;
 
-    if (pages > 0) {
+    if (page > 0) {
       return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
     }
 

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -1,3 +1,5 @@
+import { PostRequestKind, PostSorting, PostStatus } from '@components/post/PostListPage/types';
+
 export interface WrittenVoteOptionType {
   id: number;
   text: string;
@@ -24,4 +26,12 @@ export interface PostInfo {
 export interface PostList {
   pageNumber: number;
   postList: PostInfo[];
+}
+
+export interface PostListByOption {
+  content: PostRequestKind;
+  postStatus: PostStatus;
+  postSorting: PostSorting;
+  pageNumber: number;
+  categoryId?: number;
 }

--- a/frontend/src/utils/getPathFragment.ts
+++ b/frontend/src/utils/getPathFragment.ts
@@ -1,0 +1,13 @@
+export const getPathFragment = (url: string) => {
+  const pathList = url.split('/');
+
+  const lastIndex = pathList.length - 1;
+
+  if (Number(pathList[lastIndex]) > 0) {
+    pathList.pop();
+
+    return pathList.join('/');
+  }
+
+  return url;
+};


### PR DESCRIPTION
## 🔥 연관 이슈

close: #127 

## 📝 작업 요약

- 내가 작성한 게시글 조회 fetch 조회 함수
- 내가 투표한 게시글 조회 fetch 조회 함수
- msw 코드 작성
- 기존의 게시글 목록을 불러오는 훅 변경
- 현재 어느 페이지인지 확인하는 훅 및 유틸 함수 구현
- 홈페이지, 내가 작성한 글 페이지, 내가 투표한 글 페이지, 카테고리별 글 페이지에서 알맞은 API를 불러오도록 연동

## 🔎 작업 상세 설명

- 홈페이지, 내가 작성한 글 페이지, 내가 투표한 글 페이지, 카테고리별 글 페이지 모두 하나의 컴포넌트 HomePage를 사용하였음 => 이유는 게시글 목록을 불러오는 기능이 모두 같기 때문
- 현재 어느 페이지인지 확인하는 유틸 함수를 만든 이유는 useLocation의 pathname을 이용하려고 했으나 category/1 과 같이 따로 가공해야하는 경우가 있어서 만들게 되었음
- posts/me를 사용하는 환경에서 테스트가 실패했는데 그 이유는 MSW handlers의 순서가 원인이였습니다.

아래와 같이 /posts/me가 /posts/:postId 보다 위에 있어야 하는데요. 그 이유는 다음과 같습니다. 
```bash
/posts/me 가 /posts/:postId 보다 위에 있어야 하는 이유는 라우팅 순서 때문입니다.
 Express나 Node.js에서는 라우팅 경로와 일치하는 첫 번째 핸들러 함수를 실행합니다. 

만약 /posts/me 가 /posts/:postId 보다 아래에 있다면, /posts/me 경로도 /posts/:postId 경로와 일치하게 됩니다. 
이렇게 되면 /posts/me 요청도 /posts/:postId 핸들러 함수가 실행되어 원하는 동작을 수행하지 못하게 됩니다.

따라서, 정확한 라우팅 동작을 위해 /posts/me 가 /posts/:postId 보다 위에 있어야 합니다. 
이렇게 하면 /posts/me 요청이 정확하게 /posts/me 핸들러 함수에 매핑되어 응답이 가능하게 됩니다.
```
```tsx
  rest.get('/posts/me', (req, res, ctx) => {
    const page = Number(req.url.searchParams.get('page'));

    if (page === null) return;

    if (page > 0) {
      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
    }


  //게시글 수정
  rest.put('/posts/:postId', (req, res, ctx) => {
    window.console.log('게시글 수정 완료', req.body);

    return res(
      ctx.delay(1000),
      ctx.status(200),
      ctx.json({ message: '게시글이 성공적으로 수정되었습니다!!' })
    );
  }),
```



## 🌟 논의 사항

HomePage를 그대로 router 4군데서 사용하는 것이 괜찮아 보이시나요?  예시로 내가 투표한 글 페이지를 만들어도 홈페이지와 똑같은 구성입니다.

검색, 내가 작성한 댓글을 만들게 되어도 비슷한 흐름으로 구현하게 될 예정입니다.

빈 결과일 때 "해당되는 게시글이 없습니다." 를 안내 문구로 보여줘야 할 것 같고 새로 이슈를 파야할 것 같아요
