### PR TITLE
글 상세 페이지에 댓글 관련 컴포넌트 추가 및 댓글 CRUD API 연동 

### DIFF
--- a/frontend/src/api/comment.ts
+++ b/frontend/src/api/comment.ts
@@ -2,6 +2,8 @@ import { Comment, CommentRequest, CommentResponse } from '@type/comment';
 
 import { getFetch, postFetch, putFetch, deleteFetch } from '@utils/fetch';
 
+const BASE_URL = process.env.VOTOGETHER_BASE_URL;
+
 export const transformCommentListResponse = (commentList: CommentResponse[]): Comment[] => {
   return commentList.map(comment => ({
     id: comment.id,
@@ -13,13 +15,13 @@ export const transformCommentListResponse = (commentList: CommentResponse[]): Co
 };
 
 export const getCommentList = async (postId: number): Promise<Comment[]> => {
-  const commentList = await getFetch<CommentResponse[]>(`/posts/${postId}/comments`);
+  const commentList = await getFetch<CommentResponse[]>(`${BASE_URL}/posts/${postId}/comments`);
 
   return transformCommentListResponse(commentList);
 };
 
 export const createComment = async (postId: number, newComment: CommentRequest) => {
-  return await postFetch(`/posts/${postId}/comments`, newComment);
+  return await postFetch(`${BASE_URL}/posts/${postId}/comments`, newComment);
 };
 
 export const editComment = async (
@@ -27,9 +29,9 @@ export const editComment = async (
   commentId: number,
   updatedComment: CommentRequest
 ) => {
-  return await putFetch(`/posts/${postId}/comments/${commentId}`, updatedComment);
+  return await putFetch(`${BASE_URL}/posts/${postId}/comments/${commentId}`, updatedComment);
 };
 
 export const deleteComment = async (postId: number, commentId: number) => {
-  return await deleteFetch(`/posts/${postId}/comments/${commentId}`);
+  return await deleteFetch(`${BASE_URL}/posts/${postId}/comments/${commentId}`);
 };

--- a/frontend/src/components/comment/CommentList/CommentItem/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentItem/index.tsx
@@ -74,7 +74,11 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
       </S.Header>
       {action === COMMENT_ACTION.EDIT ? (
         <S.TextFormWrapper>
-          <CommentTextForm initialComment={content} handleCancelClick={handleCancelClick} />
+          <CommentTextForm
+            commentId={-1}
+            initialComment={content}
+            handleCancelClick={handleCancelClick}
+          />
         </S.TextFormWrapper>
       ) : (
         <S.Description>{content}</S.Description>

--- a/frontend/src/components/comment/CommentList/CommentItem/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentItem/index.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { Comment } from '@type/comment';
 
+import { useDeleteComment } from '@hooks/query/comment/useDeleteComment';
 import { useToggle } from '@hooks/useToggle';
 
 import CommentDeleteModal from '@components/comment/CommentDeleteModal';
@@ -27,6 +29,11 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
   const { member, content, createdAt, isEdit } = comment;
   const [action, setAction] = useState<CommentAction | null>(null);
 
+  const params = useParams() as { postId: string };
+  const postId = Number(params.postId);
+
+  const { mutate } = useDeleteComment(postId, comment.id);
+
   const handleMenuClick = (menu: CommentAction) => {
     closeComponent();
     setAction(menu);
@@ -34,6 +41,10 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
 
   const handleCancelClick = () => {
     setAction(null);
+  };
+
+  const handleDeleteClick = () => {
+    mutate();
   };
 
   const USER_TYPE = COMMENT_USER_MENU[userType];
@@ -69,7 +80,10 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
         <S.Description>{content}</S.Description>
       )}
       {action === COMMENT_ACTION.DELETE && (
-        <CommentDeleteModal handleCancelClick={handleCancelClick} handleDeleteClick={() => {}} />
+        <CommentDeleteModal
+          handleCancelClick={handleCancelClick}
+          handleDeleteClick={handleDeleteClick}
+        />
       )}
       {action === COMMENT_ACTION.USER_REPORT && (
         <UserReportModal handleCancelClick={handleCancelClick} />

--- a/frontend/src/components/comment/CommentList/CommentTextForm/CommentTextForm.stories.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/CommentTextForm.stories.tsx
@@ -12,12 +12,13 @@ export default meta;
 type Story = StoryObj<typeof CommentTextForm>;
 
 export const InitForm: Story = {
-  render: () => <CommentTextForm initialComment="" />,
+  render: () => <CommentTextForm commentId={-1} initialComment="" />,
 };
 
 export const EditForm: Story = {
   render: () => (
     <CommentTextForm
+      commentId={MOCK_TRANSFORMED_COMMENT_LIST[0].id}
       initialComment={MOCK_TRANSFORMED_COMMENT_LIST[0].content}
       handleCancelClick={() => {}}
     />

--- a/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
@@ -1,5 +1,8 @@
 import { ChangeEvent } from 'react';
+import { useParams } from 'react-router-dom';
 
+import { useCreateComment } from '@hooks/query/comment/useCreateComment';
+import { useEditComment } from '@hooks/query/comment/useEditComment';
 import { useText } from '@hooks/useText';
 
 import SquareButton from '@components/common/SquareButton';
@@ -9,20 +12,36 @@ import { COMMENT_MAX_LENGTH } from '@constants/comment';
 import * as S from './style';
 
 interface CommentTextFormProps {
+  commentId: number;
   initialComment: string;
   handleCancelClick?: () => void;
 }
 
 export default function CommentTextForm({
+  commentId,
   initialComment,
   handleCancelClick,
 }: CommentTextFormProps) {
-  const { handleTextChange, text } = useText(initialComment);
+  const { handleTextChange, text: content } = useText(initialComment);
+
+  const params = useParams() as { postId: string };
+  const postId = Number(params.postId);
+
+  const { mutate: createComment } = useCreateComment(postId);
+  const { mutate: editComment } = useEditComment(postId, commentId, { content: initialComment });
+
+  const updateComment = initialComment
+    ? () => {
+        editComment();
+      }
+    : () => {
+        createComment({ content });
+      };
 
   return (
     <S.Container>
       <S.TextArea
-        value={text}
+        value={content}
         onChange={(e: ChangeEvent<HTMLTextAreaElement>) => handleTextChange(e, COMMENT_MAX_LENGTH)}
       />
       <S.ButtonContainer>
@@ -34,7 +53,7 @@ export default function CommentTextForm({
           </S.ButtonWrapper>
         )}
         <S.ButtonWrapper>
-          <SquareButton theme="blank" type="button">
+          <SquareButton onClick={() => updateComment()} theme="blank" type="button">
             저장
           </SquareButton>
         </S.ButtonWrapper>

--- a/frontend/src/components/comment/CommentList/index.tsx
+++ b/frontend/src/components/comment/CommentList/index.tsx
@@ -45,7 +45,7 @@ export default function CommentList({
         {isGuest ? (
           <CommentLoginSection name={postWriterName} />
         ) : (
-          <CommentTextForm initialComment="" />
+          <CommentTextForm commentId={-1} initialComment="" />
         )}
       </S.TextOrLoginWrapper>
       <S.ListContainer>

--- a/frontend/src/constants/queryKey.ts
+++ b/frontend/src/constants/queryKey.ts
@@ -1,5 +1,6 @@
 export const QUERY_KEY = {
   POSTS: 'posts',
+  POST_DETAIL: 'postDetail',
   COMMENTS: 'comments',
   CATEGORIES: 'categories',
   USER_INFO: 'user_info',

--- a/frontend/src/hooks/query/comment/useEditComment.ts
+++ b/frontend/src/hooks/query/comment/useEditComment.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { CommentRequest } from '@type/comment';
+import { CommentRequest, CommentResponse } from '@type/comment';
 
 import { editComment } from '@api/comment';
 
@@ -21,17 +21,22 @@ export const useEditComment = (
         // 댓글 데이터에 대한 모든 퀴리요청을 취소하여 이전 서버 데이터가 낙관적 업데이트를 덮어쓰지 않도록 함 -> refetch 취소시킴
         await queryClient.cancelQueries(queryKey);
 
-        const oldComment = queryClient.getQueryData(queryKey); // 기존 댓글 데이터의 snapshot
+        const oldCommentList: CommentResponse[] | undefined = queryClient.getQueryData(queryKey); // 기존 댓글 데이터의 snapshot
+        window.console.log('기존 댓글 데이터: ', oldCommentList);
 
-        window.console.log('기존 댓글 데이터: ', oldComment);
+        if (oldCommentList) {
+          const updatedCommentList = oldCommentList.map(comment => {
+            if (comment.id === commentId) return updatedComment;
+          });
 
-        queryClient.setQueryData(queryKey, updatedComment); // 낙관적 업데이트 실시
+          queryClient.setQueryData(queryKey, updatedCommentList); // 낙관적 업데이트 실시
 
-        return { oldComment, updatedComment }; // context를 return, context 예시에는 이전 스냅샷, 새로운 값(또는 롤백하는 함수)이 있음
+          return { oldCommentList, updatedCommentList }; // context를 return, context 예시에는 이전 스냅샷, 새로운 값(또는 롤백하는 함수)이 있음
+        }
       },
       onError: (error, _, context) => {
         // 캐시를 저장된 값으로 롤백
-        queryClient.setQueryData(queryKey, context?.oldComment);
+        queryClient.setQueryData(queryKey, context?.oldCommentList);
         window.console.log('댓글 수정에 실패했습니다. 다시 시도해주세요.', error);
       },
       onSuccess: () => {

--- a/frontend/src/hooks/query/post/usePostDetail.ts
+++ b/frontend/src/hooks/query/post/usePostDetail.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { PostInfo } from '@type/post';
+
+import { getPost } from '@api/post';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const usePostDetail = (postId: number) => {
+  const { data, error, isLoading } = useQuery<PostInfo>(
+    [QUERY_KEY.POST_DETAIL, postId],
+    () => getPost(postId),
+    {
+      onSuccess: data => {
+        return data;
+      },
+      onError: error => {
+        window.console.error(error);
+      },
+    }
+  );
+
+  return { data, error, isLoading };
+};

--- a/frontend/src/mocks/comment.ts
+++ b/frontend/src/mocks/comment.ts
@@ -3,7 +3,7 @@ import { rest } from 'msw';
 import { MOCK_COMMENT_LIST } from './mockData/comment';
 
 export const mockComment = [
-  rest.get('/posts/:postId/comments', (req, res, ctx) => {
+  rest.get(`${process.env.VOTOGETHER_BASE_URL}/posts/:postId/comments`, (req, res, ctx) => {
     return res(ctx.delay(1000), ctx.status(200), ctx.json(MOCK_COMMENT_LIST));
   }),
 

--- a/frontend/src/pages/post/PostDetail/index.tsx
+++ b/frontend/src/pages/post/PostDetail/index.tsx
@@ -10,6 +10,7 @@ import Layout from '@components/common/Layout';
 import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
 import Post from '@components/common/Post';
 
+import { getCookieToken, getMemberId } from '@utils/cookie';
 import { checkClosedPost } from '@utils/time';
 
 import BottomButtonPart from './BottomButtonPart';
@@ -22,7 +23,9 @@ export default function PostDetailPage() {
   const params = useParams() as { postId: string };
   const postId = Number(params.postId);
 
-  const userId = 12121221;
+  const token = getCookieToken().accessToken;
+  const decodedPayload = getMemberId(token);
+  const memberId = decodedPayload.memberId;
 
   const { data: postData, errorMessage, isLoading, refetch } = useFetch(() => getPost(postId));
   const { data: commentData, isLoading: isCommentLoading } = useCommentList(postId);
@@ -49,7 +52,7 @@ export default function PostDetailPage() {
   }
 
   window.console.log(postData);
-  const isWriter = postData.writer.id === userId;
+  const isWriter = postData.writer.id === memberId;
   const isClosed = checkClosedPost(postData.deadline);
 
   const movePage = {
@@ -108,7 +111,7 @@ export default function PostDetailPage() {
         {!isCommentLoading && commentData && (
           <CommentList
             commentList={commentData}
-            memberId={userId}
+            memberId={memberId}
             isGuest={false}
             postWriterName={'익명의손님1'}
           />

--- a/frontend/src/pages/post/PostDetail/index.tsx
+++ b/frontend/src/pages/post/PostDetail/index.tsx
@@ -1,13 +1,14 @@
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { useCommentList } from '@hooks/query/comment/useCommentList';
 import { useFetch } from '@hooks/useFetch';
 
 import { getPost, removePost, setEarlyClosePost } from '@api/post';
 
+import CommentList from '@components/comment/CommentList';
 import Layout from '@components/common/Layout';
 import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
 import Post from '@components/common/Post';
-import { MOCK_NOT_VOTE_POST } from '@components/common/Post/mockData';
 
 import { checkClosedPost } from '@utils/time';
 
@@ -24,6 +25,8 @@ export default function PostDetailPage() {
   const userId = 12121221;
 
   const { data: postData, errorMessage, isLoading, refetch } = useFetch(() => getPost(postId));
+  const { data: commentData, isLoading: isCommentLoading } = useCommentList(postId);
+  // const { data: userInfo, isLoading: isUserInfoLoading, error } = useUserInfo(isLoggedIn);
 
   if (!postData) {
     return (
@@ -45,6 +48,7 @@ export default function PostDetailPage() {
     return <div>로딩중</div>;
   }
 
+  window.console.log(postData);
   const isWriter = postData.writer.id === userId;
   const isClosed = checkClosedPost(postData.deadline);
 
@@ -95,12 +99,20 @@ export default function PostDetailPage() {
         </NarrowTemplateHeader>
       </S.HeaderContainer>
       <S.Container>
-        <Post postInfo={MOCK_NOT_VOTE_POST} isPreview={false} />
+        <Post postInfo={postData} isPreview={false} />
         <BottomButtonPart
           isClosed={isClosed}
           isWriter={isWriter}
           handleEvent={{ movePage, controlPost }}
         />
+        {!isCommentLoading && commentData && (
+          <CommentList
+            commentList={commentData}
+            memberId={userId}
+            isGuest={false}
+            postWriterName={'익명의손님1'}
+          />
+        )}
       </S.Container>
     </Layout>
   );

--- a/frontend/src/utils/cookie/index.ts
+++ b/frontend/src/utils/cookie/index.ts
@@ -15,3 +15,17 @@ export function getCookieToken() {
   });
   return cookieContent as Record<CookieKey, any>;
 }
+
+interface MemberPayload {
+  memberId: number;
+  iat: number;
+  exp: number;
+}
+
+export function getMemberId(token: string): MemberPayload {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const decodedData = JSON.parse(atob(base64));
+
+  return decodedData;
+}

--- a/frontend/src/utils/fetch.ts
+++ b/frontend/src/utils/fetch.ts
@@ -28,11 +28,11 @@ export const getFetch = async <T>(url: string): Promise<T> => {
     headers: makeFetchHeaders(),
   });
 
-  const data = await response.json();
-
   if (!response.ok) {
-    throw new Error(data.message);
+    throw new Error('에러');
   }
+
+  const data = await response.json();
 
   return data;
 };


### PR DESCRIPTION
## 🔥 연관 이슈

close: #168 

## 📝 작업 요약

* 글 상세 페이지에 댓글 관련 컴포넌트(CommentList, CommentDeleteModal 등 components/comment 하위 파일들 참고) 추가
* 댓글 관련 컴포넌트에 hooks/query/comment 의 커스텀 쿼리 연결하여 API 연동 완료
* usePostDetail 커스텀 쿼리 구현 -> 게시글 상세조회를 위한 쿼리

## 🔎 작업 상세 설명
* 댓글 CRUD API 잘되는지 개발 서버 주소 들어가서 확인해봐야 합니다!

## 🌟 논의 사항
* 프론트 화이팅~