### PR TITLE
댓글 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/votogether/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/votogether/config/WebMvcConfig.java
@@ -2,7 +2,6 @@ package com.votogether.config;
 
 import com.votogether.global.jwt.JwtAuthorizationArgumentResolver;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -13,14 +12,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver;
-    private final String origins;
 
-    public WebMvcConfig(
-            final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver,
-            @Value("${votogether.openapi.prod-url}") final String origins
-    ) {
+    public WebMvcConfig(final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver) {
         this.jwtAuthorizationArgumentResolver = jwtAuthorizationArgumentResolver;
-        this.origins = origins;
     }
 
     @Override
@@ -36,4 +30,5 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .allowedMethods("*")
                 .exposedHeaders(HttpHeaders.LOCATION);
     }
+
 }

--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
         final Member member = Member.from(response);
         final Member registeredMember = memberService.register(member);
         final String token = tokenProcessor.generateToken(registeredMember);
-        return new LoginResponse(token, registeredMember.getNickname().getValue());
+        return new LoginResponse(token, registeredMember.getNickname());
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -91,4 +91,8 @@ public class Member extends BaseEntity {
         this.nickname = new Nickname(nickname);
     }
 
+    public String getNickname() {
+        return nickname.getValue();
+    }
+
 }

--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -43,7 +43,7 @@ public class MemberService {
         final int numberOfVotes = voteRepository.countByMember(member);
 
         return new MemberInfoResponse(
-                member.getNickname().getValue(),
+                member.getNickname(),
                 member.getPoint(),
                 numberOfPosts,
                 numberOfVotes

--- a/backend/src/main/java/com/votogether/domain/post/controller/PostCommentController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostCommentController.java
@@ -58,7 +58,11 @@ public class PostCommentController {
     @Operation(summary = "게시글 댓글 목록 조회", description = "게시글 댓글 목록을 조회한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 댓글 목록 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글")
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+            )
     })
     @GetMapping("/{postId}/comments")
     public ResponseEntity<List<CommentResponse>> getComments(@PathVariable final Long postId) {

--- a/backend/src/main/java/com/votogether/domain/post/controller/PostCommentController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostCommentController.java
@@ -66,7 +66,7 @@ public class PostCommentController {
     })
     @GetMapping("/{postId}/comments")
     public ResponseEntity<List<CommentResponse>> getComments(@PathVariable final Long postId) {
-        List<CommentResponse> response = postCommentService.getComments(postId);
+        final List<CommentResponse> response = postCommentService.getComments(postId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/votogether/domain/post/controller/PostCommentController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostCommentController.java
@@ -3,6 +3,7 @@ package com.votogether.domain.post.controller;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.post.dto.request.CommentRegisterRequest;
 import com.votogether.domain.post.dto.request.CommentUpdateRequest;
+import com.votogether.domain.post.dto.response.CommentResponse;
 import com.votogether.domain.post.service.PostCommentService;
 import com.votogether.exception.ExceptionResponse;
 import com.votogether.global.jwt.Auth;
@@ -14,10 +15,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -50,6 +53,17 @@ public class PostCommentController {
     ) {
         postCommentService.createComment(member, postId, commentRegisterRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "게시글 댓글 목록 조회", description = "게시글 댓글 목록을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 댓글 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글")
+    })
+    @GetMapping("/{postId}/comments")
+    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable final Long postId) {
+        List<CommentResponse> response = postCommentService.getComments(postId);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "게시글 댓글 수정", description = "게시글 댓글을 수정한다.")

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/CommentResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/CommentResponse.java
@@ -1,14 +1,23 @@
 package com.votogether.domain.post.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.post.entity.comment.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "댓글 응답")
 public record CommentResponse(
+        @Schema(description = "댓글 ID", example = "1")
         Long id,
         CommentMember member,
+        @Schema(description = "댓글 내용", example = "재밌어요!")
         String content,
+        @Schema(description = "댓글 작성시각", example = "2023-08-01 10:56")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
         LocalDateTime createdAt,
+        @Schema(description = "댓글 수정시각", example = "2023-08-01 13:56")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
         LocalDateTime updatedAt
 ) {
 
@@ -22,7 +31,13 @@ public record CommentResponse(
         );
     }
 
-    record CommentMember(Long id, String nickname) {
+    @Schema(description = "댓글 작성자 회원 응답")
+    record CommentMember(
+            @Schema(description = "댓글 작성자 회원 ID", example = "1")
+            Long id,
+            @Schema(description = "댓글 작성자 회원 닉네임", example = "votogether")
+            String nickname
+    ) {
 
         public static CommentMember from(final Member member) {
             return new CommentMember(member.getId(), member.getNickname());

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/CommentResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/CommentResponse.java
@@ -10,12 +10,16 @@ import java.time.LocalDateTime;
 public record CommentResponse(
         @Schema(description = "댓글 ID", example = "1")
         Long id,
+
         CommentMember member,
+
         @Schema(description = "댓글 내용", example = "재밌어요!")
         String content,
+
         @Schema(description = "댓글 작성시각", example = "2023-08-01 10:56")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
         LocalDateTime createdAt,
+
         @Schema(description = "댓글 수정시각", example = "2023-08-01 13:56")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
         LocalDateTime updatedAt

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/CommentResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/CommentResponse.java
@@ -1,0 +1,33 @@
+package com.votogether.domain.post.dto.response;
+
+import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.post.entity.comment.Comment;
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        Long id,
+        CommentMember member,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static CommentResponse from(final Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                CommentMember.from(comment.getMember()),
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt()
+        );
+    }
+
+    record CommentMember(Long id, String nickname) {
+
+        public static CommentMember from(final Member member) {
+            return new CommentMember(member.getId(), member.getNickname());
+        }
+
+    }
+
+}

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/PostResponse.java
@@ -24,7 +24,7 @@ public record PostResponse(
 
         return new PostResponse(
                 post.getId(),
-                WriterResponse.of(writer.getId(), writer.getNickname().getValue()),
+                WriterResponse.of(writer.getId(), writer.getNickname()),
                 postBody.getTitle(),
                 postBody.getContent(),
                 getCategories(post),

--- a/backend/src/main/java/com/votogether/domain/post/repository/CommentRepository.java
+++ b/backend/src/main/java/com/votogether/domain/post/repository/CommentRepository.java
@@ -1,7 +1,14 @@
 package com.votogether.domain.post.repository;
 
+import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.comment.Comment;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @EntityGraph(attributePaths = {"member"})
+    List<Comment> findAllByPostOrderByCreatedAtAsc(final Post post);
+
 }

--- a/backend/src/main/java/com/votogether/domain/post/service/PostCommentService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostCommentService.java
@@ -3,6 +3,7 @@ package com.votogether.domain.post.service;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.post.dto.request.CommentRegisterRequest;
 import com.votogether.domain.post.dto.request.CommentUpdateRequest;
+import com.votogether.domain.post.dto.response.CommentResponse;
 import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.comment.Comment;
 import com.votogether.domain.post.exception.CommentExceptionType;
@@ -10,6 +11,7 @@ import com.votogether.domain.post.exception.PostExceptionType;
 import com.votogether.domain.post.repository.CommentRepository;
 import com.votogether.domain.post.repository.PostRepository;
 import com.votogether.exception.NotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +38,17 @@ public class PostCommentService {
                 .build();
 
         post.addComment(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getComments(final Long postId) {
+        final Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException(PostExceptionType.POST_NOT_FOUND));
+
+        return commentRepository.findAllByPostOrderByCreatedAtAsc(post)
+                .stream()
+                .map(CommentResponse::from)
+                .toList();
     }
 
     @Transactional
@@ -68,4 +81,5 @@ public class PostCommentService {
 
         commentRepository.delete(comment);
     }
+
 }

--- a/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
@@ -5,7 +5,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -27,6 +29,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/swagger-ui"
     );
 
+    private static final Map<String, String> MATCH_URI_METHOD = new HashMap<>(
+            Map.ofEntries(
+                    Map.entry("^/posts/.+/comments$", "GET")
+            )
+    );
+
     private final TokenProcessor tokenProcessor;
 
     @Override
@@ -43,8 +51,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        return ALLOWED_URIS.stream().anyMatch(url -> request.getRequestURI().contains(url))
-                || ALLOWED_START_URIS.stream().anyMatch(url -> request.getRequestURI().startsWith(url));
+        return containsAllowedUris(request) || startsWithAllowedStartUris(request) || matchesUriPattern(request);
+    }
+
+    private boolean containsAllowedUris(final HttpServletRequest request) {
+        return ALLOWED_URIS.stream()
+                .anyMatch(url -> request.getRequestURI().contains(url));
+    }
+
+    private boolean startsWithAllowedStartUris(final HttpServletRequest request) {
+        return ALLOWED_START_URIS.stream()
+                .anyMatch(url -> request.getRequestURI().startsWith(url));
+    }
+
+    private boolean matchesUriPattern(final HttpServletRequest request) {
+        return MATCH_URI_METHOD.keySet()
+                .stream()
+                .anyMatch(key -> isMatchUriAndMethod(request, key));
+    }
+
+    private boolean isMatchUriAndMethod(final HttpServletRequest request, final String uriPattern) {
+        return request.getRequestURI().matches(uriPattern)
+                && MATCH_URI_METHOD.get(uriPattern).equalsIgnoreCase(request.getMethod());
     }
 
 }

--- a/backend/src/test/java/com/votogether/domain/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/repository/MemberRepositoryTest.java
@@ -28,7 +28,7 @@ class MemberRepositoryTest {
             Member savedMember = memberRepository.save(MemberFixtures.MALE_20.get());
 
             // when
-            boolean isExist = memberRepository.existsByNickname(savedMember.getNickname());
+            boolean isExist = memberRepository.existsByNickname(new Nickname(savedMember.getNickname()));
 
             // then
             assertThat(isExist).isTrue();

--- a/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
@@ -52,7 +52,7 @@ class MemberServiceTest {
             memberService.changeNickname(member, newNickname);
 
             // then
-            assertThat(member.getNickname().getValue()).isEqualTo(newNickname);
+            assertThat(member.getNickname()).isEqualTo(newNickname);
         }
 
         @ParameterizedTest
@@ -89,7 +89,7 @@ class MemberServiceTest {
             Member member2 = memberRepository.save(MemberFixtures.MALE_30.get());
 
             // when, then
-            assertThatThrownBy(() -> memberService.changeNickname(member1, member2.getNickname().getValue()))
+            assertThatThrownBy(() -> memberService.changeNickname(member1, member2.getNickname()))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 중복된 닉네임이 존재합니다.");
         }

--- a/backend/src/test/java/com/votogether/domain/post/controller/PostCommentControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/controller/PostCommentControllerTest.java
@@ -16,6 +16,7 @@ import com.votogether.domain.post.dto.request.CommentUpdateRequest;
 import com.votogether.domain.post.dto.response.CommentResponse;
 import com.votogether.domain.post.entity.comment.Comment;
 import com.votogether.domain.post.service.PostCommentService;
+import com.votogether.exception.GlobalExceptionHandler;
 import com.votogether.fixtures.MemberFixtures;
 import com.votogether.global.jwt.TokenPayload;
 import com.votogether.global.jwt.TokenProcessor;
@@ -36,7 +37,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.context.WebApplicationContext;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @WebMvcTest(PostCommentController.class)
 class PostCommentControllerTest {
@@ -51,9 +52,12 @@ class PostCommentControllerTest {
     TokenProcessor tokenProcessor;
 
     @BeforeEach
-    void setUp(WebApplicationContext webApplicationContext) {
-        RestAssuredMockMvc.standaloneSetup(new PostCommentController(postCommentService));
-        RestAssuredMockMvc.webAppContextSetup(webApplicationContext);
+    void setUp() {
+        RestAssuredMockMvc.standaloneSetup(
+                MockMvcBuilders
+                        .standaloneSetup(new PostCommentController(postCommentService))
+                        .setControllerAdvice(GlobalExceptionHandler.class)
+        );
     }
 
     @Nested
@@ -185,7 +189,7 @@ class PostCommentControllerTest {
 
             // when
             List<CommentResponse> response = RestAssuredMockMvc.given().log().all()
-                    .headers(HttpHeaders.AUTHORIZATION, "Bearer token")
+                    //.headers(HttpHeaders.AUTHORIZATION, "Bearer token")
                     .when().get("/posts/{postId}/comments", 1L)
                     .then().log().all()
                     .status(HttpStatus.OK)

--- a/backend/src/test/java/com/votogether/domain/post/controller/PostCommentControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/controller/PostCommentControllerTest.java
@@ -18,6 +18,7 @@ import com.votogether.domain.post.entity.comment.Comment;
 import com.votogether.domain.post.service.PostCommentService;
 import com.votogether.exception.GlobalExceptionHandler;
 import com.votogether.fixtures.MemberFixtures;
+import com.votogether.global.jwt.JwtAuthenticationFilter;
 import com.votogether.global.jwt.TokenPayload;
 import com.votogether.global.jwt.TokenProcessor;
 import io.restassured.common.mapper.TypeRef;
@@ -57,6 +58,7 @@ class PostCommentControllerTest {
                 MockMvcBuilders
                         .standaloneSetup(new PostCommentController(postCommentService))
                         .setControllerAdvice(GlobalExceptionHandler.class)
+                        .addFilters(new JwtAuthenticationFilter(tokenProcessor))
         );
     }
 

--- a/backend/src/test/java/com/votogether/domain/post/controller/PostCommentControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/controller/PostCommentControllerTest.java
@@ -21,6 +21,7 @@ import com.votogether.global.jwt.TokenPayload;
 import com.votogether.global.jwt.TokenProcessor;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -174,6 +175,10 @@ class PostCommentControllerTest {
                     .member(memberB)
                     .content("commentA")
                     .build();
+            LocalDateTime now = LocalDateTime.now();
+            ReflectionTestUtils.setField(commentA, "createdAt", now);
+            ReflectionTestUtils.setField(commentB, "createdAt", now);
+
             CommentResponse commentResponseA = CommentResponse.from(commentA);
             CommentResponse commentResponseB = CommentResponse.from(commentB);
             given(postCommentService.getComments(anyLong())).willReturn(List.of(commentResponseA, commentResponseB));
@@ -189,7 +194,9 @@ class PostCommentControllerTest {
                     });
 
             // then
-            assertThat(response).usingRecursiveComparison().isEqualTo(List.of(commentResponseA, commentResponseB));
+            assertThat(response).usingRecursiveComparison()
+                    .ignoringFieldsOfTypes(LocalDateTime.class)
+                    .isEqualTo(List.of(commentResponseA, commentResponseB));
         }
 
     }

--- a/backend/src/test/java/com/votogether/domain/post/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/repository/CommentRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.votogether.domain.post.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.votogether.RepositoryTest;
+import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.member.repository.MemberRepository;
+import com.votogether.domain.post.entity.Post;
+import com.votogether.domain.post.entity.PostBody;
+import com.votogether.domain.post.entity.comment.Comment;
+import com.votogether.fixtures.MemberFixtures;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+class CommentRepositoryTest {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Test
+    @DisplayName("게시글의 댓글 목록을 조회한다.")
+    void findAllByPost() {
+        // given
+        Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+        Post post = postRepository.save(
+                Post.builder()
+                        .writer(member)
+                        .postBody(PostBody.builder().title("titleA").content("contentA").build())
+                        .deadline(LocalDateTime.of(2100, 7, 12, 0, 0))
+                        .build()
+        );
+        Comment commentA = commentRepository.save(
+                Comment.builder()
+                        .member(member)
+                        .post(post)
+                        .content("commentA")
+                        .build()
+        );
+        Comment commentB = commentRepository.save(
+                Comment.builder()
+                        .member(member)
+                        .post(post)
+                        .content("commentB")
+                        .build()
+        );
+
+        // when
+        List<Comment> result = commentRepository.findAllByPostOrderByCreatedAtAsc(post);
+
+        // then
+        assertThat(result).containsExactly(commentA, commentB);
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #129

## 📝 작업 요약

게시글에 대한 댓글 목록 조회 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- 게시글에 대한 댓글 목록 조회 기능을 구현하였습니다.
- `@EntityGraph`를 사용하여 댓글 응답 시 항상 필요한 회원을 fetch join해서 가져오도록 하였습니다.

## 🌟 논의 사항

`LocalDateTime`이 응답으로 반환될 때 `@JsonFormat`을 사용하기에 `yyyy-MM-dd HH:mm`과 같은 형식으로 반환되는데 이걸 깔끔하게 테스트할 수 있는 방법이 떠오르지 않아요 ㅜ 도와주세요 고수분들