### PR TITLE
테스트 실패로 인해 빌드가 안되는 문제 수정

### DIFF
--- a/frontend/__test__/hooks/useMoreComment.test.tsx
+++ b/frontend/__test__/hooks/useMoreComment.test.tsx
@@ -3,24 +3,24 @@ import { act } from 'react-dom/test-utils';
 
 import { useMoreComment } from '@hooks/useMoreComment';
 
-import { MOCK_COMMENT_LIST } from '@mocks/mockData/comment';
+import { MOCK_TRANSFORMED_COMMENT_LIST } from '@mocks/mockData/comment';
 
 describe(`useMoreComment 훅에서 댓글 리스트를 입력받고, 10개 단위로 자른 댓글 리스트를 반환한다. 
 더보기를 했을 때 10개 단위로 추가된다. 더 이상 보여줄 댓글이 없다면 더 이상 데이터를 자를 수 없다고 boolean 변수를 반환한다.`, () => {
   test('테스트에 사용되는 댓글 리스트의 개수는 20개 이상이다', () => {
-    expect(MOCK_COMMENT_LIST.length).toBeGreaterThan(20);
+    expect(MOCK_TRANSFORMED_COMMENT_LIST.length).toBeGreaterThan(20);
   });
 
   test('댓글 리스트를 입력받고, 10개 단위로 보여준다. ', () => {
-    const { result } = renderHook(() => useMoreComment(MOCK_COMMENT_LIST));
+    const { result } = renderHook(() => useMoreComment(MOCK_TRANSFORMED_COMMENT_LIST));
 
     const { slicedCommentList } = result.current;
 
-    expect(slicedCommentList).toEqual(MOCK_COMMENT_LIST.slice(0, 10));
+    expect(slicedCommentList).toEqual(MOCK_TRANSFORMED_COMMENT_LIST.slice(0, 10));
   });
 
   test('더보기를 했을 때 10개 단위로 댓글 리스트에 추가된다.', () => {
-    const { result } = renderHook(() => useMoreComment(MOCK_COMMENT_LIST));
+    const { result } = renderHook(() => useMoreComment(MOCK_TRANSFORMED_COMMENT_LIST));
 
     const { handleMoreComment } = result.current;
 
@@ -30,11 +30,11 @@ describe(`useMoreComment 훅에서 댓글 리스트를 입력받고, 10개 단�
 
     const { slicedCommentList } = result.current;
 
-    expect(slicedCommentList).toEqual(MOCK_COMMENT_LIST.slice(0, 20));
+    expect(slicedCommentList).toEqual(MOCK_TRANSFORMED_COMMENT_LIST.slice(0, 20));
   });
 
   test('10개 초과의 댓글 리스트가 있을 때 hasMoreComment를 true로 반환한다.', () => {
-    const { result } = renderHook(() => useMoreComment(MOCK_COMMENT_LIST));
+    const { result } = renderHook(() => useMoreComment(MOCK_TRANSFORMED_COMMENT_LIST));
 
     const { hasMoreComment } = result.current;
 
@@ -42,7 +42,7 @@ describe(`useMoreComment 훅에서 댓글 리스트를 입력받고, 10개 단�
   });
 
   test('10개의 댓글 리스트가 있을 때 hasMoreComment를 false로 반환한다.', () => {
-    const TEN_LENGTH_COMMENT_LIST = MOCK_COMMENT_LIST.slice(0, 10);
+    const TEN_LENGTH_COMMENT_LIST = MOCK_TRANSFORMED_COMMENT_LIST.slice(0, 10);
 
     const { result } = renderHook(() => useMoreComment(TEN_LENGTH_COMMENT_LIST));
 
@@ -52,7 +52,7 @@ describe(`useMoreComment 훅에서 댓글 리스트를 입력받고, 10개 단�
   });
 
   test('15개의 댓글 리스트가 있을 때 더보기를 하고 나면 hasMoreComment를 false로 반환한다.', () => {
-    const FIFTEEN_LENGTH_COMMENT_LIST = MOCK_COMMENT_LIST.slice(0, 15);
+    const FIFTEEN_LENGTH_COMMENT_LIST = MOCK_TRANSFORMED_COMMENT_LIST.slice(0, 15);
 
     const { result } = renderHook(() => useMoreComment(FIFTEEN_LENGTH_COMMENT_LIST));
 


### PR DESCRIPTION


## 🔥 연관 이슈

close: #193 

## 📝 작업 요약

- 테스트 실패로 인해 빌드가 안되는 문제 해결
- useMoreComment.test.ts 에서 MOCK_COMMENT_LIST => MOCK_TRANSFORMED_COMMENT_LIST로 변경
- 목 데이터를 서버의 댓글 리스트에서 클라이언트에서 사용하는 댓글 리스트로 변경
