### PR TITLE
스토리북을 PR이 merge 될 때 배포되도록 설정

### DIFF
--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -3,8 +3,13 @@ name: Deploy
 on:
   push:
     branches: ['feat/#165']
+    paths:
+      - 'frontend/**'
+      - '.github/**'
 
-  workflow_dispatch:
+defaults:
+  run:
+    working-directory: frontend
 
 jobs:
   deploy:
@@ -42,14 +47,15 @@ jobs:
           PUBLIC_URL=$(echo $GITHUB_REPOSITORY | sed -r 's/^.+\/(.+)$/\/\1\//')
           echo PUBLIC_URL=$PUBLIC_URL > .env
 
-      - name: Build storybook
+      - name: build 빈 폴더를 만든다. 스토리북을 빌드하고 build 폴더로 옮긴다.
         run: |
           mkdir build
           npm run build-storybook
           mv ./storybook-static ./build
 
-      - name: Deploy to  storybook-deploy branch
+      - name: storybook-deploy 브런치에 배포할 파일을 업데이트 한다.
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: storybook-deploy
           publish_dir: ./build

--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -1,8 +1,9 @@
 name: Deploy
 
 on:
-  push:
-    branches: ['feat/#165']
+  pull_request:
+    branches: ['dev']
+    types: ['closed']
     paths:
       - 'frontend/**'
       - '.github/**'

--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -47,19 +47,13 @@ jobs:
           PUBLIC_URL=$(echo $GITHUB_REPOSITORY | sed -r 's/^.+\/(.+)$/\/\1\//')
           echo PUBLIC_URL=$PUBLIC_URL > .env
 
-      - name: Build app
-        run: |
-          npm run build
-          cp ./dist/index.html ./dist/404.html
-
-      - name: Build storybook
+      - name: 스토리북을 빌드한다.
         run: |
           npm run build-storybook
-          mv ./storybook-static ./dist/storybook
 
       - name: storybook-deploy 브런치에 배포할 파일을 업데이트 한다.
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: storybook-deploy
-          publish_dir: ./dist
+          publish_dir: ./frontend/storybook-static

--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['feat/#165']
+
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Use repository source
+        uses: actions/checkout@v3
+
+      - name: Use node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Cache node_modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+        if: steps.cache.outputs.cache-hit != 'true'
+
+      - name: Set PUBLIC_URL
+        run: |
+          PUBLIC_URL=$(echo $GITHUB_REPOSITORY | sed -r 's/^.+\/(.+)$/\/\1\//')
+          echo PUBLIC_URL=$PUBLIC_URL > .env
+
+      - name: Build storybook
+        run: |
+          mkdir build
+          npm run build-storybook
+          mv ./storybook-static ./build
+
+      - name: Deploy to  storybook-deploy branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -47,15 +47,13 @@ jobs:
           PUBLIC_URL=$(echo $GITHUB_REPOSITORY | sed -r 's/^.+\/(.+)$/\/\1\//')
           echo PUBLIC_URL=$PUBLIC_URL > .env
 
-      - name: build 빈 폴더를 만든다. 스토리북을 빌드하고 build 폴더로 옮긴다.
+      - name: 스토리북을 빌드한다.
         run: |
-          mkdir build
           npm run build-storybook
-          mv ./storybook-static ./build
 
       - name: storybook-deploy 브런치에 배포할 파일을 업데이트 한다.
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: storybook-deploy
-          publish_dir: ./build
+          publish_dir: ./storybook-static

--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -47,13 +47,19 @@ jobs:
           PUBLIC_URL=$(echo $GITHUB_REPOSITORY | sed -r 's/^.+\/(.+)$/\/\1\//')
           echo PUBLIC_URL=$PUBLIC_URL > .env
 
-      - name: 스토리북을 빌드한다.
+      - name: Build app
+        run: |
+          npm run build
+          cp ./build/index.html ./build/404.html
+
+      - name: Build storybook
         run: |
           npm run build-storybook
+          mv ./storybook-static ./build/storybook
 
       - name: storybook-deploy 브런치에 배포할 파일을 업데이트 한다.
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: storybook-deploy
-          publish_dir: ./storybook-static
+          publish_dir: ./build

--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -50,16 +50,16 @@ jobs:
       - name: Build app
         run: |
           npm run build
-          cp ./build/index.html ./build/404.html
+          cp ./dist/index.html ./dist/404.html
 
       - name: Build storybook
         run: |
           npm run build-storybook
-          mv ./storybook-static ./build/storybook
+          mv ./storybook-static ./dist/storybook
 
       - name: storybook-deploy 브런치에 배포할 파일을 업데이트 한다.
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: storybook-deploy
-          publish_dir: ./build
+          publish_dir: ./dist


### PR DESCRIPTION
## 🔥 연관 이슈

close: #165 

## 작업 소요 시간

약 1시간

## 📝 작업 요약

- dev로 보낸 PR이 머지될 때 스토리북이 배포되도록 함
- storybook-deploy 브런치에 스토리북 빌드된 파일을 올려서 깃허브 페이지로 배포되도록 함

## 🔎 작업 상세 설명

배포된 사이트

https://woowacourse-teams.github.io/2023-votogether/

## 🌟 논의 사항

저희가 frontend, backend로 폴더가 나뉘어 있어서 이 부분 설정하는 것이 처음이라 까다로웠어요 !
