### PR TITLE
게시글 타입 수정에 따른 반영이 되지 않아 게시글 컴포넌트에서 발생하는 오류 수정

### DIFF
--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -57,8 +57,8 @@ export default function Post({ postInfo, isPreview }: PostProps) {
         <S.Wrapper>
           <span aria-label="작성자">{writer.nickname}</span>
           <S.Wrapper>
-            <span aria-label="작성일시">{startTime}</span>
-            <span aria-label="투표 마감일시">{endTime}</span>
+            <span aria-label="작성일시">{createTime}</span>
+            <span aria-label="투표 마감일시">{deadline}</span>
           </S.Wrapper>
         </S.Wrapper>
         <S.Content aria-label="내용" $isPreview={isPreview}>

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -22,7 +22,7 @@ export default function MyInfo() {
 
   if (!userInfo) {
     navigate('/');
-    return;
+    return <></>;
   }
 
   return (


### PR DESCRIPTION
## 🔥 연관 이슈

close: #223

## 📝 작업 요약
게시글 타입 수정에 따른 반영이 되지 않아 게시글 컴포넌트에서 발생하는 오류 수정

## 🔎 작업 상세 설명
다른 pr에서 게시글 타입 중 startTime, endTime을 creatTime, deadline으로 수정
이 부분이 반영이 되지 않아 오류 발생

## 🌟 논의 사항

크루들과 이야기 해보고 싶은 부분을 적어주세요.
