### PR TITLE
닉네임 수정 기능 구현

### DIFF
--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
         final Member member = Member.from(response);
         final Member registeredMember = memberService.register(member);
         final String token = tokenProcessor.generateToken(registeredMember);
-        return new LoginResponse(token, registeredMember.getNickname());
+        return new LoginResponse(token, registeredMember.getNickname().getValue());
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/votogether/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,17 +29,22 @@ public class MemberController {
     @Operation(summary = "회원 정보 조회", description = "회원 정보를 반환한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "정보 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "올바르지 않은 요청"),
+            @ApiResponse(responseCode = "400", description = "올바르지 않은 요청")
     })
     @GetMapping("/me")
     public ResponseEntity<MemberInfoResponse> findMemberInfo(@Auth final Member member) {
         return ResponseEntity.ok(memberService.findMemberInfo(member));
     }
 
+    @Operation(summary = "회원 닉네임 변경", description = "회원 닉네임을 변경한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "닉네임 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "올바르지 않은 변경할 닉네임 요청")
+    })
     @PatchMapping("/me/nickname")
     public ResponseEntity<Void> changeNickname(
             @Auth final Member member,
-            @RequestBody final MemberNicknameRequest request
+            @Valid @RequestBody final MemberNicknameRequest request
     ) {
         memberService.changeNickname(member, request.nickname());
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/votogether/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/votogether/domain/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.votogether.domain.member.controller;
 
 import com.votogether.domain.member.dto.MemberInfoResponse;
-import com.votogether.domain.member.dto.MemberNicknameRequest;
+import com.votogether.domain.member.dto.MemberNicknameUpdateRequest;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.member.service.MemberService;
 import com.votogether.global.jwt.Auth;
@@ -44,7 +44,7 @@ public class MemberController {
     @PatchMapping("/me/nickname")
     public ResponseEntity<Void> changeNickname(
             @Auth final Member member,
-            @Valid @RequestBody final MemberNicknameRequest request
+            @Valid @RequestBody final MemberNicknameUpdateRequest request
     ) {
         memberService.changeNickname(member, request.nickname());
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/votogether/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/votogether/domain/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package com.votogether.domain.member.controller;
+
+import com.votogether.domain.member.dto.MemberNicknameRequest;
+import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.member.service.MemberService;
+import com.votogether.global.jwt.Auth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PatchMapping("/members/me/nickname")
+    public ResponseEntity<Void> changeNickname(
+            @Auth final Member member,
+            @RequestBody final MemberNicknameRequest request
+    ) {
+        memberService.changeNickname(member, request.nickname());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/votogether/domain/member/dto/MemberNicknameRequest.java
+++ b/backend/src/main/java/com/votogether/domain/member/dto/MemberNicknameRequest.java
@@ -1,0 +1,6 @@
+package com.votogether.domain.member.dto;
+
+public record MemberNicknameRequest(
+        String nickname
+) {
+}

--- a/backend/src/main/java/com/votogether/domain/member/dto/MemberNicknameRequest.java
+++ b/backend/src/main/java/com/votogether/domain/member/dto/MemberNicknameRequest.java
@@ -1,6 +1,12 @@
 package com.votogether.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "닉네임 변경 요청")
 public record MemberNicknameRequest(
+        @Schema(description = "변경할 닉네임", example = "jeomxon")
+        @NotBlank(message = "닉네임은 빈값 혹은 공백이 포함될 수 없습니다.")
         String nickname
 ) {
 }

--- a/backend/src/main/java/com/votogether/domain/member/dto/MemberNicknameUpdateRequest.java
+++ b/backend/src/main/java/com/votogether/domain/member/dto/MemberNicknameUpdateRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "닉네임 변경 요청")
-public record MemberNicknameRequest(
+public record MemberNicknameUpdateRequest(
         @Schema(description = "변경할 닉네임", example = "jeomxon")
         @NotBlank(message = "닉네임은 빈값 혹은 공백이 포함될 수 없습니다.")
         String nickname

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -97,9 +97,6 @@ public class Member extends BaseEntity {
         if (!Pattern.matches("^[가-힣a-zA-Z0-9]+$", nickname)) {
             throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LETTER);
         }
-        if (this.nickname.equals(nickname)) {
-            throw new BadRequestException(MemberExceptionType.DUPLICATED_NICKNAME_BEFORE);
-        }
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -2,6 +2,8 @@ package com.votogether.domain.member.entity;
 
 import com.votogether.domain.auth.dto.KakaoMemberResponse;
 import com.votogether.domain.common.BaseEntity;
+import com.votogether.domain.member.exception.MemberExceptionType;
+import com.votogether.exception.BadRequestException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,6 +11,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -80,6 +83,23 @@ public class Member extends BaseEntity {
 
     public void plusPoint(final int point) {
         this.point = this.point + point;
+    }
+
+    public void changeNickname(final String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
+    }
+
+    private void validateNickname(final String nickname) {
+        if (nickname.length() < 2 || nickname.length() > 16) {
+            throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LENGTH);
+        }
+        if (!Pattern.matches("^[가-힣a-zA-Z0-9]+$", nickname)) {
+            throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LETTER);
+        }
+        if (this.nickname.equals(nickname)) {
+            throw new BadRequestException(MemberExceptionType.DUPLICATED_NICKNAME_BEFORE);
+        }
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -2,16 +2,14 @@ package com.votogether.domain.member.entity;
 
 import com.votogether.domain.auth.dto.KakaoMemberResponse;
 import com.votogether.domain.common.BaseEntity;
-import com.votogether.domain.member.exception.MemberExceptionType;
-import com.votogether.exception.BadRequestException;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,8 +24,8 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 15, unique = true, nullable = false)
-    private String nickname;
+    @Embedded
+    private Nickname nickname;
 
     @Enumerated(value = EnumType.STRING)
     @Column(length = 20, nullable = false)
@@ -59,7 +57,7 @@ public class Member extends BaseEntity {
             final String socialId,
             final Integer point
     ) {
-        this.nickname = nickname;
+        this.nickname = new Nickname(nickname);
         this.gender = gender;
         this.ageRange = ageRange;
         this.birthday = birthday;
@@ -86,17 +84,7 @@ public class Member extends BaseEntity {
     }
 
     public void changeNickname(final String nickname) {
-        validateNickname(nickname);
-        this.nickname = nickname;
-    }
-
-    private void validateNickname(final String nickname) {
-        if (nickname.length() < 2 || nickname.length() > 16) {
-            throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LENGTH);
-        }
-        if (!Pattern.matches("^[가-힣a-zA-Z0-9]+$", nickname)) {
-            throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LETTER);
-        }
+        this.nickname = new Nickname(nickname);
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/entity/Nickname.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Nickname.java
@@ -1,0 +1,37 @@
+package com.votogether.domain.member.entity;
+
+import com.votogether.domain.member.exception.MemberExceptionType;
+import com.votogether.exception.BadRequestException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Embeddable
+public class Nickname {
+
+    private static final int MINIMUM_NICKNAME_LENGTH = 2;
+    private static final int MAXIMUM_NICKNAME_LENGTH = 16;
+
+    @Column(name = "nickname", length = 15, unique = true, nullable = false)
+    private String value;
+
+    public Nickname(final String nickname) {
+        validateNickname(nickname);
+        this.value = nickname;
+    }
+
+    private void validateNickname(final String nickname) {
+        if (nickname.length() < MINIMUM_NICKNAME_LENGTH || nickname.length() > MAXIMUM_NICKNAME_LENGTH) {
+            throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LENGTH);
+        }
+        if (!Pattern.matches("^[가-힣a-zA-Z0-9]+$", nickname)) {
+            throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LETTER);
+        }
+    }
+
+}

--- a/backend/src/main/java/com/votogether/domain/member/exception/MemberExceptionType.java
+++ b/backend/src/main/java/com/votogether/domain/member/exception/MemberExceptionType.java
@@ -8,9 +8,8 @@ public enum MemberExceptionType implements ExceptionType {
 
     INVALID_NICKNAME_LENGTH(800, "닉네임의 길이가 올바르지 않습니다."),
     INVALID_NICKNAME_LETTER(801, "닉네임에 들어갈 수 없는 문자가 포함되어 있습니다."),
-    DUPLICATED_NICKNAME_BEFORE(802, "변경할 닉네임은 이전 닉네임과 동일할 수 없습니다."),
-    ALREADY_EXISTENT_NICKNAME(803, "이미 중복된 닉네임이 존재합니다."),
-    NONEXISTENT_MEMBER(804, "해당 회원이 존재하지 않습니다.");
+    ALREADY_EXISTENT_NICKNAME(802, "이미 중복된 닉네임이 존재합니다."),
+    NONEXISTENT_MEMBER(803, "해당 회원이 존재하지 않습니다.");
 
     private final int code;
     private final String message;

--- a/backend/src/main/java/com/votogether/domain/member/exception/MemberExceptionType.java
+++ b/backend/src/main/java/com/votogether/domain/member/exception/MemberExceptionType.java
@@ -1,0 +1,23 @@
+package com.votogether.domain.member.exception;
+
+import com.votogether.exception.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public enum MemberExceptionType implements ExceptionType {
+
+    INVALID_NICKNAME_LENGTH(800, "닉네임의 길이가 올바르지 않습니다."),
+    INVALID_NICKNAME_LETTER(801, "닉네임에 들어갈 수 없는 문자가 포함되어 있습니다."),
+    DUPLICATED_NICKNAME_BEFORE(802, "변경할 닉네임은 이전 닉네임과 동일할 수 없습니다."),
+    ALREADY_EXISTENT_NICKNAME(803, "이미 중복된 닉네임이 존재합니다."),
+    NONEXISTENT_MEMBER(804, "해당 회원이 존재하지 않습니다.");
+
+    private final int code;
+    private final String message;
+
+    MemberExceptionType(final int code, final String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+}

--- a/backend/src/main/java/com/votogether/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/votogether/domain/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialIdAndSocialType(final String socialId, final SocialType socialType);
 
+    boolean existsByNickname(final String nickname);
+
 }

--- a/backend/src/main/java/com/votogether/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/votogether/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.votogether.domain.member.repository;
 
 import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.member.entity.Nickname;
 import com.votogether.domain.member.entity.SocialType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialIdAndSocialType(final String socialId, final SocialType socialType);
 
-    boolean existsByNickname(final String nickname);
+    boolean existsByNickname(final Nickname nickname);
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.votogether.domain.member.service;
 
 import com.votogether.domain.member.dto.MemberInfoResponse;
 import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.member.entity.Nickname;
 import com.votogether.domain.member.exception.MemberExceptionType;
 import com.votogether.domain.member.repository.MemberRepository;
 import com.votogether.domain.post.repository.PostRepository;
@@ -42,7 +43,7 @@ public class MemberService {
         final int numberOfVotes = voteRepository.countByMember(member);
 
         return new MemberInfoResponse(
-                member.getNickname(),
+                member.getNickname().getValue(),
                 member.getPoint(),
                 numberOfPosts,
                 numberOfVotes
@@ -56,7 +57,7 @@ public class MemberService {
     }
 
     private void validateExistentNickname(final String nickname) {
-        final boolean isExist = memberRepository.existsByNickname(nickname);
+        final boolean isExist = memberRepository.existsByNickname(new Nickname(nickname));
         if (isExist) {
             throw new BadRequestException(MemberExceptionType.ALREADY_EXISTENT_NICKNAME);
         }

--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -1,7 +1,10 @@
 package com.votogether.domain.member.service;
 
 import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.member.exception.MemberExceptionType;
 import com.votogether.domain.member.repository.MemberRepository;
+import com.votogether.exception.BadRequestException;
+import com.votogether.exception.NotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,7 +28,20 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member findById(final Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 Id를 가진 회원은 존재하지 않습니다."));
+                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NONEXISTENT_MEMBER));
+    }
+
+    @Transactional
+    public void changeNickname(final Member member, final String nickname) {
+        validateExistentNickname(nickname);
+        member.changeNickname(nickname);
+    }
+
+    private void validateExistentNickname(final String nickname) {
+        final boolean isExist = memberRepository.existsByNickname(nickname);
+        if (!isExist) {
+            throw new BadRequestException(MemberExceptionType.ALREADY_EXISTENT_NICKNAME);
+        }
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -39,7 +39,7 @@ public class MemberService {
 
     private void validateExistentNickname(final String nickname) {
         final boolean isExist = memberRepository.existsByNickname(nickname);
-        if (!isExist) {
+        if (isExist) {
             throw new BadRequestException(MemberExceptionType.ALREADY_EXISTENT_NICKNAME);
         }
     }

--- a/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 
 import com.votogether.domain.member.dto.MemberInfoResponse;
-import com.votogether.domain.member.dto.MemberNicknameRequest;
+import com.votogether.domain.member.dto.MemberNicknameUpdateRequest;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.member.service.MemberService;
 import com.votogether.global.jwt.TokenProcessor;
@@ -78,7 +78,7 @@ class MemberControllerTest {
         void changeNicknameSuccess() {
             // given
             String nicknameToChange = "jeomxon";
-            MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest(nicknameToChange);
+            MemberNicknameUpdateRequest memberNicknameUpdateRequest = new MemberNicknameUpdateRequest(nicknameToChange);
 
             willDoNothing().given(memberService).changeNickname(any(Member.class), anyString());
 
@@ -86,7 +86,7 @@ class MemberControllerTest {
             RestAssuredMockMvc
                     .given().log().all()
                     .contentType(ContentType.JSON)
-                    .body(memberNicknameRequest)
+                    .body(memberNicknameUpdateRequest)
                     .when().patch("/members/me/nickname")
                     .then().log().all()
                     .statusCode(HttpStatus.OK.value())
@@ -98,7 +98,7 @@ class MemberControllerTest {
         void changeNicknameFail() {
             // given
             String nicknameToChange = "";
-            MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest(nicknameToChange);
+            MemberNicknameUpdateRequest memberNicknameUpdateRequest = new MemberNicknameUpdateRequest(nicknameToChange);
 
             willDoNothing().given(memberService).changeNickname(any(Member.class), anyString());
 
@@ -106,7 +106,7 @@ class MemberControllerTest {
             RestAssuredMockMvc
                     .given().log().all()
                     .contentType(ContentType.JSON)
-                    .body(memberNicknameRequest)
+                    .body(memberNicknameUpdateRequest)
                     .when().patch("/members/me/nickname")
                     .then().log().all()
                     .statusCode(HttpStatus.BAD_REQUEST.value())

--- a/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
@@ -3,12 +3,16 @@ package com.votogether.domain.member.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 
 import com.votogether.domain.member.dto.MemberInfoResponse;
+import com.votogether.domain.member.dto.MemberNicknameRequest;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.member.service.MemberService;
 import com.votogether.global.jwt.TokenProcessor;
+import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 
 @Import(TokenProcessor.class)
 @WebMvcTest(MemberController.class)
@@ -61,6 +66,26 @@ class MemberControllerTest {
                 () -> assertThat(response.postCount()).isEqualTo(0),
                 () -> assertThat(response.voteCount()).isEqualTo(0)
         );
+    }
+
+    @Test
+    @DisplayName("회원의 닉네임을 변경한다.")
+    void changeNickname() {
+        // given
+        String nicknameToChange = "jeomxon";
+        MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest(nicknameToChange);
+        
+        willDoNothing().given(memberService).changeNickname(any(Member.class), anyString());
+
+        // when, then
+        RestAssuredMockMvc
+                .given().log().all()
+                .contentType(ContentType.JSON)
+                .body(memberNicknameRequest)
+                .when().patch("/members/me/nickname")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
     }
 
 }

--- a/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
@@ -16,6 +16,7 @@ import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -68,24 +69,50 @@ class MemberControllerTest {
         );
     }
 
-    @Test
-    @DisplayName("회원의 닉네임을 변경한다.")
-    void changeNickname() {
-        // given
-        String nicknameToChange = "jeomxon";
-        MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest(nicknameToChange);
-        
-        willDoNothing().given(memberService).changeNickname(any(Member.class), anyString());
+    @Nested
+    @DisplayName("회원의 닉네임이")
+    class ChangeNickname {
 
-        // when, then
-        RestAssuredMockMvc
-                .given().log().all()
-                .contentType(ContentType.JSON)
-                .body(memberNicknameRequest)
-                .when().patch("/members/me/nickname")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract();
+        @Test
+        @DisplayName("변경에 성공하면 200을 반환한다.")
+        void changeNicknameSuccess() {
+            // given
+            String nicknameToChange = "jeomxon";
+            MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest(nicknameToChange);
+
+            willDoNothing().given(memberService).changeNickname(any(Member.class), anyString());
+
+            // when, then
+            RestAssuredMockMvc
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(memberNicknameRequest)
+                    .when().patch("/members/me/nickname")
+                    .then().log().all()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract();
+        }
+
+        @Test
+        @DisplayName("변경에 실패하면 400을 반환한다.")
+        void changeNicknameFail() {
+            // given
+            String nicknameToChange = "";
+            MemberNicknameRequest memberNicknameRequest = new MemberNicknameRequest(nicknameToChange);
+
+            willDoNothing().given(memberService).changeNickname(any(Member.class), anyString());
+
+            // when, then
+            RestAssuredMockMvc
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(memberNicknameRequest)
+                    .when().patch("/members/me/nickname")
+                    .then().log().all()
+                    .statusCode(HttpStatus.BAD_REQUEST.value())
+                    .extract();
+        }
+
     }
 
 }

--- a/backend/src/test/java/com/votogether/domain/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/repository/MemberRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.votogether.RepositoryTest;
 import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.member.entity.Nickname;
 import com.votogether.fixtures.MemberFixtures;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,7 +38,7 @@ class MemberRepositoryTest {
         @DisplayName("false를 반환한다.")
         void existsByNicknameFalse() {
             // given
-            String nonExistentNickname = "jeomxon";
+            Nickname nonExistentNickname = new Nickname("jeomxon");
 
             // when
             boolean isExist = memberRepository.existsByNickname(nonExistentNickname);

--- a/backend/src/test/java/com/votogether/domain/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.votogether.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.votogether.RepositoryTest;
+import com.votogether.domain.member.entity.Member;
+import com.votogether.fixtures.MemberFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("회원 닉네임을 받아서 존재하는 회원이라면")
+    class existByNickname {
+
+        @Test
+        @DisplayName("true를 반환한다.")
+        void ExistByNickname() {
+            // given
+            Member savedMember = memberRepository.save(MemberFixtures.MALE_20.get());
+
+            // when
+            boolean isExist = memberRepository.existsByNickname(savedMember.getNickname());
+
+            // then
+            assertThat(isExist).isTrue();
+        }
+
+        @Test
+        @DisplayName("false를 반환한다.")
+        void existsByNicknameFalse() {
+            // given
+            String nonExistentNickname = "jeomxon";
+
+            // when
+            boolean isExist = memberRepository.existsByNickname(nonExistentNickname);
+
+            // then
+            assertThat(isExist).isFalse();
+        }
+
+    }
+
+}

--- a/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
@@ -1,12 +1,18 @@
 package com.votogether.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.votogether.ServiceTest;
 import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.member.repository.MemberRepository;
+import com.votogether.exception.BadRequestException;
 import com.votogether.fixtures.MemberFixtures;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @ServiceTest
@@ -14,6 +20,9 @@ class MemberServiceTest {
 
     @Autowired
     MemberService memberService;
+
+    @Autowired
+    MemberRepository memberRepository;
 
     @Test
     @DisplayName("멤버가 존재하지 않으면 저장한다.")
@@ -26,6 +35,65 @@ class MemberServiceTest {
 
         // then
         assertThat(registeredMember.getId()).isNotNull();
+    }
+
+    @Nested
+    @DisplayName("변경할 회원의 닉네임이")
+    class ChangeNickname {
+
+        @Test
+        @DisplayName("주어질 때 정상적으로 닉네임을 변경한다.")
+        void changeNickname() {
+            // given
+            String newNickname = "jeomxon";
+            Member member = memberRepository.save(MemberFixtures.FEMALE_30.get());
+
+            // when
+            memberService.changeNickname(member, newNickname);
+
+            // then
+            assertThat(member.getNickname()).isEqualTo(newNickname);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"j", "abcdefabcdefabcdeff", ""})
+        @DisplayName("올바르지 않은 길이라면 예외가 발생한다.")
+        void changeNicknameThrowsExceptionInvalidLength(String newNickname) {
+            // given
+            Member member = memberRepository.save(MemberFixtures.FEMALE_30.get());
+
+            // when, then
+            assertThatThrownBy(() -> memberService.changeNickname(member, newNickname))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("닉네임의 길이가 올바르지 않습니다.");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"(((", "%%$%^^^", "12vvv^vvvd"})
+        @DisplayName("한글, 영어, 숫자 이외의 문자가 포함되어있다면 예외가 발생한다.")
+        void changeNicknameThrowsExceptionInvalid(String newNickname) {
+            // given
+            Member member = memberRepository.save(MemberFixtures.FEMALE_30.get());
+
+            // when, then
+            assertThatThrownBy(() -> memberService.changeNickname(member, newNickname))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("닉네임에 들어갈 수 없는 문자가 포함되어 있습니다.");
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 회원의 닉네임과 같다면 예외가 발생한다.")
+        void changeNicknameEqualToPrevious() {
+            // given
+            Member member1 = memberRepository.save(MemberFixtures.MALE_20.get());
+            Member member2 = memberRepository.save(MemberFixtures.MALE_30.get());
+
+            // when, then
+            assertThatThrownBy(() -> memberService.changeNickname(member1, member2.getNickname()))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("이미 중복된 닉네임이 존재합니다.");
+        }
+
     }
 
 }

--- a/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
@@ -52,7 +52,7 @@ class MemberServiceTest {
             memberService.changeNickname(member, newNickname);
 
             // then
-            assertThat(member.getNickname()).isEqualTo(newNickname);
+            assertThat(member.getNickname().getValue()).isEqualTo(newNickname);
         }
 
         @ParameterizedTest
@@ -89,7 +89,7 @@ class MemberServiceTest {
             Member member2 = memberRepository.save(MemberFixtures.MALE_30.get());
 
             // when, then
-            assertThatThrownBy(() -> memberService.changeNickname(member1, member2.getNickname()))
+            assertThatThrownBy(() -> memberService.changeNickname(member1, member2.getNickname().getValue()))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 중복된 닉네임이 존재합니다.");
         }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #139 

## 📝 작업 요약

닉네임 수정 기능 추가

## 🔎 작업 상세 설명

- 중복된 닉네임 불가
- 닉네임 길이 2~15자
- 한글, 영어, 숫자를 제외한 문자는 불가능하도록

## 🌟 논의 사항

없음.
