### PR TITLE
댓글 수정 기능 구현

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/controller/PostCommentController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostCommentController.java
@@ -2,6 +2,7 @@ package com.votogether.domain.post.controller;
 
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.post.dto.request.CommentRegisterRequest;
+import com.votogether.domain.post.dto.request.CommentUpdateRequest;
 import com.votogether.domain.post.service.PostCommentService;
 import com.votogether.exception.ExceptionResponse;
 import com.votogether.global.jwt.Auth;
@@ -19,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,9 +52,39 @@ public class PostCommentController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Operation(summary = "게시글 댓글 수정", description = "게시글 댓글을 수정한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 댓글 수정 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "게시글에 속하지 않은 댓글, 올바르지 않은 댓글 작성자",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글, 존재하지 않는 댓글",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    @PutMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<Void> updateComment(
+            @PathVariable @Parameter(description = "게시글 ID") final Long postId,
+            @PathVariable @Parameter(description = "댓글 ID") final Long commentId,
+            @RequestBody @Valid final CommentUpdateRequest commentUpdateRequest,
+            @Auth final Member member
+    ) {
+        postCommentService.updateComment(postId, commentId, commentUpdateRequest, member);
+        return ResponseEntity.ok().build();
+    }
+
     @Operation(summary = "게시글 댓글 삭제", description = "게시글 댓글을 삭제한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "게시글 댓글 삭제 성공"),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "게시글에 속하지 않은 댓글, 올바르지 않은 댓글 작성자",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            ),
             @ApiResponse(
                     responseCode = "404",
                     description = "존재하지 않는 게시글, 존재하지 않는 댓글",

--- a/backend/src/main/java/com/votogether/domain/post/dto/request/CommentUpdateRequest.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.votogether.domain.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "게시글 수정 요청")
+public record CommentUpdateRequest(
+        @Schema(description = "댓글 수정 내용", example = "content")
+        @NotBlank(message = "댓글 내용은 존재해야 합니다.")
+        String content
+) {
+}

--- a/backend/src/main/java/com/votogether/domain/post/entity/comment/Comment.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/comment/Comment.java
@@ -63,5 +63,9 @@ public class Comment extends BaseEntity {
     public void updateContent(final String content) {
         this.content = new Content(content);
     }
+    
+    public String getContent() {
+        return content.getValue();
+    }
 
 }

--- a/backend/src/main/java/com/votogether/domain/post/entity/comment/Comment.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/comment/Comment.java
@@ -60,4 +60,8 @@ public class Comment extends BaseEntity {
         }
     }
 
+    public void updateContent(final String content) {
+        this.content = new Content(content);
+    }
+
 }

--- a/backend/src/main/java/com/votogether/domain/post/entity/comment/Comment.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/comment/Comment.java
@@ -63,7 +63,7 @@ public class Comment extends BaseEntity {
     public void updateContent(final String content) {
         this.content = new Content(content);
     }
-    
+
     public String getContent() {
         return content.getValue();
     }

--- a/backend/src/main/java/com/votogether/domain/post/service/PostCommentService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostCommentService.java
@@ -2,6 +2,7 @@ package com.votogether.domain.post.service;
 
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.post.dto.request.CommentRegisterRequest;
+import com.votogether.domain.post.dto.request.CommentUpdateRequest;
 import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.comment.Comment;
 import com.votogether.domain.post.exception.CommentExceptionType;
@@ -38,6 +39,24 @@ public class PostCommentService {
     }
 
     @Transactional
+    public void updateComment(
+            final Long postId,
+            final Long commentId,
+            final CommentUpdateRequest commentUpdateRequest,
+            final Member member
+    ) {
+        final Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException(PostExceptionType.POST_NOT_FOUND));
+        final Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException(CommentExceptionType.COMMENT_NOT_FOUND));
+
+        comment.validateBelong(post);
+        comment.validateWriter(member);
+
+        comment.updateContent(commentUpdateRequest.content());
+    }
+
+    @Transactional
     public void deleteComment(final Long postId, final Long commentId, final Member member) {
         final Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException(PostExceptionType.POST_NOT_FOUND));
@@ -49,5 +68,4 @@ public class PostCommentService {
 
         commentRepository.delete(comment);
     }
-
 }

--- a/backend/src/test/java/com/votogether/domain/post/entity/comment/CommentTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/entity/comment/CommentTest.java
@@ -106,4 +106,29 @@ class CommentTest {
                 .hasMessage("댓글의 게시글 정보와 일치하지 않습니다.");
     }
 
+    @Test
+    @DisplayName("댓글 수정 시 최대 글자를 초과하면 예외를 던진다.")
+    void updateContentWithInvalidContentLength() {
+        // given
+        PostBody body = PostBody.builder()
+                .title("title")
+                .content("content")
+                .build();
+        Post post = Post.builder()
+                .writer(MemberFixtures.FEMALE_20.get())
+                .postBody(body)
+                .deadline(LocalDateTime.now())
+                .build();
+        Comment comment = Comment.builder()
+                .member(MemberFixtures.MALE_20.get())
+                .post(post)
+                .content("hello")
+                .build();
+
+        // when, then
+        assertThatThrownBy(() -> comment.updateContent("a".repeat(501)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("유효하지 않은 댓글 길이입니다.");
+    }
+
 }

--- a/backend/src/test/java/com/votogether/domain/post/service/PostCommentServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/service/PostCommentServiceTest.java
@@ -7,6 +7,7 @@ import com.votogether.ServiceTest;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.member.repository.MemberRepository;
 import com.votogether.domain.post.dto.request.CommentRegisterRequest;
+import com.votogether.domain.post.dto.request.CommentUpdateRequest;
 import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.PostBody;
 import com.votogether.domain.post.entity.comment.Comment;
@@ -72,6 +73,135 @@ class PostCommentServiceTest {
 
             // then
             assertThat(commentRepository.findAll()).hasSize(1);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("게시글 댓글 수정")
+    class UpdateComment {
+
+        @Test
+        @DisplayName("존재하지 않는 게시글이라면 예외를 던진다.")
+        void emptyPost() {
+            // given
+            Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+            CommentUpdateRequest request = new CommentUpdateRequest("hello");
+
+            // when, then
+            assertThatThrownBy(() -> postCommentService.updateComment(-1L, 1L, request, member))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("해당 게시글이 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 댓글이라면 예외를 던진다.")
+        void emptyComment() {
+            // given
+            Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+            Post post = postRepository.save(
+                    Post.builder()
+                            .writer(member)
+                            .postBody(PostBody.builder().title("title").content("content").build())
+                            .deadline(LocalDateTime.of(2100, 7, 12, 0, 0))
+                            .build()
+            );
+            CommentUpdateRequest request = new CommentUpdateRequest("hello");
+
+            // when, then
+            assertThatThrownBy(() -> postCommentService.updateComment(post.getId(), -1L, request, member))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("해당 댓글이 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("댓글의 게시글과 일치하지 않으면 예외를 던진다.")
+        void invalidBelongPost() {
+            // given
+            Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+            Post postA = postRepository.save(
+                    Post.builder()
+                            .writer(member)
+                            .postBody(PostBody.builder().title("titleA").content("contentA").build())
+                            .deadline(LocalDateTime.of(2100, 7, 12, 0, 0))
+                            .build()
+            );
+            Post postB = postRepository.save(
+                    Post.builder()
+                            .writer(member)
+                            .postBody(PostBody.builder().title("titleB").content("contentB").build())
+                            .deadline(LocalDateTime.of(2100, 7, 12, 0, 0))
+                            .build()
+            );
+            Comment comment = commentRepository.save(
+                    Comment.builder()
+                            .member(member)
+                            .post(postA)
+                            .content("comment")
+                            .build()
+            );
+            CommentUpdateRequest request = new CommentUpdateRequest("hello");
+
+            // when, then
+            assertThatThrownBy(() -> postCommentService.updateComment(postB.getId(), comment.getId(), request, member))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("댓글의 게시글 정보와 일치하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("댓글의 작성자가 아니라면 예외르 던진다.")
+        void invalidWriter() {
+            // given
+            Member memberA = memberRepository.save(MemberFixtures.MALE_20.get());
+            Member memberB = memberRepository.save(MemberFixtures.FEMALE_20.get());
+            Post post = postRepository.save(
+                    Post.builder()
+                            .writer(memberA)
+                            .postBody(PostBody.builder().title("titleA").content("contentA").build())
+                            .deadline(LocalDateTime.of(2100, 7, 12, 0, 0))
+                            .build()
+            );
+            Comment comment = commentRepository.save(
+                    Comment.builder()
+                            .member(memberB)
+                            .post(post)
+                            .content("comment")
+                            .build()
+            );
+            CommentUpdateRequest request = new CommentUpdateRequest("hello");
+
+            // when, then
+            assertThatThrownBy(() -> postCommentService.updateComment(post.getId(), comment.getId(), request, memberA))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("댓글 작성자가 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("게시글의 댓글을 수정한다.")
+        void deleteComment() {
+            // given
+            Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+            Post post = postRepository.save(
+                    Post.builder()
+                            .writer(member)
+                            .postBody(PostBody.builder().title("titleA").content("contentA").build())
+                            .deadline(LocalDateTime.of(2100, 7, 12, 0, 0))
+                            .build()
+            );
+            Comment comment = commentRepository.save(
+                    Comment.builder()
+                            .member(member)
+                            .post(post)
+                            .content("comment")
+                            .build()
+            );
+            CommentUpdateRequest request = new CommentUpdateRequest("hello");
+
+            // when
+            postCommentService.updateComment(post.getId(), comment.getId(), request, member);
+
+            // then
+            assertThat(comment.getContent()).isEqualTo("hello");
         }
 
     }

--- a/backend/src/test/java/com/votogether/domain/post/service/PostCommentServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/service/PostCommentServiceTest.java
@@ -149,7 +149,7 @@ class PostCommentServiceTest {
         }
 
         @Test
-        @DisplayName("댓글의 작성자가 아니라면 예외르 던진다.")
+        @DisplayName("댓글의 작성자가 아니라면 예외를 던진다.")
         void invalidWriter() {
             // given
             Member memberA = memberRepository.save(MemberFixtures.MALE_20.get());
@@ -275,7 +275,7 @@ class PostCommentServiceTest {
         }
 
         @Test
-        @DisplayName("댓글의 작성자가 아니라면 예외르 던진다.")
+        @DisplayName("댓글의 작성자가 아니라면 예외를 던진다.")
         void invalidWriter() {
             // given
             Member memberA = memberRepository.save(MemberFixtures.MALE_20.get());


### PR DESCRIPTION
## 🔥 연관 이슈

close: #130

## 📝 작업 요약

댓글 수정 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 게시글, 댓글이 유효한지 검증합니다.
- 해당 게시글의 댓글인지, 댓글 작성자가 맞는지 검증합니다.
- 수정하고자 하는 내용이 올바른지 검증합니다.
- 댓글을 수정합니다.

## 🌟 논의 사항

- 추후 리팩토링 시 Swagger 어노테이션을 따로 빼도록 해야할 것 같아요!
- 매개변수 순서도 코드 컨벤션으로 정하면 좋을 것 같아요 :)