### PR TITLE
내 정보 페이지 UI 구현, Accordion 컴포넌트 구현

### DIFF
--- a/frontend/src/components/common/Accordion/Accordion.stories.tsx
+++ b/frontend/src/components/common/Accordion/Accordion.stories.tsx
@@ -2,6 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import { styled } from 'styled-components';
 
+import { useToggle } from '@hooks/useToggle';
+
+import Modal from '../Modal';
 import SquareButton from '../SquareButton';
 
 import Accordion from '.';
@@ -34,17 +37,35 @@ export const NicknameChange: Story = {
   ),
 };
 
-export const DeleteUserAccount: Story = {
-  render: () => (
+export const DeleteUserAccount = () => {
+  const { isOpen, openComponent, closeComponent } = useToggle();
+  return (
     <Accordion title="회원 탈퇴">
-      <Input placeholder="비밀번호를 입력해주세요" />
       <ButtonWrapper>
-        <SquareButton aria-label="회원 탈퇴" theme="fill">
+        <SquareButton onClick={openComponent} aria-label="회원 탈퇴" theme="blank">
           회원 탈퇴
         </SquareButton>
       </ButtonWrapper>
+      {isOpen && (
+        <Modal size="sm" onModalClose={closeComponent}>
+          <ModalBody>
+            <ModalTitle>정말 탈퇴하시겠어요?</ModalTitle>
+            <ModalDescription>
+              탈퇴 버튼 클릭 시, <br></br>계정은 삭제되며 복구되지 않아요.
+            </ModalDescription>
+            <ButtonListWrapper>
+              <SquareButton aria-label="회원 탈퇴" theme="fill">
+                탈퇴
+              </SquareButton>
+              <SquareButton onClick={closeComponent} aria-label="회원 탈퇴" theme="blank">
+                취소
+              </SquareButton>
+            </ButtonListWrapper>
+          </ModalBody>
+        </Modal>
+      )}
     </Accordion>
-  ),
+  );
 };
 
 const ButtonWrapper = styled.div`
@@ -56,4 +77,36 @@ const Input = styled.input`
   width: 80%;
   border: 1px solid #f2f2f2;
   padding: 20px;
+`;
+
+const ModalBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 30px;
+
+  width: 90%;
+  margin: 40px 20px 0px 16px;
+
+  font: var(--text-caption);
+`;
+
+const ModalTitle = styled.div`
+  font: var(--text-title);
+`;
+
+const ModalDescription = styled.div`
+  font: var(--text-body);
+`;
+
+const ButtonListWrapper = styled.div`
+  display: flex;
+  justify-content: space-around;
+  gap: 20px;
+
+  width: 90%;
+  height: 50px;
+
+  margin-top: 20px;
 `;

--- a/frontend/src/components/common/Accordion/Accordion.stories.tsx
+++ b/frontend/src/components/common/Accordion/Accordion.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { styled } from 'styled-components';
+
+import SquareButton from '../SquareButton';
+
+import Accordion from '.';
+
+const meta: Meta<typeof Accordion> = {
+  component: Accordion,
+};
+
+export default meta;
+type Story = StoryObj<typeof Accordion>;
+
+export const Default: Story = {
+  render: () => (
+    <Accordion title="Click Title to Open Content">
+      <span>Hello This is Content!</span>
+    </Accordion>
+  ),
+};
+
+export const NicknameChange: Story = {
+  render: () => (
+    <Accordion title="닉네임 변경">
+      <Input placeholder="새로운 닉네임을 입력해주세요" />
+      <ButtonWrapper>
+        <SquareButton aria-label="닉네임 변경" theme="fill">
+          변경
+        </SquareButton>
+      </ButtonWrapper>
+    </Accordion>
+  ),
+};
+
+export const DeleteUserAccount: Story = {
+  render: () => (
+    <Accordion title="회원 탈퇴">
+      <Input placeholder="비밀번호를 입력해주세요" />
+      <ButtonWrapper>
+        <SquareButton aria-label="회원 탈퇴" theme="fill">
+          회원 탈퇴
+        </SquareButton>
+      </ButtonWrapper>
+    </Accordion>
+  ),
+};
+
+const ButtonWrapper = styled.div`
+  width: 90px;
+  height: 50px;
+`;
+
+const Input = styled.input`
+  width: 80%;
+  border: 1px solid #f2f2f2;
+  padding: 20px;
+`;

--- a/frontend/src/components/common/Accordion/index.tsx
+++ b/frontend/src/components/common/Accordion/index.tsx
@@ -1,0 +1,30 @@
+import { PropsWithChildren, useState } from 'react';
+
+import chevronDown from '@assets/chevron-down.svg';
+import chevronUp from '@assets/chevron-up.svg';
+
+import * as S from './style';
+
+interface AccordionProps extends PropsWithChildren {
+  title: string;
+}
+
+export default function Accordion({ title, children }: AccordionProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleAccordion = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <S.Wrapper aria-label="Accordion">
+      <S.Title onClick={toggleAccordion} aria-controls={`${title}에 대한 내용`}>
+        {title}
+        <S.Image src={isOpen ? chevronUp : chevronDown} alt="" $isOpen={isOpen} />
+      </S.Title>
+      <S.Content id={`${title}에 대한 내용`} $isOpen={isOpen}>
+        {children}
+      </S.Content>
+    </S.Wrapper>
+  );
+}

--- a/frontend/src/components/common/Accordion/style.ts
+++ b/frontend/src/components/common/Accordion/style.ts
@@ -1,0 +1,62 @@
+import styled, { keyframes } from 'styled-components';
+
+export const Wrapper = styled.div`
+  width: 100%;
+
+  font: var(--text-caption);
+`;
+
+export const Title = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  border: 1px solid #f2f2f2;
+  border-radius: 7px 7px 0 0;
+  padding: 16px;
+
+  background-color: #ffffff;
+
+  &:hover {
+    background-color: #f2f2f2;
+  }
+  cursor: pointer;
+`;
+
+export const Content = styled.div<{ $isOpen: boolean }>`
+  display: ${props => (props.$isOpen ? 'flex' : 'none')};
+  justify-content: space-between;
+
+  border: 1px solid #f2f2f2;
+  border-radius: 0 0 7px 7px;
+  padding: 16px;
+
+  opacity: ${props => (props.$isOpen ? 1 : 0)};
+  animation: ${props => (props.$isOpen ? fadeIn : fadeOut)} 0.2s ease-in-out;
+`;
+
+export const Image = styled.img<{ $isOpen: boolean }>`
+  width: 20px;
+  height: 20px;
+`;
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+    height: 0;
+  }
+  to {
+    opacity: 1;
+    height: auto;
+  }
+`;
+
+const fadeOut = keyframes`
+  from {
+    opacity: 1;
+    height: auto;
+  }
+  to {
+    opacity: 0;
+    height: 0;
+  }
+`;

--- a/frontend/src/components/common/TimePickerOptionList/TimePickerOption/index.tsx
+++ b/frontend/src/components/common/TimePickerOptionList/TimePickerOption/index.tsx
@@ -48,7 +48,7 @@ export default function TimePickerOption({
     return () => {
       timeBox.removeEventListener('scroll', handleScroll);
     };
-  }, [handlePickTime, timeUnit]);
+  }, [currentTime, handlePickTime, option, timeUnit]);
 
   return (
     <S.TimeBox ref={timeBoxRef}>
@@ -56,7 +56,7 @@ export default function TimePickerOption({
         <S.Time
           key={index}
           ref={index === currentTime ? timeBoxChildRef : null}
-          isPicked={currentTime === index}
+          $isPicked={currentTime === index}
         >
           {index}
         </S.Time>

--- a/frontend/src/components/common/TimePickerOptionList/TimePickerOption/style.ts
+++ b/frontend/src/components/common/TimePickerOptionList/TimePickerOption/style.ts
@@ -19,7 +19,7 @@ export const TimeBox = styled.div`
   scrollbar-width: none;
 `;
 
-export const Time = styled.div<{ isPicked: boolean }>`
+export const Time = styled.div<{ $isPicked: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -27,8 +27,8 @@ export const Time = styled.div<{ isPicked: boolean }>`
   width: 100%;
   height: 50px;
 
-  background: ${props => (props.isPicked ? '#F2F2F2' : 'var(--white)')};
+  background: ${props => (props.$isPicked ? '#F2F2F2' : 'var(--white)')};
 
   font: var(--text-small);
-  font-weight: ${props => (props.isPicked ? 'bold' : 'light')};
+  font-weight: ${props => (props.$isPicked ? 'bold' : 'light')};
 `;

--- a/frontend/src/mocks/example/get.ts
+++ b/frontend/src/mocks/example/get.ts
@@ -5,5 +5,3 @@ export const example = [
     return res(ctx.status(200));
   }),
 ];
-
-window.console.log('husky pre-commit test');

--- a/frontend/src/pages/MyInfo/MyInfo.stories.tsx
+++ b/frontend/src/pages/MyInfo/MyInfo.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import MyInfo from '.';
+
+const meta: Meta<typeof MyInfo> = {
+  component: MyInfo,
+};
+
+export default meta;
+type Story = StoryObj<typeof MyInfo>;
+
+export const Default: Story = {
+  render: () => <MyInfo />,
+};

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -2,9 +2,12 @@ import { useNavigate } from 'react-router-dom';
 
 import { User } from '@type/user';
 
+import { useToggle } from '@hooks/useToggle';
+
 import Accordion from '@components/common/Accordion';
 import UserProfile from '@components/common/Dashboard/UserProfile';
 import IconButton from '@components/common/IconButton';
+import Modal from '@components/common/Modal';
 import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
 import SquareButton from '@components/common/SquareButton';
 
@@ -12,6 +15,7 @@ import * as S from './style';
 
 export default function MyInfo() {
   const navigate = useNavigate();
+  const { isOpen, openComponent, closeComponent } = useToggle();
 
   // const { data: userInfo, error, isLoading, isError } = useUserInfo(); // 유저 정보 조회 관련 pr merge 필요
   const MOCK_USER_INFO: User = {
@@ -46,12 +50,29 @@ export default function MyInfo() {
           </S.ButtonWrapper>
         </Accordion>
         <Accordion title="회원 탈퇴">
-          <S.Input placeholder="비밀번호를 입력해주세요" />
           <S.ButtonWrapper>
-            <SquareButton aria-label="회원 탈퇴" theme="fill">
+            <SquareButton onClick={openComponent} aria-label="회원 탈퇴" theme="blank">
               회원 탈퇴
             </SquareButton>
           </S.ButtonWrapper>
+          {isOpen && (
+            <Modal size="sm" onModalClose={closeComponent}>
+              <S.ModalBody>
+                <S.ModalTitle>정말 탈퇴하시겠어요?</S.ModalTitle>
+                <S.ModalDescription>
+                  탈퇴 버튼 클릭 시, <br></br>계정은 삭제되며 복구되지 않아요.
+                </S.ModalDescription>
+                <S.ButtonListWrapper>
+                  <SquareButton aria-label="회원 탈퇴" theme="fill">
+                    탈퇴
+                  </SquareButton>
+                  <SquareButton onClick={closeComponent} aria-label="회원 탈퇴" theme="blank">
+                    취소
+                  </SquareButton>
+                </S.ButtonListWrapper>
+              </S.ModalBody>
+            </Modal>
+          )}
         </Accordion>
       </S.UserControlSection>
     </S.Wrapper>

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -7,6 +7,7 @@ import { useToggle } from '@hooks/useToggle';
 import Accordion from '@components/common/Accordion';
 import UserProfile from '@components/common/Dashboard/UserProfile';
 import IconButton from '@components/common/IconButton';
+import Layout from '@components/common/Layout';
 import Modal from '@components/common/Modal';
 import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
 import SquareButton from '@components/common/SquareButton';
@@ -26,55 +27,57 @@ export default function MyInfo() {
   };
 
   return (
-    <S.Wrapper>
-      <S.HeaderWrapper>
-        <NarrowTemplateHeader>
-          <IconButton
-            category="back"
-            onClick={() => {
-              navigate(-1);
-            }}
-          />
-        </NarrowTemplateHeader>
-      </S.HeaderWrapper>
-      <S.ProfileSection>
-        <UserProfile userInfo={MOCK_USER_INFO} />
-      </S.ProfileSection>
-      <S.UserControlSection>
-        <Accordion title="닉네임 변경">
-          <S.Input placeholder="새로운 닉네임을 입력해주세요" />
-          <S.ButtonWrapper>
-            <SquareButton aria-label="닉네임 변경" theme="fill">
-              변경
-            </SquareButton>
-          </S.ButtonWrapper>
-        </Accordion>
-        <Accordion title="회원 탈퇴">
-          <S.ButtonWrapper>
-            <SquareButton onClick={openComponent} aria-label="회원 탈퇴" theme="blank">
-              회원 탈퇴
-            </SquareButton>
-          </S.ButtonWrapper>
-          {isOpen && (
-            <Modal size="sm" onModalClose={closeComponent}>
-              <S.ModalBody>
-                <S.ModalTitle>정말 탈퇴하시겠어요?</S.ModalTitle>
-                <S.ModalDescription>
-                  탈퇴 버튼 클릭 시, <br></br>계정은 삭제되며 복구되지 않아요.
-                </S.ModalDescription>
-                <S.ButtonListWrapper>
-                  <SquareButton aria-label="회원 탈퇴" theme="fill">
-                    탈퇴
-                  </SquareButton>
-                  <SquareButton onClick={closeComponent} aria-label="회원 탈퇴" theme="blank">
-                    취소
-                  </SquareButton>
-                </S.ButtonListWrapper>
-              </S.ModalBody>
-            </Modal>
-          )}
-        </Accordion>
-      </S.UserControlSection>
-    </S.Wrapper>
+    <Layout isSidebarVisible={true}>
+      <S.Wrapper>
+        <S.HeaderWrapper>
+          <NarrowTemplateHeader>
+            <IconButton
+              category="back"
+              onClick={() => {
+                navigate(-1);
+              }}
+            />
+          </NarrowTemplateHeader>
+        </S.HeaderWrapper>
+        <S.ProfileSection>
+          <UserProfile userInfo={MOCK_USER_INFO} />
+        </S.ProfileSection>
+        <S.UserControlSection>
+          <Accordion title="닉네임 변경">
+            <S.Input placeholder="새로운 닉네임을 입력해주세요" />
+            <S.ButtonWrapper>
+              <SquareButton aria-label="닉네임 변경" theme="fill">
+                변경
+              </SquareButton>
+            </S.ButtonWrapper>
+          </Accordion>
+          <Accordion title="회원 탈퇴">
+            <S.ButtonWrapper>
+              <SquareButton onClick={openComponent} aria-label="회원 탈퇴" theme="blank">
+                회원 탈퇴
+              </SquareButton>
+            </S.ButtonWrapper>
+            {isOpen && (
+              <Modal size="sm" onModalClose={closeComponent}>
+                <S.ModalBody>
+                  <S.ModalTitle>정말 탈퇴하시겠어요?</S.ModalTitle>
+                  <S.ModalDescription>
+                    탈퇴 버튼 클릭 시, <br></br>계정은 삭제되며 복구되지 않아요.
+                  </S.ModalDescription>
+                  <S.ButtonListWrapper>
+                    <SquareButton aria-label="회원 탈퇴" theme="fill">
+                      탈퇴
+                    </SquareButton>
+                    <SquareButton onClick={closeComponent} aria-label="회원 탈퇴" theme="blank">
+                      취소
+                    </SquareButton>
+                  </S.ButtonListWrapper>
+                </S.ModalBody>
+              </Modal>
+            )}
+          </Accordion>
+        </S.UserControlSection>
+      </S.Wrapper>
+    </Layout>
   );
 }

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -1,0 +1,59 @@
+import { useNavigate } from 'react-router-dom';
+
+import { User } from '@type/user';
+
+import Accordion from '@components/common/Accordion';
+import UserProfile from '@components/common/Dashboard/UserProfile';
+import IconButton from '@components/common/IconButton';
+import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
+import SquareButton from '@components/common/SquareButton';
+
+import * as S from './style';
+
+export default function MyInfo() {
+  const navigate = useNavigate();
+
+  // const { data: userInfo, error, isLoading, isError } = useUserInfo(); // 유저 정보 조회 관련 pr merge 필요
+  const MOCK_USER_INFO: User = {
+    nickname: '우아한 코끼리',
+    postCount: 4,
+    voteCount: 128,
+    userPoint: 200,
+  };
+
+  return (
+    <S.Wrapper>
+      <S.HeaderWrapper>
+        <NarrowTemplateHeader>
+          <IconButton
+            category="back"
+            onClick={() => {
+              navigate(-1);
+            }}
+          />
+        </NarrowTemplateHeader>
+      </S.HeaderWrapper>
+      <S.ProfileSection>
+        <UserProfile userInfo={MOCK_USER_INFO} />
+      </S.ProfileSection>
+      <S.UserControlSection>
+        <Accordion title="닉네임 변경">
+          <S.Input placeholder="새로운 닉네임을 입력해주세요" />
+          <S.ButtonWrapper>
+            <SquareButton aria-label="닉네임 변경" theme="fill">
+              변경
+            </SquareButton>
+          </S.ButtonWrapper>
+        </Accordion>
+        <Accordion title="회원 탈퇴">
+          <S.Input placeholder="비밀번호를 입력해주세요" />
+          <S.ButtonWrapper>
+            <SquareButton aria-label="회원 탈퇴" theme="fill">
+              회원 탈퇴
+            </SquareButton>
+          </S.ButtonWrapper>
+        </Accordion>
+      </S.UserControlSection>
+    </S.Wrapper>
+  );
+}

--- a/frontend/src/pages/MyInfo/style.ts
+++ b/frontend/src/pages/MyInfo/style.ts
@@ -1,0 +1,41 @@
+import { styled } from 'styled-components';
+
+import { theme } from '@styles/theme';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 30px;
+
+  padding-top: 70px;
+  position: relative;
+`;
+
+export const HeaderWrapper = styled.div`
+  width: 100%;
+
+  position: fixed;
+
+  z-index: ${theme.zIndex.header};
+`;
+
+export const ProfileSection = styled.section`
+  width: 90%;
+`;
+
+export const UserControlSection = styled.section`
+  width: 90%;
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 90px;
+  height: 50px;
+`;
+
+export const Input = styled.input`
+  width: 80%;
+  border: 1px solid #f2f2f2;
+  padding: 20px;
+`;

--- a/frontend/src/pages/MyInfo/style.ts
+++ b/frontend/src/pages/MyInfo/style.ts
@@ -9,8 +9,16 @@ export const Wrapper = styled.div`
   align-items: center;
   gap: 30px;
 
-  padding-top: 70px;
+  padding-top: 55px;
   position: relative;
+
+  @media (min-width: 768px) {
+    padding-top: 20px;
+  }
+
+  @media (min-width: ${theme.breakpoint.md}) {
+    padding-top: 20px;
+  }
 `;
 
 export const HeaderWrapper = styled.div`
@@ -19,6 +27,10 @@ export const HeaderWrapper = styled.div`
   position: fixed;
 
   z-index: ${theme.zIndex.header};
+
+  @media (min-width: ${theme.breakpoint.md}) {
+    display: none;
+  }
 `;
 
 export const ProfileSection = styled.section`

--- a/frontend/src/pages/MyInfo/style.ts
+++ b/frontend/src/pages/MyInfo/style.ts
@@ -39,3 +39,35 @@ export const Input = styled.input`
   border: 1px solid #f2f2f2;
   padding: 20px;
 `;
+
+export const ModalBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 30px;
+
+  width: 90%;
+  margin: 40px 20px 0px 16px;
+
+  font: var(--text-caption);
+`;
+
+export const ModalTitle = styled.div`
+  font: var(--text-title);
+`;
+
+export const ModalDescription = styled.div`
+  font: var(--text-body);
+`;
+
+export const ButtonListWrapper = styled.div`
+  display: flex;
+  justify-content: space-around;
+  gap: 20px;
+
+  width: 90%;
+  height: 50px;
+
+  margin-top: 20px;
+`;

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 
 import Home from '@pages/Home';
+import MyInfo from '@pages/MyInfo';
 import CreatePost from '@pages/post/CreatePost';
 import EditPost from '@pages/post/EditPost';
 import PostDetailPage from '@pages/post/PostDetail';
@@ -39,9 +40,9 @@ const router = createBrowserRouter([
   {
     path: PATH.USER,
     children: [
+      { path: 'myPage', element: <MyInfo /> },
       { path: 'posts', element: <Home /> },
       { path: 'votes', element: <Home /> },
-      { path: 'myPage', element: <Home /> },
     ],
   },
 ]);

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -3,8 +3,8 @@ import { DefaultTheme } from 'styled-components';
 const breakpoint = {
   /** @media (min-width: 576px) { ... } */
   sm: '576px',
-  /** @media (min-width: 960px) { ... } */
-  md: '960px',
+  /** @media (min-width: 768px) { ... } */
+  md: '768px',
   /** @media (min-width: 1440px) { ... }*/
   lg: '1440px',
 };


### PR DESCRIPTION
## 🔥 연관 이슈

close: #175 

## 📝 작업 요약
* Accordion 컴포넌트를 구현하였습니다. (common/Accordion)
* 내정보(닉네임, 포인트, 작성글, 투표수)를 조회할 수 있는 페이지 구현하였습니다.
* 해당 페이지에서 닉네임을 변경하거나 회원 탈퇴를 할 수 있도록 UI를 구현하였습니다. 

## 🔎 작업 상세 설명
* Accordion props 
```TypeScript
interface AccordionProps extends PropsWithChildren {
  title: string;  // 아코디언 제목
}
```
* MyInfo 페이지 Storybook
![storybook-myinfo](https://github.com/woowacourse-teams/2023-votogether/assets/81199414/1c5c947b-d1f8-4604-9984-5011fadbaf22)


## 🌟 논의 사항
* 닉네임 변경, 회원 탈퇴, 유저 정보 조회 관련 API fetching 함수와 커스텀 쿼리 관련 코드들이 merge되어야 합니다. (임시로 mock data 사용함)
