### PR TITLE
게시글 생성, 투표지 선택 시 새로 고침해야 적용되는 버그

### DIFF
--- a/frontend/__test__/hooks/query/useCreateVote.test.tsx
+++ b/frontend/__test__/hooks/query/useCreateVote.test.tsx
@@ -1,0 +1,30 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useCreateVote } from '@hooks/query/post/useCreateVote';
+
+import { MOCK_POST_INFO } from '@mocks/mockData/post';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useCreateVote 훅이 선택지를 생성하는 지 확인한다.', () => {
+  test('선택지를 변경한다.', async () => {
+    const { result } = renderHook(() => useCreateVote({ isPreview: false, postId: 1 }), {
+      wrapper,
+    });
+
+    const { mutate } = result.current;
+
+    await waitFor(() => {
+      mutate(1);
+
+      expect(MOCK_POST_INFO.voteInfo.selectedOptionId).toBe(999);
+    });
+  });
+});

--- a/frontend/__test__/hooks/query/useEditVote.test.tsx
+++ b/frontend/__test__/hooks/query/useEditVote.test.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useEditVote } from '@hooks/query/post/useEditVote';
+
+import { MOCK_POST_INFO } from '@mocks/mockData/post';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useEditVote 훅이 선택지를 바꾸는 지 확인한다.', () => {
+  test('선택지를 변경한다.', async () => {
+    const { result } = renderHook(() => useEditVote({ isPreview: false, postId: 1 }), {
+      wrapper,
+    });
+
+    const { mutate } = result.current;
+
+    await waitFor(() => {
+      mutate({
+        newOptionId: 1,
+        originOptionId: 2,
+      });
+
+      expect(MOCK_POST_INFO.voteInfo.selectedOptionId).toBe(888);
+    });
+  });
+});

--- a/frontend/src/api/post.ts
+++ b/frontend/src/api/post.ts
@@ -42,7 +42,7 @@ export const votePost = async (postId: number, optionId: number) => {
   return await postFetch(`${BASE_URL}/posts/${postId}/options/${optionId}`, '');
 };
 
-interface OptionData {
+export interface OptionData {
   originOptionId: number;
   newOptionId: number;
 }

--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -1,6 +1,7 @@
 import { PostInfo } from '@type/post';
 
-import { changeVotedOption, votePost } from '@api/post';
+import { useCreateVote } from '@hooks/query/post/useCreateVote';
+import { useEditVote } from '@hooks/query/post/useEditVote';
 
 import WrittenVoteOptionList from '@components/optionList/WrittenVoteOptionList';
 
@@ -16,16 +17,17 @@ interface PostProps {
 
 export default function Post({ postInfo, isPreview }: PostProps) {
   const { postId, category, title, writer, createTime, deadline, content, voteInfo } = postInfo;
-
+  const { mutate: createVote } = useCreateVote({ isPreview, postId });
+  const { mutate: editVote } = useEditVote({ isPreview, postId });
   const handleVoteClick = (newOptionId: number) => {
     if (voteInfo.selectedOptionId === newOptionId) return;
 
     if (voteInfo.selectedOptionId === POST.NOT_VOTE) {
-      votePost(postId, newOptionId);
+      createVote(newOptionId);
       return;
     }
 
-    changeVotedOption(postId, {
+    editVote({
       originOptionId: voteInfo.selectedOptionId,
       newOptionId,
     });

--- a/frontend/src/constants/post.ts
+++ b/frontend/src/constants/post.ts
@@ -51,3 +51,7 @@ export const POST_DESCRIPTION_MAX_LENGTH = 1000;
 export const SEARCH_KEYWORD_MAX_LENGTH = 100;
 
 export const POST_LIST_MAX_LENGTH = 10;
+
+export const DEFAULT_CATEGORY_ID = 0;
+
+export const DEFAULT_KEYWORD = '';

--- a/frontend/src/constants/queryKey.ts
+++ b/frontend/src/constants/queryKey.ts
@@ -1,5 +1,6 @@
 export const QUERY_KEY = {
   POSTS: 'posts',
+  POST_DETAIL: 'postDetail',
   COMMENTS: 'comments',
   CATEGORIES: 'categories',
   USER_INFO: 'user_info',

--- a/frontend/src/hooks/query/post/useCreatePost.ts
+++ b/frontend/src/hooks/query/post/useCreatePost.ts
@@ -2,13 +2,20 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { createPost } from '@api/post';
 
+import { DEFAULT_CATEGORY_ID, DEFAULT_KEYWORD, SORTING, STATUS } from '@constants/post';
 import { QUERY_KEY } from '@constants/queryKey';
 
 export const useCreatePost = () => {
   const queryClient = useQueryClient();
   const { mutate, isLoading, isError, error } = useMutation((post: FormData) => createPost(post), {
     onSuccess: () => {
-      queryClient.invalidateQueries([QUERY_KEY.POSTS]);
+      queryClient.invalidateQueries([
+        QUERY_KEY.POSTS,
+        SORTING.LATEST,
+        STATUS.PROGRESS,
+        DEFAULT_CATEGORY_ID,
+        DEFAULT_KEYWORD,
+      ]);
     },
     onError: error => {
       window.console.log('createPost error', error);

--- a/frontend/src/hooks/query/post/useCreateVote.ts
+++ b/frontend/src/hooks/query/post/useCreateVote.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { votePost } from '@api/post';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useCreateVote = ({ isPreview, postId }: { isPreview: boolean; postId: number }) => {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: (optionId: number) => votePost(postId, optionId),
+    onSuccess: () => {
+      if (isPreview) {
+        queryClient.invalidateQueries({
+          predicate: ({ queryKey }) => queryKey[0] === QUERY_KEY.POSTS,
+        });
+        return;
+      }
+
+      queryClient.invalidateQueries([QUERY_KEY.POST_DETAIL, postId]);
+    },
+    onError: error => {
+      window.console.log('투표 선택지 생성에 실패했습니다.', error);
+    },
+  });
+
+  return { mutate };
+};

--- a/frontend/src/hooks/query/post/useEditVote.ts
+++ b/frontend/src/hooks/query/post/useEditVote.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { OptionData, changeVotedOption } from '@api/post';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useEditVote = ({ isPreview, postId }: { isPreview: boolean; postId: number }) => {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: (optionData: OptionData) => changeVotedOption(postId, optionData),
+    onSuccess: () => {
+      if (isPreview) {
+        queryClient.invalidateQueries({
+          predicate: ({ queryKey }) => queryKey[0] === QUERY_KEY.POSTS,
+        });
+        return;
+      }
+
+      queryClient.invalidateQueries([QUERY_KEY.POST_DETAIL, postId]);
+    },
+    onError: error => {
+      window.console.log('투표 선택지 생성에 실패했습니다.', error);
+    },
+  });
+
+  return { mutate };
+};

--- a/frontend/src/hooks/query/usePostList.tsx
+++ b/frontend/src/hooks/query/usePostList.tsx
@@ -5,6 +5,7 @@ import { PostList, PostListByOptionalOption, PostListByRequiredOption } from '@t
 import { getPostList } from '@api/postList';
 
 import { POST_LIST_MAX_LENGTH } from '@constants/post';
+import { QUERY_KEY } from '@constants/queryKey';
 
 export const usePostList = (
   requiredOption: Omit<PostListByRequiredOption, 'pageNumber'>,
@@ -15,7 +16,7 @@ export const usePostList = (
 
   const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteQuery<PostList>(
-      ['posts', postSorting, postStatus, categoryId, keyword],
+      [QUERY_KEY.POSTS, postSorting, postStatus, categoryId, keyword],
       ({ pageParam = 0 }) =>
         getPostList({ ...requiredOption, pageNumber: pageParam }, optionalOption),
       {

--- a/frontend/src/hooks/usePostRequestInfo.ts
+++ b/frontend/src/hooks/usePostRequestInfo.ts
@@ -3,7 +3,13 @@ import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { PostRequestKind } from '@components/post/PostListPage/types';
 
 import { PATH } from '@constants/path';
-import { POST_TYPE, SEARCH_KEYWORD, SEARCH_KEYWORD_MAX_LENGTH } from '@constants/post';
+import {
+  DEFAULT_CATEGORY_ID,
+  DEFAULT_KEYWORD,
+  POST_TYPE,
+  SEARCH_KEYWORD,
+  SEARCH_KEYWORD_MAX_LENGTH,
+} from '@constants/post';
 
 import { getPathFragment } from '@utils/getPathFragment';
 
@@ -20,9 +26,10 @@ export const usePostRequestInfo = () => {
   const [searchParams] = useSearchParams();
   const { pathname } = useLocation();
 
-  const categoryId = Number(params.categoryId ?? 0);
+  const categoryId = Number(params.categoryId ?? DEFAULT_CATEGORY_ID);
   const keyword =
-    searchParams.get(SEARCH_KEYWORD)?.toString().slice(0, SEARCH_KEYWORD_MAX_LENGTH) ?? '';
+    searchParams.get(SEARCH_KEYWORD)?.toString().slice(0, SEARCH_KEYWORD_MAX_LENGTH) ??
+    DEFAULT_KEYWORD;
   const convertedPathname = getPathFragment(pathname);
   const postType = REQUEST_URL[convertedPathname];
 

--- a/frontend/src/mocks/vote.ts
+++ b/frontend/src/mocks/vote.ts
@@ -4,14 +4,19 @@ import { MOCK_POST_INFO } from './mockData/post';
 
 export const mockVote = [
   //투표
-  rest.post(`/posts/:postId/options/:optionId`, (req, res, ctx) => {
-    MOCK_POST_INFO.voteInfo.selectedOptionId = 999;
+  rest.post(
+    `${process.env.VOTOGETHER_BASE_URL}/posts/:postId/options/:optionId`,
+    (req, res, ctx) => {
+      MOCK_POST_INFO.voteInfo.selectedOptionId = 999;
 
-    return res(ctx.status(200), ctx.json({ message: 'ok' }));
-  }),
+      return res(ctx.status(200), ctx.json({ message: 'ok' }));
+    }
+  ),
 
   //선택지 수정
-  rest.patch(`/posts/:postId/options`, (req, res, ctx) => {
+  rest.patch(`${process.env.VOTOGETHER_BASE_URL}/posts/:postId/options`, (req, res, ctx) => {
+    MOCK_POST_INFO.voteInfo.selectedOptionId = 888;
+
     return res(ctx.status(200), ctx.json({ message: 'ok' }));
   }),
 ];

--- a/frontend/src/mocks/vote.ts
+++ b/frontend/src/mocks/vote.ts
@@ -1,8 +1,12 @@
 import { rest } from 'msw';
 
+import { MOCK_POST_INFO } from './mockData/post';
+
 export const mockVote = [
   //투표
   rest.post(`/posts/:postId/options/:optionId`, (req, res, ctx) => {
+    MOCK_POST_INFO.voteInfo.selectedOptionId = 999;
+
     return res(ctx.status(200), ctx.json({ message: 'ok' }));
   }),
 

--- a/frontend/src/utils/fetch.ts
+++ b/frontend/src/utils/fetch.ts
@@ -1,7 +1,6 @@
 import { getCookieToken } from './cookie';
 
 const headers = {
-  'Content-Type': 'application/json;charset=utf-8',
   Authorization: `Bearer `,
 };
 
@@ -44,11 +43,11 @@ export const postFetch = async <T, R>(url: string, body: T): Promise<R | void> =
     headers: makeFetchHeaders(),
   });
 
-  const data = await response.json();
-
   if (!response.ok) {
-    throw new Error(data.message);
+    throw new Error('에러');
   }
+
+  const data = await response.json();
 
   return data;
 };
@@ -76,10 +75,8 @@ export const patchFetch = async <T>(url: string, body?: T) => {
     body: JSON.stringify(body),
   });
 
-  const data = await response.json();
-
   if (!response.ok) {
-    throw new Error(data.message);
+    throw new Error('에러');
   }
 
   return response;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #220 

## 📝 작업 요약

- 게시글 생성 후 게시글 목록 페이지로 이동하는데 새로 고침을 해야 게시글이 보이는 버그 수정
- 투표지 선택 후 새로 고침을 해야 투표지 선택이 반영되는 버그 수정

## 🔎 작업 상세 설명

- 포스트 생성 후 리엑트 쿼리를 통한 캐시 메모리를 초기화한다.
- 투표지 선택 후 리엑트 쿼리를 통해 캐시 메모리를 초기화한다.

## 🌟 논의 사항

투표지 선택 후 낙관적 업데이트는 어려운 작업인 것 같아 다음 기회로 미뤄보려고 합니다
