### PR TITLE
전체 게시글 목록 기능에 검색한 게시글 목록 기능 추가 구현 + 검색 기능 구현 + 스토리북 .env 설정

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -34,5 +34,10 @@ const config: StorybookConfig = {
     return config;
   },
   staticDirs: ['./public'],
+  env: config => ({
+    ...config,
+    VOTOGETHER_BASE_URL: '',
+    VOTOGETHER_MOCKING_URL: '',
+  }),
 };
 export default config;

--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -1,6 +1,6 @@
 import { getPostList } from '@api/postList';
 
-import { POST_CONTENT, SORTING, STATUS } from '@constants/post';
+import { POST_TYPE, SORTING, STATUS } from '@constants/post';
 
 import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
@@ -10,7 +10,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postStatus: STATUS.ALL,
       postSorting: SORTING.POPULAR,
       pageNumber: 0,
-      content: POST_CONTENT.ALL,
+      postType: POST_TYPE.ALL,
     });
 
     expect(data.postList.length).toBe(10);
@@ -21,7 +21,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postStatus: STATUS.CLOSED,
       postSorting: SORTING.POPULAR,
       pageNumber: 0,
-      content: POST_CONTENT.ALL,
+      postType: POST_TYPE.ALL,
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -32,7 +32,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postStatus: STATUS.CLOSED,
       postSorting: SORTING.POPULAR,
       pageNumber: 3,
-      content: POST_CONTENT.ALL,
+      postType: POST_TYPE.ALL,
     });
 
     expect(data.pageNumber).toEqual(3);
@@ -44,7 +44,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: SORTING.POPULAR,
       pageNumber: 0,
       categoryId: 1,
-      content: POST_CONTENT.CATEGORY,
+      postType: POST_TYPE.CATEGORY,
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -56,7 +56,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: SORTING.POPULAR,
       pageNumber: 0,
       categoryId: 1,
-      content: POST_CONTENT.MY_POST,
+      postType: POST_TYPE.MY_POST,
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -68,7 +68,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: SORTING.POPULAR,
       pageNumber: 0,
       categoryId: 1,
-      content: POST_CONTENT.MY_VOTE,
+      postType: POST_TYPE.MY_VOTE,
     });
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
@@ -80,7 +80,7 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
       postSorting: SORTING.POPULAR,
       pageNumber: 0,
       categoryId: 1,
-      content: POST_CONTENT.SEARCH,
+      postType: POST_TYPE.SEARCH,
       keyword: '갤럭시',
     });
 

--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -6,83 +6,120 @@ import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
 describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확인한다.', () => {
   test('게시글 목록의 개수는 10개씩 불러온다.', async () => {
-    const data = await getPostList({
-      postStatus: STATUS.ALL,
-      postSorting: SORTING.POPULAR,
-      pageNumber: 0,
-      postType: POST_TYPE.ALL,
-    });
+    const data = await getPostList(
+      {
+        postStatus: STATUS.ALL,
+        postSorting: SORTING.POPULAR,
+        pageNumber: 0,
+        postType: POST_TYPE.ALL,
+      },
+      {
+        categoryId: 0,
+        keyword: '',
+      }
+    );
 
     expect(data.postList.length).toBe(10);
   });
 
   test('게시글 목록을 불러온다.', async () => {
-    const data = await getPostList({
-      postStatus: STATUS.CLOSED,
-      postSorting: SORTING.POPULAR,
-      pageNumber: 0,
-      postType: POST_TYPE.ALL,
-    });
+    const data = await getPostList(
+      {
+        postStatus: STATUS.CLOSED,
+        postSorting: SORTING.POPULAR,
+        pageNumber: 0,
+        postType: POST_TYPE.ALL,
+      },
+      {
+        categoryId: 0,
+        keyword: '',
+      }
+    );
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
   });
 
   test('게시글 페이지의 정보를 불러온다.', async () => {
-    const data = await getPostList({
-      postStatus: STATUS.CLOSED,
-      postSorting: SORTING.POPULAR,
-      pageNumber: 3,
-      postType: POST_TYPE.ALL,
-    });
+    const data = await getPostList(
+      {
+        postStatus: STATUS.CLOSED,
+        postSorting: SORTING.POPULAR,
+        pageNumber: 3,
+        postType: POST_TYPE.ALL,
+      },
+      {
+        categoryId: 0,
+        keyword: '',
+      }
+    );
 
     expect(data.pageNumber).toEqual(3);
   });
 
   test('카테고리별 게시글 페이지의 정보를 불러온다.', async () => {
-    const data = await getPostList({
-      postStatus: STATUS.CLOSED,
-      postSorting: SORTING.POPULAR,
-      pageNumber: 0,
-      categoryId: 1,
-      postType: POST_TYPE.CATEGORY,
-    });
+    const data = await getPostList(
+      {
+        postStatus: STATUS.CLOSED,
+        postSorting: SORTING.POPULAR,
+        pageNumber: 0,
+        postType: POST_TYPE.CATEGORY,
+      },
+      {
+        categoryId: 1,
+        keyword: '',
+      }
+    );
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
   });
 
   test('내가 작성한 게시글 페이지의 정보를 불러온다.', async () => {
-    const data = await getPostList({
-      postStatus: STATUS.CLOSED,
-      postSorting: SORTING.POPULAR,
-      pageNumber: 0,
-      categoryId: 1,
-      postType: POST_TYPE.MY_POST,
-    });
+    const data = await getPostList(
+      {
+        postStatus: STATUS.CLOSED,
+        postSorting: SORTING.POPULAR,
+        pageNumber: 0,
+        postType: POST_TYPE.MY_POST,
+      },
+      {
+        categoryId: 0,
+        keyword: '',
+      }
+    );
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
   });
 
   test('내가 투표한 게시글 페이지의 정보를 불러온다.', async () => {
-    const data = await getPostList({
-      postStatus: STATUS.CLOSED,
-      postSorting: SORTING.POPULAR,
-      pageNumber: 0,
-      categoryId: 1,
-      postType: POST_TYPE.MY_VOTE,
-    });
+    const data = await getPostList(
+      {
+        postStatus: STATUS.CLOSED,
+        postSorting: SORTING.POPULAR,
+        pageNumber: 0,
+        postType: POST_TYPE.MY_VOTE,
+      },
+      {
+        categoryId: 0,
+        keyword: '',
+      }
+    );
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
   });
 
   test('내가 검색한 게시글 페이지의 정보를 불러온다.', async () => {
-    const data = await getPostList({
-      postStatus: STATUS.CLOSED,
-      postSorting: SORTING.POPULAR,
-      pageNumber: 0,
-      categoryId: 1,
-      postType: POST_TYPE.SEARCH,
-      keyword: '갤럭시',
-    });
+    const data = await getPostList(
+      {
+        postStatus: STATUS.CLOSED,
+        postSorting: SORTING.POPULAR,
+        pageNumber: 0,
+        postType: POST_TYPE.SEARCH,
+      },
+      {
+        categoryId: 0,
+        keyword: '갤럭시',
+      }
+    );
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
   });

--- a/frontend/__test__/api/postList.test.ts
+++ b/frontend/__test__/api/postList.test.ts
@@ -73,4 +73,17 @@ describe('서버와 통신하여 전체 게시글 목록을 불러오는지 확�
 
     expect(data.postList).toEqual(MOCK_POST_LIST);
   });
+
+  test('내가 검색한 게시글 페이지의 정보를 불러온다.', async () => {
+    const data = await getPostList({
+      postStatus: STATUS.CLOSED,
+      postSorting: SORTING.POPULAR,
+      pageNumber: 0,
+      categoryId: 1,
+      content: POST_CONTENT.SEARCH,
+      keyword: '갤럭시',
+    });
+
+    expect(data.postList).toEqual(MOCK_POST_LIST);
+  });
 });

--- a/frontend/__test__/hooks/query/usePostList.test.tsx
+++ b/frontend/__test__/hooks/query/usePostList.test.tsx
@@ -19,11 +19,17 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
   test('전체 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
       () =>
-        usePostList({
-          postSorting: SORTING.POPULAR,
-          postStatus: STATUS.ALL,
-          postType: POST_TYPE.ALL,
-        }),
+        usePostList(
+          {
+            postSorting: SORTING.POPULAR,
+            postStatus: STATUS.ALL,
+            postType: POST_TYPE.ALL,
+          },
+          {
+            categoryId: 0,
+            keyword: '',
+          }
+        ),
       {
         wrapper,
       }
@@ -35,12 +41,17 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
   test('카테고리별 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
       () =>
-        usePostList({
-          postSorting: SORTING.POPULAR,
-          postStatus: STATUS.ALL,
-          categoryId: 1,
-          postType: POST_TYPE.CATEGORY,
-        }),
+        usePostList(
+          {
+            postSorting: SORTING.POPULAR,
+            postStatus: STATUS.ALL,
+            postType: POST_TYPE.CATEGORY,
+          },
+          {
+            categoryId: 1,
+            keyword: '',
+          }
+        ),
       {
         wrapper,
       }
@@ -52,11 +63,17 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
   test('내가 작성한 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
       () =>
-        usePostList({
-          postSorting: SORTING.POPULAR,
-          postStatus: STATUS.ALL,
-          postType: POST_TYPE.MY_POST,
-        }),
+        usePostList(
+          {
+            postSorting: SORTING.POPULAR,
+            postStatus: STATUS.ALL,
+            postType: POST_TYPE.MY_POST,
+          },
+          {
+            categoryId: 0,
+            keyword: '',
+          }
+        ),
       {
         wrapper,
       }
@@ -68,11 +85,17 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
   test('내가 투표한 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
       () =>
-        usePostList({
-          postSorting: SORTING.POPULAR,
-          postStatus: STATUS.ALL,
-          postType: POST_TYPE.MY_VOTE,
-        }),
+        usePostList(
+          {
+            postSorting: SORTING.POPULAR,
+            postStatus: STATUS.ALL,
+            postType: POST_TYPE.MY_VOTE,
+          },
+          {
+            categoryId: 0,
+            keyword: '',
+          }
+        ),
       {
         wrapper,
       }
@@ -84,12 +107,17 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
   test('내가 검색한 게시글 목록을 불러온다.', async () => {
     const { result } = renderHook(
       () =>
-        usePostList({
-          postSorting: SORTING.POPULAR,
-          postStatus: STATUS.ALL,
-          postType: POST_TYPE.SEARCH,
-          keyword: '갤럭시',
-        }),
+        usePostList(
+          {
+            postSorting: SORTING.POPULAR,
+            postStatus: STATUS.ALL,
+            postType: POST_TYPE.SEARCH,
+          },
+          {
+            categoryId: 0,
+            keyword: '갤럭시',
+          }
+        ),
       {
         wrapper,
       }

--- a/frontend/__test__/hooks/query/usePostList.test.tsx
+++ b/frontend/__test__/hooks/query/usePostList.test.tsx
@@ -5,7 +5,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 
 import { usePostList } from '@hooks/query/usePostList';
 
-import { POST_CONTENT, SORTING, STATUS } from '@constants/post';
+import { POST_TYPE, SORTING, STATUS } from '@constants/post';
 
 import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
@@ -22,7 +22,7 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
         usePostList({
           postSorting: SORTING.POPULAR,
           postStatus: STATUS.ALL,
-          content: POST_CONTENT.ALL,
+          postType: POST_TYPE.ALL,
         }),
       {
         wrapper,
@@ -39,7 +39,7 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
           postSorting: SORTING.POPULAR,
           postStatus: STATUS.ALL,
           categoryId: 1,
-          content: POST_CONTENT.CATEGORY,
+          postType: POST_TYPE.CATEGORY,
         }),
       {
         wrapper,
@@ -55,7 +55,7 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
         usePostList({
           postSorting: SORTING.POPULAR,
           postStatus: STATUS.ALL,
-          content: POST_CONTENT.MY_POST,
+          postType: POST_TYPE.MY_POST,
         }),
       {
         wrapper,
@@ -71,7 +71,7 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
         usePostList({
           postSorting: SORTING.POPULAR,
           postStatus: STATUS.ALL,
-          content: POST_CONTENT.MY_VOTE,
+          postType: POST_TYPE.MY_VOTE,
         }),
       {
         wrapper,
@@ -87,7 +87,7 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
         usePostList({
           postSorting: SORTING.POPULAR,
           postStatus: STATUS.ALL,
-          content: POST_CONTENT.SEARCH,
+          postType: POST_TYPE.SEARCH,
           keyword: '갤럭시',
         }),
       {

--- a/frontend/__test__/hooks/query/usePostList.test.tsx
+++ b/frontend/__test__/hooks/query/usePostList.test.tsx
@@ -55,7 +55,6 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
         usePostList({
           postSorting: SORTING.POPULAR,
           postStatus: STATUS.ALL,
-          categoryId: 1,
           content: POST_CONTENT.MY_POST,
         }),
       {
@@ -72,8 +71,24 @@ describe('usePostList 훅이 게시글 목록을 불러오는지 확인한다.',
         usePostList({
           postSorting: SORTING.POPULAR,
           postStatus: STATUS.ALL,
-          categoryId: 1,
           content: POST_CONTENT.MY_VOTE,
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.data?.pages[0].postList).toEqual(MOCK_POST_LIST));
+  });
+
+  test('내가 검색한 게시글 목록을 불러온다.', async () => {
+    const { result } = renderHook(
+      () =>
+        usePostList({
+          postSorting: SORTING.POPULAR,
+          postStatus: STATUS.ALL,
+          content: POST_CONTENT.SEARCH,
+          keyword: '갤럭시',
         }),
       {
         wrapper,

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -4,7 +4,7 @@ import {
   REQUEST_STATUS_OPTION,
   REQUEST_SORTING_OPTION,
   REQUEST_POST_KIND_URL,
-  POST_CONTENT,
+  POST_TYPE,
   SEARCH_KEYWORD,
 } from '@constants/post';
 
@@ -13,7 +13,7 @@ import { getFetch } from '@utils/fetch';
 const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
 
 export const makePostListUrl = ({
-  content,
+  postType,
   categoryId,
   postStatus,
   postSorting,
@@ -23,14 +23,14 @@ export const makePostListUrl = ({
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
-  const POST_BASE_URL = `${BASE_URL}/${REQUEST_POST_KIND_URL[content]}`;
+  const POST_BASE_URL = `${BASE_URL}/${REQUEST_POST_KIND_URL[postType]}`;
   const OPTION_URL = `postClosingType=${requestedStatus}&postSortType=${requestedSorting}&page=${pageNumber}`;
 
-  if (categoryId && content === POST_CONTENT.CATEGORY) {
+  if (categoryId && postType === POST_TYPE.CATEGORY) {
     return `${POST_BASE_URL}/${categoryId}?${OPTION_URL}`;
   }
 
-  if (content === POST_CONTENT.SEARCH) {
+  if (postType === POST_TYPE.SEARCH) {
     return `${POST_BASE_URL}?${SEARCH_KEYWORD}=${keyword}&${OPTION_URL}`;
   }
 
@@ -38,7 +38,7 @@ export const makePostListUrl = ({
 };
 
 export const getPostList = async ({
-  content,
+  postType,
   postStatus,
   postSorting,
   pageNumber,
@@ -46,7 +46,7 @@ export const getPostList = async ({
   keyword,
 }: PostListByOption) => {
   const postListUrl = makePostListUrl({
-    content,
+    postType,
     pageNumber,
     postSorting,
     postStatus,

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -4,6 +4,7 @@ import {
   REQUEST_STATUS_OPTION,
   REQUEST_SORTING_OPTION,
   REQUEST_POST_KIND_URL,
+  POST_CONTENT,
 } from '@constants/post';
 
 import { getFetch } from '@utils/fetch';
@@ -16,6 +17,7 @@ export const makePostListUrl = ({
   postStatus,
   postSorting,
   pageNumber,
+  keyword,
 }: PostListByOption) => {
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
@@ -23,8 +25,12 @@ export const makePostListUrl = ({
   const POST_BASE_URL = `${BASE_URL}/${REQUEST_POST_KIND_URL[content]}`;
   const OPTION_URL = `postClosingType=${requestedStatus}&postSortType=${requestedSorting}&page=${pageNumber}`;
 
-  if (categoryId && content === 'category') {
+  if (categoryId && content === POST_CONTENT.CATEGORY) {
     return `${POST_BASE_URL}/${categoryId}?${OPTION_URL}`;
+  }
+
+  if (content === POST_CONTENT.SEARCH) {
+    return `${POST_BASE_URL}?keyword=${keyword}&${OPTION_URL}`;
   }
 
   return `${POST_BASE_URL}?${OPTION_URL}`;
@@ -36,6 +42,7 @@ export const getPostList = async ({
   postSorting,
   pageNumber,
   categoryId,
+  keyword,
 }: PostListByOption) => {
   const postListUrl = makePostListUrl({
     content,
@@ -43,6 +50,7 @@ export const getPostList = async ({
     postSorting,
     postStatus,
     categoryId,
+    keyword,
   });
 
   const postList = await getFetch<PostInfo[]>(postListUrl);

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -5,6 +5,7 @@ import {
   REQUEST_SORTING_OPTION,
   REQUEST_POST_KIND_URL,
   POST_CONTENT,
+  SEARCH_KEYWORD,
 } from '@constants/post';
 
 import { getFetch } from '@utils/fetch';
@@ -30,7 +31,7 @@ export const makePostListUrl = ({
   }
 
   if (content === POST_CONTENT.SEARCH) {
-    return `${POST_BASE_URL}?keyword=${keyword}&${OPTION_URL}`;
+    return `${POST_BASE_URL}?${SEARCH_KEYWORD}=${keyword}&${OPTION_URL}`;
   }
 
   return `${POST_BASE_URL}?${OPTION_URL}`;

--- a/frontend/src/api/postList.ts
+++ b/frontend/src/api/postList.ts
@@ -1,4 +1,4 @@
-import { PostInfo, PostListByOption } from '@type/post';
+import { PostInfo, PostListByOptionalOption, PostListByRequiredOption } from '@type/post';
 
 import {
   REQUEST_STATUS_OPTION,
@@ -12,21 +12,20 @@ import { getFetch } from '@utils/fetch';
 
 const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
 
-export const makePostListUrl = ({
-  postType,
-  categoryId,
-  postStatus,
-  postSorting,
-  pageNumber,
-  keyword,
-}: PostListByOption) => {
+export const makePostListUrl = (
+  requiredOption: PostListByRequiredOption,
+  optionalOption: PostListByOptionalOption
+) => {
+  const { pageNumber, postSorting, postStatus, postType } = requiredOption;
+  const { categoryId, keyword } = optionalOption;
+
   const requestedStatus = REQUEST_STATUS_OPTION[postStatus];
   const requestedSorting = REQUEST_SORTING_OPTION[postSorting];
 
   const POST_BASE_URL = `${BASE_URL}/${REQUEST_POST_KIND_URL[postType]}`;
   const OPTION_URL = `postClosingType=${requestedStatus}&postSortType=${requestedSorting}&page=${pageNumber}`;
 
-  if (categoryId && postType === POST_TYPE.CATEGORY) {
+  if (categoryId > 0 && postType === POST_TYPE.CATEGORY) {
     return `${POST_BASE_URL}/${categoryId}?${OPTION_URL}`;
   }
 
@@ -37,22 +36,13 @@ export const makePostListUrl = ({
   return `${POST_BASE_URL}?${OPTION_URL}`;
 };
 
-export const getPostList = async ({
-  postType,
-  postStatus,
-  postSorting,
-  pageNumber,
-  categoryId,
-  keyword,
-}: PostListByOption) => {
-  const postListUrl = makePostListUrl({
-    postType,
-    pageNumber,
-    postSorting,
-    postStatus,
-    categoryId,
-    keyword,
-  });
+export const getPostList = async (
+  requiredOption: PostListByRequiredOption,
+  optionalOption: PostListByOptionalOption
+) => {
+  const { pageNumber } = requiredOption;
+
+  const postListUrl = makePostListUrl(requiredOption, optionalOption);
 
   const postList = await getFetch<PostInfo[]>(postListUrl);
 

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -16,6 +16,8 @@ import SquareButton from '@components/common/SquareButton';
 import TimePickerOptionList from '@components/common/TimePickerOptionList';
 import WritingVoteOptionList from '@components/optionList/WritingVoteOptionList';
 
+import { POST_DESCRIPTION_MAX_LENGTH, POST_TITLE_MAX_LENGTH } from '@constants/post';
+
 import { addTimeToDate, formatTimeWithOption } from '@utils/post/formatTime';
 
 import { DEADLINE_OPTION } from './constants';
@@ -177,14 +179,18 @@ export default function PostForm({ data, mutate, isError, error }: PostFormProps
             </select>
             <S.Title
               value={writingTitle}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleTitleChange(e, 100)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                handleTitleChange(e, POST_TITLE_MAX_LENGTH)
+              }
               placeholder="제목을 입력해주세요"
               maxLength={MAX_TITLE_LENGTH}
               required
             />
             <S.Content
               value={writingContent}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleContentChange(e, 1000)}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                handleContentChange(e, POST_DESCRIPTION_MAX_LENGTH)
+              }
               placeholder="내용을 입력해주세요"
               maxLength={MAX_CONTENT_LENGTH}
               required

--- a/frontend/src/components/common/SearchBar/index.tsx
+++ b/frontend/src/components/common/SearchBar/index.tsx
@@ -3,6 +3,7 @@ import { FormHTMLAttributes } from 'react';
 import { Size } from '@type/style';
 
 import { PATH } from '@constants/path';
+import { SEARCH_KEYWORD } from '@constants/post';
 
 import searchIcon from '@assets/search_black.svg';
 
@@ -15,7 +16,7 @@ interface SearchBarProps extends FormHTMLAttributes<HTMLFormElement> {
 export default function SearchBar({ size, ...rest }: SearchBarProps) {
   return (
     <S.Form size={size} {...rest} action={PATH.SEARCH}>
-      <S.Input type="search" name="keyword" />
+      <S.Input type="search" name={SEARCH_KEYWORD} />
       <S.Button type="submit">
         <img src={searchIcon} alt="검색버튼" />
       </S.Button>

--- a/frontend/src/components/common/SearchBar/index.tsx
+++ b/frontend/src/components/common/SearchBar/index.tsx
@@ -2,6 +2,8 @@ import { FormHTMLAttributes } from 'react';
 
 import { Size } from '@type/style';
 
+import { PATH } from '@constants/path';
+
 import searchIcon from '@assets/search_black.svg';
 
 import * as S from './style';
@@ -12,8 +14,8 @@ interface SearchBarProps extends FormHTMLAttributes<HTMLFormElement> {
 
 export default function SearchBar({ size, ...rest }: SearchBarProps) {
   return (
-    <S.Form size={size} {...rest}>
-      <S.Input type="text" />
+    <S.Form size={size} {...rest} action={PATH.SEARCH}>
+      <S.Input type="search" name="keyword" />
       <S.Button type="submit">
         <img src={searchIcon} alt="검색버튼" />
       </S.Button>

--- a/frontend/src/components/post/PostList/constants.ts
+++ b/frontend/src/components/post/PostList/constants.ts
@@ -1,1 +1,0 @@
-export const CATEGORY_ID = 'categoryId';

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -16,7 +16,7 @@ import { SORTING, STATUS } from '@constants/post';
 import * as S from './style';
 
 export default function PostList() {
-  const { categoryId, postType, keyword } = usePostRequestInfo();
+  const { postType, postOptionalOption } = usePostRequestInfo();
   const { targetRef, isIntersecting } = useIntersectionObserver({
     root: null,
     rootMargin: '',
@@ -27,13 +27,14 @@ export default function PostList() {
   const { selectedOption: selectedSortingOption, handleOptionChange: handleSortingOptionChange } =
     useSelect<PostSorting>(SORTING.LATEST);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList({
-    postType,
-    categoryId,
-    postSorting: selectedSortingOption,
-    postStatus: selectedStatusOption,
-    keyword,
-  });
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList(
+    {
+      postType,
+      postSorting: selectedSortingOption,
+      postStatus: selectedStatusOption,
+    },
+    postOptionalOption
+  );
 
   useEffect(() => {
     if (isIntersecting && hasNextPage) {

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -16,7 +16,7 @@ import { SORTING, STATUS } from '@constants/post';
 import * as S from './style';
 
 export default function PostList() {
-  const { categoryId, content } = usePostRequestInfo();
+  const { categoryId, content, keyword } = usePostRequestInfo();
   const { targetRef, isIntersecting } = useIntersectionObserver({
     root: null,
     rootMargin: '',
@@ -32,6 +32,7 @@ export default function PostList() {
     categoryId,
     postSorting: selectedSortingOption,
     postStatus: selectedStatusOption,
+    keyword,
   });
 
   useEffect(() => {

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -16,7 +16,7 @@ import { SORTING, STATUS } from '@constants/post';
 import * as S from './style';
 
 export default function PostList() {
-  const { categoryId, content, keyword } = usePostRequestInfo();
+  const { categoryId, postType, keyword } = usePostRequestInfo();
   const { targetRef, isIntersecting } = useIntersectionObserver({
     root: null,
     rootMargin: '',
@@ -28,7 +28,7 @@ export default function PostList() {
     useSelect<PostSorting>(SORTING.LATEST);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = usePostList({
-    content,
+    postType,
     categoryId,
     postSorting: selectedSortingOption,
     postStatus: selectedStatusOption,

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -39,3 +39,5 @@ export const REQUEST_POST_KIND_URL = {
   [POST_CONTENT.CATEGORY]: 'posts/categories',
   [POST_CONTENT.SEARCH]: 'posts/search',
 } as const;
+
+export const SEARCH_KEYWORD = 'keyword';

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -13,7 +13,7 @@ export const SORTING = {
   POPULAR: 'popular',
 } as const;
 
-export const POST_CONTENT = {
+export const POST_TYPE = {
   ALL: 'posts',
   MY_POST: 'myPost',
   MY_VOTE: 'myVote',
@@ -33,11 +33,11 @@ export const REQUEST_SORTING_OPTION = {
 } as const;
 
 export const REQUEST_POST_KIND_URL = {
-  [POST_CONTENT.ALL]: 'posts',
-  [POST_CONTENT.MY_POST]: 'posts/me',
-  [POST_CONTENT.MY_VOTE]: 'posts/votes/me',
-  [POST_CONTENT.CATEGORY]: 'posts/categories',
-  [POST_CONTENT.SEARCH]: 'posts/search',
+  [POST_TYPE.ALL]: 'posts',
+  [POST_TYPE.MY_POST]: 'posts/me',
+  [POST_TYPE.MY_VOTE]: 'posts/votes/me',
+  [POST_TYPE.CATEGORY]: 'posts/categories',
+  [POST_TYPE.SEARCH]: 'posts/search',
 } as const;
 
 export const SEARCH_KEYWORD = 'keyword';

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -41,3 +41,13 @@ export const REQUEST_POST_KIND_URL = {
 } as const;
 
 export const SEARCH_KEYWORD = 'keyword';
+
+export const MAX_FILE_SIZE = 5000000;
+
+export const POST_TITLE_MAX_LENGTH = 100;
+
+export const POST_DESCRIPTION_MAX_LENGTH = 1000;
+
+export const SEARCH_KEYWORD_MAX_LENGTH = 100;
+
+export const POST_LIST_MAX_LENGTH = 10;

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -18,6 +18,7 @@ export const POST_CONTENT = {
   MY_POST: 'myPost',
   MY_VOTE: 'myVote',
   CATEGORY: 'category',
+  SEARCH: 'search',
 } as const;
 
 export const REQUEST_STATUS_OPTION = {
@@ -36,4 +37,5 @@ export const REQUEST_POST_KIND_URL = {
   [POST_CONTENT.MY_POST]: 'posts/me',
   [POST_CONTENT.MY_VOTE]: 'posts/votes/me',
   [POST_CONTENT.CATEGORY]: 'posts/categories',
+  [POST_CONTENT.SEARCH]: 'posts/search',
 } as const;

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -1,30 +1,23 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import { PostList, PostListByOption } from '@type/post';
+import { PostList, PostListByOptionalOption, PostListByRequiredOption } from '@type/post';
 
 import { getPostList } from '@api/postList';
 
 import { POST_LIST_MAX_LENGTH } from '@constants/post';
 
-export const usePostList = ({
-  postType,
-  postSorting,
-  postStatus,
-  categoryId = 0,
-  keyword = '',
-}: Omit<PostListByOption, 'pageNumber'>) => {
+export const usePostList = (
+  requiredOption: Omit<PostListByRequiredOption, 'pageNumber'>,
+  optionalOption: PostListByOptionalOption
+) => {
+  const { postSorting, postStatus } = requiredOption;
+  const { categoryId, keyword } = optionalOption;
+
   const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<PostList>(
       ['posts', postSorting, postStatus, categoryId, keyword],
       ({ pageParam = 0 }) =>
-        getPostList({
-          postType,
-          postSorting,
-          postStatus,
-          pageNumber: pageParam,
-          categoryId,
-          keyword,
-        }),
+        getPostList({ ...requiredOption, pageNumber: pageParam }, optionalOption),
       {
         getNextPageParam: lastPage => {
           if (lastPage.postList.length !== POST_LIST_MAX_LENGTH) return;

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -17,7 +17,14 @@ export const usePostList = ({
     useInfiniteQuery<PostList>(
       ['posts', postSorting, postStatus, categoryId, keyword],
       ({ pageParam = 0 }) =>
-        getPostList({ content, postSorting, postStatus, pageNumber: pageParam, categoryId }),
+        getPostList({
+          content,
+          postSorting,
+          postStatus,
+          pageNumber: pageParam,
+          categoryId,
+          keyword,
+        }),
       {
         getNextPageParam: lastPage => {
           if (lastPage.postList.length !== MAX_LIST_LENGTH) return;

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -4,7 +4,7 @@ import { PostList, PostListByOption } from '@type/post';
 
 import { getPostList } from '@api/postList';
 
-const MAX_LIST_LENGTH = 10;
+import { POST_LIST_MAX_LENGTH } from '@constants/post';
 
 export const usePostList = ({
   postType,
@@ -27,7 +27,7 @@ export const usePostList = ({
         }),
       {
         getNextPageParam: lastPage => {
-          if (lastPage.postList.length !== MAX_LIST_LENGTH) return;
+          if (lastPage.postList.length !== POST_LIST_MAX_LENGTH) return;
 
           return lastPage.pageNumber + 1;
         },

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -7,7 +7,7 @@ import { getPostList } from '@api/postList';
 const MAX_LIST_LENGTH = 10;
 
 export const usePostList = ({
-  content,
+  postType,
   postSorting,
   postStatus,
   categoryId = 0,
@@ -18,7 +18,7 @@ export const usePostList = ({
       ['posts', postSorting, postStatus, categoryId, keyword],
       ({ pageParam = 0 }) =>
         getPostList({
-          content,
+          postType,
           postSorting,
           postStatus,
           pageNumber: pageParam,

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -10,11 +10,12 @@ export const usePostList = ({
   content,
   postSorting,
   postStatus,
-  categoryId,
+  categoryId = 0,
+  keyword = '',
 }: Omit<PostListByOption, 'pageNumber'>) => {
   const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<PostList>(
-      ['posts', postSorting, postStatus, categoryId],
+      ['posts', postSorting, postStatus, categoryId, keyword],
       ({ pageParam = 0 }) =>
         getPostList({ content, postSorting, postStatus, pageNumber: pageParam, categoryId }),
       {

--- a/frontend/src/hooks/usePostRequestInfo.ts
+++ b/frontend/src/hooks/usePostRequestInfo.ts
@@ -20,7 +20,7 @@ export const usePostRequestInfo = () => {
   const [searchParams] = useSearchParams();
 
   const { pathname } = useLocation();
-  const keyword = searchParams.get(SEARCH_KEYWORD)?.toString();
+  const keyword = searchParams.get(SEARCH_KEYWORD)?.toString().slice(0, 100);
 
   const convertedPathname = getPathFragment(pathname);
 

--- a/frontend/src/hooks/usePostRequestInfo.ts
+++ b/frontend/src/hooks/usePostRequestInfo.ts
@@ -16,17 +16,24 @@ const REQUEST_URL: Record<string, PostRequestKind> = {
 };
 
 export const usePostRequestInfo = () => {
-  const { categoryId } = useParams<{ categoryId?: string }>();
+  const params = useParams<{ categoryId?: string }>();
   const [searchParams] = useSearchParams();
   const { pathname } = useLocation();
 
-  const keyword = searchParams.get(SEARCH_KEYWORD)?.toString().slice(0, SEARCH_KEYWORD_MAX_LENGTH);
+  const categoryId = Number(params.categoryId ?? 0);
+  const keyword =
+    searchParams.get(SEARCH_KEYWORD)?.toString().slice(0, SEARCH_KEYWORD_MAX_LENGTH) ?? '';
   const convertedPathname = getPathFragment(pathname);
   const postType = REQUEST_URL[convertedPathname];
 
+  const postOptionalOption = {
+    categoryId,
+    keyword,
+  };
+
   if (!postType) {
-    return { categoryId: Number(categoryId), postType: REQUEST_URL[PATH.HOME], keyword };
+    return { postType: REQUEST_URL[PATH.HOME], postOptionalOption };
   }
 
-  return { categoryId: Number(categoryId), postType, keyword };
+  return { postType, postOptionalOption };
 };

--- a/frontend/src/hooks/usePostRequestInfo.ts
+++ b/frontend/src/hooks/usePostRequestInfo.ts
@@ -3,7 +3,7 @@ import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { PostRequestKind } from '@components/post/PostListPage/types';
 
 import { PATH } from '@constants/path';
-import { POST_TYPE, SEARCH_KEYWORD } from '@constants/post';
+import { POST_TYPE, SEARCH_KEYWORD, SEARCH_KEYWORD_MAX_LENGTH } from '@constants/post';
 
 import { getPathFragment } from '@utils/getPathFragment';
 
@@ -18,12 +18,10 @@ const REQUEST_URL: Record<string, PostRequestKind> = {
 export const usePostRequestInfo = () => {
   const { categoryId } = useParams<{ categoryId?: string }>();
   const [searchParams] = useSearchParams();
-
   const { pathname } = useLocation();
-  const keyword = searchParams.get(SEARCH_KEYWORD)?.toString().slice(0, 100);
 
+  const keyword = searchParams.get(SEARCH_KEYWORD)?.toString().slice(0, SEARCH_KEYWORD_MAX_LENGTH);
   const convertedPathname = getPathFragment(pathname);
-
   const postType = REQUEST_URL[convertedPathname];
 
   if (!postType) {

--- a/frontend/src/hooks/usePostRequestInfo.ts
+++ b/frontend/src/hooks/usePostRequestInfo.ts
@@ -1,9 +1,9 @@
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 
 import { PostRequestKind } from '@components/post/PostListPage/types';
 
 import { PATH } from '@constants/path';
-import { POST_CONTENT } from '@constants/post';
+import { POST_CONTENT, SEARCH_KEYWORD } from '@constants/post';
 
 import { getPathFragment } from '@utils/getPathFragment';
 
@@ -12,14 +12,23 @@ const REQUEST_URL: Record<string, PostRequestKind> = {
   [PATH.POST_CATEGORY]: POST_CONTENT.CATEGORY,
   [PATH.USER_POST]: POST_CONTENT.MY_POST,
   [PATH.USER_VOTE]: POST_CONTENT.MY_VOTE,
+  [PATH.SEARCH]: POST_CONTENT.SEARCH,
 };
 
 export const usePostRequestInfo = () => {
   const { categoryId } = useParams<{ categoryId?: string }>();
+  const [searchParams] = useSearchParams();
 
   const { pathname } = useLocation();
+  const keyword = searchParams.get(SEARCH_KEYWORD)?.toString();
 
   const convertedPathname = getPathFragment(pathname);
 
-  return { categoryId: Number(categoryId), content: REQUEST_URL[convertedPathname] };
+  const content = REQUEST_URL[convertedPathname];
+
+  if (!content) {
+    return { categoryId: Number(categoryId), content: REQUEST_URL[PATH.HOME], keyword };
+  }
+
+  return { categoryId: Number(categoryId), content, keyword };
 };

--- a/frontend/src/hooks/usePostRequestInfo.ts
+++ b/frontend/src/hooks/usePostRequestInfo.ts
@@ -3,16 +3,16 @@ import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { PostRequestKind } from '@components/post/PostListPage/types';
 
 import { PATH } from '@constants/path';
-import { POST_CONTENT, SEARCH_KEYWORD } from '@constants/post';
+import { POST_TYPE, SEARCH_KEYWORD } from '@constants/post';
 
 import { getPathFragment } from '@utils/getPathFragment';
 
 const REQUEST_URL: Record<string, PostRequestKind> = {
-  [PATH.HOME]: POST_CONTENT.ALL,
-  [PATH.POST_CATEGORY]: POST_CONTENT.CATEGORY,
-  [PATH.USER_POST]: POST_CONTENT.MY_POST,
-  [PATH.USER_VOTE]: POST_CONTENT.MY_VOTE,
-  [PATH.SEARCH]: POST_CONTENT.SEARCH,
+  [PATH.HOME]: POST_TYPE.ALL,
+  [PATH.POST_CATEGORY]: POST_TYPE.CATEGORY,
+  [PATH.USER_POST]: POST_TYPE.MY_POST,
+  [PATH.USER_VOTE]: POST_TYPE.MY_VOTE,
+  [PATH.SEARCH]: POST_TYPE.SEARCH,
 };
 
 export const usePostRequestInfo = () => {
@@ -24,11 +24,11 @@ export const usePostRequestInfo = () => {
 
   const convertedPathname = getPathFragment(pathname);
 
-  const content = REQUEST_URL[convertedPathname];
+  const postType = REQUEST_URL[convertedPathname];
 
-  if (!content) {
-    return { categoryId: Number(categoryId), content: REQUEST_URL[PATH.HOME], keyword };
+  if (!postType) {
+    return { categoryId: Number(categoryId), postType: REQUEST_URL[PATH.HOME], keyword };
   }
 
-  return { categoryId: Number(categoryId), content, keyword };
+  return { categoryId: Number(categoryId), postType, keyword };
 };

--- a/frontend/src/mocks/wus/post.ts
+++ b/frontend/src/mocks/wus/post.ts
@@ -1,53 +1,52 @@
-import { rest } from 'msw';
+import {
+  DefaultBodyType,
+  PathParams,
+  ResponseComposition,
+  RestContext,
+  RestRequest,
+  rest,
+} from 'msw';
 
 import { MOCK_POST_LIST } from '@mocks/mockData/postList';
 
 export const mockPostList = [
   rest.get('/posts', (req, res, ctx) => {
-    const page = Number(req.url.searchParams.get('page'));
-
-    if (page === null) return;
-
-    if (page > 0) {
-      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
-    }
-
-    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+    return createMockPostListResponse(req, res, ctx);
   }),
 
   rest.get('/posts/categories/:categoryId', (req, res, ctx) => {
-    const page = Number(req.url.searchParams.get('page'));
-
-    if (page === null) return;
-
-    if (page > 0) {
-      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
-    }
-
-    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+    return createMockPostListResponse(req, res, ctx);
   }),
 
   rest.get('/posts/me', (req, res, ctx) => {
-    const page = Number(req.url.searchParams.get('page'));
-
-    if (page === null) return;
-
-    if (page > 0) {
-      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
-    }
-
-    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+    return createMockPostListResponse(req, res, ctx);
   }),
 
   rest.get('/posts/votes/me', (req, res, ctx) => {
-    const page = Number(req.url.searchParams.get('page'));
+    return createMockPostListResponse(req, res, ctx);
+  }),
 
-    if (page === null) return;
+  rest.get('/posts/votes/me', (req, res, ctx) => {
+    return createMockPostListResponse(req, res, ctx);
+  }),
 
-    if (page > 0) {
-      return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
-    }
-
-    return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+  rest.get('/posts/search', (req, res, ctx) => {
+    return createMockPostListResponse(req, res, ctx);
   }),
 ];
+
+const createMockPostListResponse = (
+  req: RestRequest<never, PathParams<string>>,
+  res: ResponseComposition<DefaultBodyType>,
+  ctx: RestContext
+) => {
+  const page = Number(req.url.searchParams.get('page'));
+
+  if (page === null) return;
+
+  if (page > 0) {
+    return res(ctx.status(200), ctx.json(MOCK_POST_LIST), ctx.delay(1000));
+  }
+
+  return res(ctx.status(200), ctx.json(MOCK_POST_LIST));
+};

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -35,4 +35,5 @@ export interface PostListByOption {
   postSorting: PostSorting;
   pageNumber: number;
   categoryId?: number;
+  keyword?: string;
 }

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -29,11 +29,14 @@ export interface PostList {
   postList: PostInfo[];
 }
 
-export interface PostListByOption {
+export interface PostListByRequiredOption {
   postType: PostRequestKind;
   postStatus: PostStatus;
   postSorting: PostSorting;
   pageNumber: number;
-  categoryId?: number;
-  keyword?: string;
+}
+
+export interface PostListByOptionalOption {
+  categoryId: number;
+  keyword: string;
 }

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -30,7 +30,7 @@ export interface PostList {
 }
 
 export interface PostListByOption {
-  content: PostRequestKind;
+  postType: PostRequestKind;
   postStatus: PostStatus;
   postSorting: PostSorting;
   pageNumber: number;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #176 

## 📝 작업 요약

- 헤더에 검색했을 때 검색한 키워드의 url로 이동하도록 함
- 검색 혹은 직접 url을 입력해서 들어왔을 때 해당 키워드에 대해 결과를 보여준다.
- 이에 대한 msw 코드, fetch 코드, react-query 코드가 추가 및 변경

## 🔎 작업 상세 설명

useSearchParams를 이용해 keyword를 불러와 fetch하는 함수에 전달

content에 따라 다른 게시글을 불러오는 로직에서 content에 search를 추가

검색한 키워드를 100자 이내로 잘라서 요청

## 🌟 논의 사항

결과가 없다면 검색한 키워드에 대한 결과가 없다고 알려주는 컴포넌트가 필요한데 따로 이슈파서 디자인 후 진행하는 것이 좋아보입니다~
