### PR TITLE
카테고리 목록 조회, 카테고리 즐겨찾기, 유저 정보 조회에 대한 커스텀 쿼리 구현

### DIFF
--- a/frontend/src/components/common/Dashboard/CategoryToggle/CategoryToggle.stories.tsx
+++ b/frontend/src/components/common/Dashboard/CategoryToggle/CategoryToggle.stories.tsx
@@ -19,22 +19,11 @@ const MOCK_CATEGORIES: Category[] = [
 ];
 
 export const Default: Story = {
-  render: () => (
-    <CategoryToggle
-      handleFavoriteClick={() => {}}
-      title="즐겨찾기"
-      categoryList={MOCK_CATEGORIES}
-    />
-  ),
+  render: () => <CategoryToggle title="즐겨찾기" categoryList={MOCK_CATEGORIES} />,
 };
 
 export const Closed: Story = {
   render: () => (
-    <CategoryToggle
-      handleFavoriteClick={() => {}}
-      title="즐겨찾기"
-      categoryList={MOCK_CATEGORIES}
-      isInitialOpen={false}
-    />
+    <CategoryToggle title="즐겨찾기" categoryList={MOCK_CATEGORIES} isInitialOpen={false} />
   ),
 };

--- a/frontend/src/components/common/Dashboard/CategoryToggle/index.tsx
+++ b/frontend/src/components/common/Dashboard/CategoryToggle/index.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 
 import { Category } from '@type/category';
 
+import { useCategoryFavoriteToggle } from '@hooks/query/category/useCategoryFavoriteToggle';
+
 import chevronDown from '@assets/chevron-down.svg';
 import chevronUp from '@assets/chevron-up.svg';
 
@@ -10,14 +12,12 @@ import * as S from './style';
 interface CategoryToggleProps {
   title: string;
   categoryList: Category[];
-  handleFavoriteClick: (categoryId: number) => void;
   isInitialOpen?: boolean;
 }
 
 export default function CategoryToggle({
   title,
   categoryList,
-  handleFavoriteClick,
   isInitialOpen = true,
 }: CategoryToggleProps) {
   const [isToggleOpen, setIsToggleOpen] = useState(isInitialOpen);
@@ -25,6 +25,8 @@ export default function CategoryToggle({
   const handleToggleClick = () => {
     setIsToggleOpen(prevIsToggleOpen => !prevIsToggleOpen);
   };
+
+  const { mutate } = useCategoryFavoriteToggle();
 
   return (
     <S.Container>
@@ -43,7 +45,7 @@ export default function CategoryToggle({
             <S.CategoryItem key={id}>
               <S.Circle
                 title="즐겨찾기 버튼"
-                onClick={() => handleFavoriteClick(id)}
+                onClick={() => mutate({ id, isFavorite })}
                 $isFavorite={isFavorite}
               />
               <S.CategoryNameLink to={`/posts/category/${id}`}>{name}</S.CategoryNameLink>

--- a/frontend/src/components/common/Dashboard/Dashboard.stories.tsx
+++ b/frontend/src/components/common/Dashboard/Dashboard.stories.tsx
@@ -65,7 +65,6 @@ export const LoggedIn: Story = {
     <Dashboard
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_CATEGORIES}
-      handleFavoriteClick={() => {}}
       handleLogoutClick={() => {}}
     />
   ),
@@ -76,7 +75,6 @@ export const FavoriteCategory: Story = {
     <Dashboard
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_FAVORITE_CATEGORIES}
-      handleFavoriteClick={() => {}}
       handleLogoutClick={() => {}}
     />
   ),
@@ -88,7 +86,6 @@ export const SelectedCategory: Story = {
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_FAVORITE_CATEGORIES}
       selectedCategory="패션"
-      handleFavoriteClick={() => {}}
       handleLogoutClick={() => {}}
     />
   ),
@@ -99,18 +96,11 @@ export const LongCategoryList: Story = {
     <Dashboard
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_LONG_CATEGORIES}
-      handleFavoriteClick={() => {}}
       handleLogoutClick={() => {}}
     />
   ),
 };
 
 export const Guest: Story = {
-  render: () => (
-    <Dashboard
-      categoryList={MOCK_CATEGORIES}
-      handleFavoriteClick={() => {}}
-      handleLogoutClick={() => {}}
-    />
-  ),
+  render: () => <Dashboard categoryList={MOCK_CATEGORIES} handleLogoutClick={() => {}} />,
 };

--- a/frontend/src/components/common/Dashboard/index.tsx
+++ b/frontend/src/components/common/Dashboard/index.tsx
@@ -13,7 +13,6 @@ import UserProfile from './UserProfile';
 interface DashboardProps {
   categoryList: Category[];
   selectedCategory?: string;
-  handleFavoriteClick: (categoryId: number) => void;
   handleLogoutClick: () => void;
   userInfo?: User;
 }
@@ -22,7 +21,6 @@ export default function Dashboard({
   userInfo,
   categoryList,
   selectedCategory = '전체',
-  handleFavoriteClick,
   handleLogoutClick,
 }: DashboardProps) {
   const favoriteCategory = categoryList.filter(category => category.isFavorite === true);
@@ -37,18 +35,8 @@ export default function Dashboard({
       </S.SelectCategoryWrapper>
       <S.ContentContainer>
         <S.CategoryToggleContainer>
-          {userInfo && (
-            <CategoryToggle
-              title="즐겨찾기"
-              categoryList={favoriteCategory}
-              handleFavoriteClick={handleFavoriteClick}
-            />
-          )}
-          <CategoryToggle
-            title="카테고리 모아보기"
-            categoryList={allCategory}
-            handleFavoriteClick={handleFavoriteClick}
-          />
+          {userInfo && <CategoryToggle title="즐겨찾기" categoryList={favoriteCategory} />}
+          <CategoryToggle title="카테고리 모아보기" categoryList={allCategory} />
         </S.CategoryToggleContainer>
       </S.ContentContainer>
       {userInfo && (

--- a/frontend/src/components/common/Drawer/Drawer.stories.tsx
+++ b/frontend/src/components/common/Drawer/Drawer.stories.tsx
@@ -40,7 +40,6 @@ export const LeftSideBar = () => {
         <Dashboard
           userInfo={MOCK_USER_INFO}
           categoryList={MOCK_CATEGORIES}
-          handleFavoriteClick={() => {}}
           handleLogoutClick={() => {}}
         />
       </Drawer>
@@ -58,7 +57,6 @@ export const RightSideBar = () => {
         <Dashboard
           userInfo={MOCK_USER_INFO}
           categoryList={MOCK_CATEGORIES}
-          handleFavoriteClick={() => {}}
           handleLogoutClick={() => {}}
         />
       </Drawer>

--- a/frontend/src/components/common/Layout/index.tsx
+++ b/frontend/src/components/common/Layout/index.tsx
@@ -19,7 +19,6 @@ export default function Layout({ children, isSidebarVisible }: LayoutProps) {
   const userInfo = undefined;
   const categoryList = MOCK_FAVORITE_CATEGORIES;
   const selectedCategory = undefined;
-  const handleFavoriteClick = () => {};
   const handleLogoutClick = () => {};
 
   const movePostListPage = () => {
@@ -38,7 +37,6 @@ export default function Layout({ children, isSidebarVisible }: LayoutProps) {
               userInfo={userInfo}
               categoryList={categoryList}
               selectedCategory={selectedCategory}
-              handleFavoriteClick={handleFavoriteClick}
               handleLogoutClick={handleLogoutClick}
             />
           </S.DashboardWrapper>

--- a/frontend/src/components/post/PostListPage/index.tsx
+++ b/frontend/src/components/post/PostListPage/index.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 
+import { useCategoryList } from '@hooks/query/category/useCategoryList';
 import { useUserInfo } from '@hooks/query/user/useUserInfo';
 import { useDrawer } from '@hooks/useDrawer';
 
@@ -13,15 +14,14 @@ import PostList from '@components/post/PostList';
 
 import { PATH } from '@constants/path';
 
-import { MOCK_FAVORITE_CATEGORIES } from '@mocks/mockData/category';
-
 import * as S from './style';
 
 export default function PostListPage() {
   const { drawerRef, closeDrawer, openDrawer } = useDrawer('left');
 
   //추후 구현 예정
-  const categoryList = MOCK_FAVORITE_CATEGORIES;
+  const isLoggedIn = true; //로그인한 유저라고 가정
+  const { data: categoryList } = useCategoryList(isLoggedIn);
   const { data: userInfo } = useUserInfo();
   const handleFavoriteClick = () => {};
   const handleLogoutClick = () => {};
@@ -39,7 +39,7 @@ export default function PostListPage() {
         <Drawer handleDrawerClose={closeDrawer} placement="left" width="225px" ref={drawerRef}>
           <Dashboard
             userInfo={userInfo}
-            categoryList={categoryList}
+            categoryList={categoryList ?? []}
             handleFavoriteClick={handleFavoriteClick}
             handleLogoutClick={handleLogoutClick}
           />

--- a/frontend/src/components/post/PostListPage/index.tsx
+++ b/frontend/src/components/post/PostListPage/index.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 
+import { useUserInfo } from '@hooks/query/user/useUserInfo';
 import { useDrawer } from '@hooks/useDrawer';
 
 import AddButton from '@components/common/AddButton';
@@ -21,7 +22,7 @@ export default function PostListPage() {
 
   //추후 구현 예정
   const categoryList = MOCK_FAVORITE_CATEGORIES;
-  const userInfo = undefined;
+  const { data: userInfo } = useUserInfo();
   const handleFavoriteClick = () => {};
   const handleLogoutClick = () => {};
 

--- a/frontend/src/components/post/PostListPage/index.tsx
+++ b/frontend/src/components/post/PostListPage/index.tsx
@@ -23,7 +23,7 @@ export default function PostListPage() {
   const isLoggedIn = true; //로그인한 유저라고 가정
   const { data: categoryList } = useCategoryList(isLoggedIn);
   const { data: userInfo } = useUserInfo();
-  const handleFavoriteClick = () => {};
+
   const handleLogoutClick = () => {};
 
   const scrollToTop = () => {
@@ -40,7 +40,6 @@ export default function PostListPage() {
           <Dashboard
             userInfo={userInfo}
             categoryList={categoryList ?? []}
-            handleFavoriteClick={handleFavoriteClick}
             handleLogoutClick={handleLogoutClick}
           />
         </Drawer>

--- a/frontend/src/constants/queryKey.ts
+++ b/frontend/src/constants/queryKey.ts
@@ -1,3 +1,5 @@
 export const QUERY_KEY = {
   POSTS: 'posts',
+  CATEGORIES: 'categories',
+  USER_INFO: 'user_info',
 };

--- a/frontend/src/hooks/query/category/useCategoryFavoriteToggle.ts
+++ b/frontend/src/hooks/query/category/useCategoryFavoriteToggle.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { Category } from '@type/category';
+
+import { addFavoriteCategory, removeFavoriteCategory } from '@api/wus/categoryList';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useCategoryFavoriteToggle = () => {
+  const queryClient = useQueryClient();
+  const { mutate, isLoading, isError, error } = useMutation(
+    ({ id, isFavorite }: Omit<Category, 'name'>) =>
+      isFavorite ? removeFavoriteCategory(id) : addFavoriteCategory(id),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries([QUERY_KEY.CATEGORIES, 'favorite']);
+      },
+      onError: error => {
+        window.console.log('Category favorite toggle error', error);
+      },
+    }
+  );
+
+  return { mutate, isLoading, isError, error };
+};

--- a/frontend/src/hooks/query/category/useCategoryList.ts
+++ b/frontend/src/hooks/query/category/useCategoryList.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { Category } from '@type/category';
+
+import { getGuestCategoryList, getUserCategoryList } from '@api/wus/categoryList';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useCategoryList = (isLoggedIn: boolean) => {
+  const { data, error, isLoading, isError } = useQuery<Category[]>(
+    [QUERY_KEY.CATEGORIES],
+    isLoggedIn ? getUserCategoryList : getGuestCategoryList
+  );
+
+  return { data, error, isLoading, isError };
+};

--- a/frontend/src/hooks/query/user/useUserInfo.ts
+++ b/frontend/src/hooks/query/user/useUserInfo.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { UserInfoResponse } from '@type/user';
+
+import { getUserInfo } from '@api/wus/userInfo';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useUserInfo = () => {
+  const { data, error, isLoading, isError } = useQuery<UserInfoResponse>(
+    [QUERY_KEY.USER_INFO],
+    getUserInfo
+  );
+
+  return { data, error, isLoading, isError };
+};

--- a/frontend/src/mocks/wus/categoryList.ts
+++ b/frontend/src/mocks/wus/categoryList.ts
@@ -12,14 +12,14 @@ export const mockCategoryHandlers = [
   }),
 
   rest.post('/categories/:categoryId/like', (req, res, ctx) => {
-    MOCK_CATEGORY_LIST[1].favorite = true;
+    MOCK_CATEGORY_LIST[2].favorite = true;
 
-    return res(ctx.status(201), ctx.json({ message: 'ok' }));
+    return res(ctx.status(201), ctx.json({ message: '카테고리 즐겨찾기 등록 성공' }));
   }),
 
   rest.delete('/categories/:categoryId/like', (req, res, ctx) => {
-    MOCK_CATEGORY_LIST[0].favorite = false;
+    MOCK_CATEGORY_LIST[1].favorite = false;
 
-    return res(ctx.status(204), ctx.json({ message: 'ok' }));
+    return res(ctx.status(204));
   }),
 ];

--- a/frontend/src/mocks/wus/categoryList.ts
+++ b/frontend/src/mocks/wus/categoryList.ts
@@ -12,13 +12,13 @@ export const mockCategoryHandlers = [
   }),
 
   rest.post('/categories/:categoryId/like', (req, res, ctx) => {
-    MOCK_CATEGORY_LIST[2].favorite = true;
+    MOCK_CATEGORY_LIST[1].favorite = true;
 
     return res(ctx.status(201), ctx.json({ message: '카테고리 즐겨찾기 등록 성공' }));
   }),
 
   rest.delete('/categories/:categoryId/like', (req, res, ctx) => {
-    MOCK_CATEGORY_LIST[1].favorite = false;
+    MOCK_CATEGORY_LIST[0].favorite = false;
 
     return res(ctx.status(204));
   }),

--- a/frontend/src/utils/fetch.ts
+++ b/frontend/src/utils/fetch.ts
@@ -74,11 +74,7 @@ export const deleteFetch = async (url: string) => {
     headers,
   });
 
-  const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error(data.message);
-  }
+  return response;
 };
 
 export const multiPostFetch = async (url: string, body: FormData) => {


### PR DESCRIPTION
## 🔥 연관 이슈

close: #108 
close: #109 

## 📝 작업 요약
* 카테고리 목록 조회, 카테고리 즐겨찾기, 유저 정보 조회에 대한 커스텀 쿼리들을 구현하여, fetch 함수들로 서버와 통신하고 서버 상태를 get, mutate 합니다.
* handleFavoriteClick 함수들을 여러 번 넘겨주는, props drilling 현상을 해결하였습니다. (onClick에 할당할 함수인 mutate를, CategoryToggle 컴포넌트에서 불러주고 있습니다. 이렇게 하면 handleFavoriteClick 함수를 아래로 계속 넘겨줄 필요가 없어집니다.) 

## 🔎 작업 상세 설명
* 카테고리 목록을 조회하는 쿼리 구현(useCategoryList)
* 카테고리를 즐겨찾기 등록 및 해제하는 쿼리 구현(useCategoryFavoriteToggle)
* 유저 정보를 조회하는 쿼리 구현(useUserInfo)

## 🌟 논의 사항
* 현재 utils/fetch.ts 에서 deleteFetch 함수를 수정한 상태입니다.
   *  상태코드 204인 경우 response가 json 형태이면 안된다고 함 -> response 만 return 하도록 수정함.
   * 그런데 이렇게 하면 error 메시지를 잡을 수 없음 -> try-catch 구문을 이용해야 함.
   * utils/fetch 내의 함수들을 try-catch 형식으로 바꾸려고 합니다! 이슈를 따로 파야할거 같아요~
---
* 따로 pr 날리는 거보다 쿼리 함수들 만드는 김에 issue 2개 동시에 완료했습니다~