### PR TITLE
회원 닉네임 수정, 회원 탈퇴 fetch 함수 구현 및 MSW 코드 작성

### DIFF
--- a/frontend/__test__/api/user.test.ts
+++ b/frontend/__test__/api/user.test.ts
@@ -1,4 +1,9 @@
-import { getUserInfo, transformUserInfoResponse } from '@api/wus/userInfo';
+import {
+  cancelMembership,
+  getUserInfo,
+  modifyNickname,
+  transformUserInfoResponse,
+} from '@api/wus/userInfo';
 
 import { MOCK_USER_INFO } from '@mocks/mockData/user';
 
@@ -15,5 +20,17 @@ describe('서버와 통신하여 유저의 정보를 불러올 수 있어야 한
     const userInfoKeys = Object.keys(data);
 
     expect(userInfoKeys).toEqual(['nickname', 'postCount', 'userPoint', 'voteCount', 'badge']);
+  });
+
+  test('유저의 닉네임을 수정한다', async () => {
+    await modifyNickname('wood');
+
+    expect(MOCK_USER_INFO.nickname).toBe('wood');
+  });
+
+  test('유저가 회원 탈퇴를 한다', async () => {
+    await cancelMembership();
+
+    expect(MOCK_USER_INFO.nickname).toBe('cancel');
   });
 });

--- a/frontend/src/api/wus/userInfo.ts
+++ b/frontend/src/api/wus/userInfo.ts
@@ -14,16 +14,18 @@ export const transformUserInfoResponse = (userInfo: UserInfoResponse): User => {
   };
 };
 
+const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
+
 export const getUserInfo = async () => {
-  const userInfo = await getFetch<UserInfoResponse>('/members/me');
+  const userInfo = await getFetch<UserInfoResponse>(`${BASE_URL}/members/me`);
 
   return transformUserInfoResponse(userInfo);
 };
 
 export const modifyNickname = async (nickname: string) => {
-  await patchFetch<ModifyNicknameRequest>('/members/me/nickname', { nickname });
+  await patchFetch<ModifyNicknameRequest>(`${BASE_URL}/members/me/nickname`, { nickname });
 };
 
 export const cancelMembership = async () => {
-  await deleteFetch('/members/me/delete');
+  await deleteFetch(`${BASE_URL}/members/me/delete`);
 };

--- a/frontend/src/api/wus/userInfo.ts
+++ b/frontend/src/api/wus/userInfo.ts
@@ -1,6 +1,6 @@
-import type { UserInfoResponse, User } from '@type/user';
+import type { UserInfoResponse, User, ModifyNicknameRequest } from '@type/user';
 
-import { getFetch } from '@utils/fetch';
+import { deleteFetch, getFetch, patchFetch } from '@utils/fetch';
 
 export const transformUserInfoResponse = (userInfo: UserInfoResponse): User => {
   const { nickname, postCount, userPoint, voteCount, badge } = userInfo;
@@ -18,4 +18,12 @@ export const getUserInfo = async () => {
   const userInfo = await getFetch<UserInfoResponse>('/members/me');
 
   return transformUserInfoResponse(userInfo);
+};
+
+export const modifyNickname = async (nickname: string) => {
+  await patchFetch<ModifyNicknameRequest>('/members/me/nickname', { nickname });
+};
+
+export const cancelMembership = async () => {
+  await deleteFetch('/members/me/delete');
 };

--- a/frontend/src/mocks/wus/userInfo.ts
+++ b/frontend/src/mocks/wus/userInfo.ts
@@ -6,4 +6,16 @@ export const mockUserInfo = [
   rest.get('/members/me', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(MOCK_USER_INFO));
   }),
+
+  rest.patch('/members/me/nickname', (req, res, ctx) => {
+    MOCK_USER_INFO.nickname = 'wood';
+
+    return res(ctx.status(200), ctx.json({ ok: true }));
+  }),
+
+  rest.delete('/members/me/delete', (req, res, ctx) => {
+    MOCK_USER_INFO.nickname = 'cancel';
+
+    return res(ctx.status(204));
+  }),
 ];

--- a/frontend/src/mocks/wus/userInfo.ts
+++ b/frontend/src/mocks/wus/userInfo.ts
@@ -10,7 +10,7 @@ export const mockUserInfo = [
   rest.patch('/members/me/nickname', (req, res, ctx) => {
     MOCK_USER_INFO.nickname = 'wood';
 
-    return res(ctx.status(200), ctx.json({ ok: true }));
+    return res(ctx.status(200), ctx.json({ ok: '닉네임이 성공적으로 수정되었습니다!' }));
   }),
 
   rest.delete('/members/me/delete', (req, res, ctx) => {

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -13,3 +13,7 @@ export interface UserInfoResponse {
   voteCount: number;
   badge?: string;
 }
+
+export interface ModifyNicknameRequest {
+  nickname: string;
+}

--- a/frontend/src/utils/fetch.ts
+++ b/frontend/src/utils/fetch.ts
@@ -55,7 +55,7 @@ export const putFetch = async <T, R>(url: string, body: T): Promise<R | void> =>
   return data;
 };
 
-export const patchFetch = async <T>(url: string, body: T) => {
+export const patchFetch = async <T>(url: string, body?: T) => {
   const response = await fetch(url, {
     method: 'PATCH',
     headers,

--- a/frontend/src/utils/fetch.ts
+++ b/frontend/src/utils/fetch.ts
@@ -55,10 +55,11 @@ export const putFetch = async <T, R>(url: string, body: T): Promise<R | void> =>
   return data;
 };
 
-export const patchFetch = async (url: string) => {
+export const patchFetch = async <T>(url: string, body: T) => {
   const response = await fetch(url, {
     method: 'PATCH',
     headers,
+    body: JSON.stringify(body),
   });
 
   const data = await response.json();
@@ -66,6 +67,8 @@ export const patchFetch = async (url: string) => {
   if (!response.ok) {
     throw new Error(data.message);
   }
+
+  return response;
 };
 
 export const deleteFetch = async (url: string) => {
@@ -74,11 +77,7 @@ export const deleteFetch = async (url: string) => {
     headers,
   });
 
-  const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error(data.message);
-  }
+  return response;
 };
 
 export const multiPostFetch = async (url: string, body: FormData) => {


### PR DESCRIPTION
## 🔥 연관 이슈

close: #153 

## 작업 소요 시간

약 1시간

## 📝 작업 요약

- 회원 닉네임 수정 fetch 함수 구현
- 회원 탈퇴 fetch 함수 구현
- MSW 코드 작성


## 🌟 논의 사항

아직 dev 브런치에 제로가 변경한 Fetch 유틸 함수 중 deleteFetch가 반영되어 있지 않아서 수동 반영하였습니다~

patchFetch 유틸 함수에서 body를 받는 옵션이 없어서 추가했습니다

react-query를 이용한 훅 구현은 따로 이슈 파도록 하겠습니다
