### PR TITLE
(비회원) 게시글 상세 조회

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostController.java
@@ -96,7 +96,7 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "게시글 상세 조회(비회원)", description = "비회원이 한 게시글의 상세를 조회한다.")
+    @Operation(summary = "게시글 상세 조회(비회원)", description = "비회원으로 게시글을 상세조회 한다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "게시글 조회 성공"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글")

--- a/backend/src/main/java/com/votogether/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostController.java
@@ -96,6 +96,19 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "게시글 상세 조회(비회원)", description = "비회원이 한 게시글의 상세를 조회한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "게시글 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글")
+    })
+    @GetMapping("{postId}/guest")
+    public ResponseEntity<PostDetailResponse> getPostByGuest(
+            @PathVariable final Long postId
+    ) {
+        final PostDetailResponse response = postService.getPostById(postId, null);
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "게시글 투표 통계 조회", description = "게시글 투표에 대한 전체 통계를 조회한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 투표 통계 조회 성공"),

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/detail/PostDetailResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/detail/PostDetailResponse.java
@@ -26,34 +26,6 @@ public record PostDetailResponse(
         VoteDetailResponse voteInfo
 ) {
 
-    public static PostDetailResponse from(final Post post) {
-        final Member writer = post.getWriter();
-        final PostBody postBody = post.getPostBody();
-        final List<PostContentImage> contentImages = postBody.getPostContentImages().getContentImages();
-        final StringBuilder contentImageUrl = new StringBuilder();
-
-        if (!contentImages.isEmpty()) {
-            contentImageUrl.append(contentImages.get(0).getImageUrl());
-        }
-
-        final PostCategories postCategories = post.getPostCategories();
-        return new PostDetailResponse(
-                post.getId(),
-                WriterResponse.of(writer.getId(), writer.getNickname()),
-                postBody.getTitle(),
-                postBody.getContent(),
-                convertImageUrl(contentImageUrl.toString()),
-                getCategories(postCategories.getPostCategories()),
-                post.getCreatedAt(),
-                post.getDeadline(),
-                VoteDetailResponse.of(
-                        0,
-                        -1,
-                        getOptionsByGuest(post)
-                )
-        );
-    }
-
     public static PostDetailResponse of(final Post post, final Member loginMember) {
         final Member writer = post.getWriter();
         final PostBody postBody = post.getPostBody();
@@ -103,18 +75,6 @@ public record PostDetailResponse(
                                 postOption,
                                 post.isVisibleVoteResult(loginMember),
                                 post.getFinalTotalVoteCount(loginMember)
-                        )
-                )
-                .toList();
-    }
-
-    private static List<PostOptionDetailResponse> getOptionsByGuest(final Post post) {
-        return post.getPostOptions().getPostOptions().stream()
-                .map(postOption ->
-                        PostOptionDetailResponse.of(
-                                postOption,
-                                false,
-                                -1L
                         )
                 )
                 .toList();

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/detail/PostDetailResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/detail/PostDetailResponse.java
@@ -26,6 +26,34 @@ public record PostDetailResponse(
         VoteDetailResponse voteInfo
 ) {
 
+    public static PostDetailResponse from(final Post post) {
+        final Member writer = post.getWriter();
+        final PostBody postBody = post.getPostBody();
+        final List<PostContentImage> contentImages = postBody.getPostContentImages().getContentImages();
+        final StringBuilder contentImageUrl = new StringBuilder();
+
+        if (!contentImages.isEmpty()) {
+            contentImageUrl.append(contentImages.get(0).getImageUrl());
+        }
+
+        final PostCategories postCategories = post.getPostCategories();
+        return new PostDetailResponse(
+                post.getId(),
+                WriterResponse.of(writer.getId(), writer.getNickname()),
+                postBody.getTitle(),
+                postBody.getContent(),
+                convertImageUrl(contentImageUrl.toString()),
+                getCategories(postCategories.getPostCategories()),
+                post.getCreatedAt(),
+                post.getDeadline(),
+                VoteDetailResponse.of(
+                        0,
+                        -1,
+                        getOptionsByGuest(post)
+                )
+        );
+    }
+
     public static PostDetailResponse of(final Post post, final Member loginMember) {
         final Member writer = post.getWriter();
         final PostBody postBody = post.getPostBody();
@@ -75,6 +103,18 @@ public record PostDetailResponse(
                                 postOption,
                                 post.isVisibleVoteResult(loginMember),
                                 post.getFinalTotalVoteCount(loginMember)
+                        )
+                )
+                .toList();
+    }
+
+    private static List<PostOptionDetailResponse> getOptionsByGuest(final Post post) {
+        return post.getPostOptions().getPostOptions().stream()
+                .map(postOption ->
+                        PostOptionDetailResponse.of(
+                                postOption,
+                                false,
+                                -1L
                         )
                 )
                 .toList();

--- a/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
@@ -30,6 +30,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/h2-console"
     );
 
+    private static final List<String> ALLOWED_END_URIS = List.of(
+            "/guest"
+    );
+
     private static final Map<String, String> MATCH_URI_METHOD = new HashMap<>(
             Map.ofEntries(
                     Map.entry("^/posts/.+/comments$", "GET")
@@ -52,7 +56,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        return containsAllowedUris(request) || startsWithAllowedStartUris(request) || matchesUriPattern(request);
+        return containsAllowedUris(request) || startsWithAllowedStartUris(request)
+                || matchesUriPattern(request) || endsWithAllowedEndUris(request);
+    }
+
+    private static boolean endsWithAllowedEndUris(final HttpServletRequest request) {
+        return ALLOWED_END_URIS.stream().anyMatch(url -> request.getRequestURI().endsWith("/guest"));
     }
 
     private boolean containsAllowedUris(final HttpServletRequest request) {

--- a/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -57,7 +59,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
         return containsAllowedUris(request) || startsWithAllowedStartUris(request)
-                || endsWithAllowedEndUris(request) || matchesUriPattern(request);
+                || matchesGuestRequest(request) || matchesUriPattern(request);
     }
 
     private boolean containsAllowedUris(final HttpServletRequest request) {
@@ -70,8 +72,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 .anyMatch(url -> request.getRequestURI().startsWith(url));
     }
 
-    private boolean endsWithAllowedEndUris(final HttpServletRequest request) {
-        return ALLOWED_END_URIS.stream().anyMatch(url -> request.getRequestURI().endsWith(url));
+    private boolean matchesGuestRequest(final HttpServletRequest request) {
+        return ALLOWED_END_URIS.stream()
+                .anyMatch(url -> request.getRequestURI().endsWith(url) &&
+                        Objects.equals(request.getMethod(), HttpMethod.GET.name()));
     }
 
     private boolean matchesUriPattern(final HttpServletRequest request) {

--- a/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
@@ -57,11 +57,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
         return containsAllowedUris(request) || startsWithAllowedStartUris(request)
-                || matchesUriPattern(request) || endsWithAllowedEndUris(request);
-    }
-
-    private static boolean endsWithAllowedEndUris(final HttpServletRequest request) {
-        return ALLOWED_END_URIS.stream().anyMatch(url -> request.getRequestURI().endsWith("/guest"));
+                || endsWithAllowedEndUris(request) || matchesUriPattern(request);
     }
 
     private boolean containsAllowedUris(final HttpServletRequest request) {
@@ -72,6 +68,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private boolean startsWithAllowedStartUris(final HttpServletRequest request) {
         return ALLOWED_START_URIS.stream()
                 .anyMatch(url -> request.getRequestURI().startsWith(url));
+    }
+
+    private boolean endsWithAllowedEndUris(final HttpServletRequest request) {
+        return ALLOWED_END_URIS.stream().anyMatch(url -> request.getRequestURI().endsWith(url));
     }
 
     private boolean matchesUriPattern(final HttpServletRequest request) {

--- a/backend/src/test/java/com/votogether/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/controller/PostControllerTest.java
@@ -283,6 +283,49 @@ class PostControllerTest {
     }
 
     @Test
+    @DisplayName("비회원이 한 게시글을 상세 조회한다.")
+    void getPostByGuest() {
+        // given
+        long postId = 0L;
+        Member writer = MALE_30.get();
+        LocalDateTime deadline = LocalDateTime.now().plusDays(3L);
+
+        PostBody postBody = PostBody.builder()
+                .title("title")
+                .content("content")
+                .build();
+
+        Post post = Post.builder()
+                .writer(writer)
+                .postBody(postBody)
+                .deadline(deadline)
+                .build();
+
+        given(postService.getPostById(postId, null)).willReturn(PostDetailResponse.of(post, null));
+
+        // when
+        PostDetailResponse response = RestAssuredMockMvc.given().log().all()
+                .when().get("/posts/{postId}/guest", postId)
+                .then().log().all()
+                .contentType(ContentType.JSON)
+                .status(HttpStatus.OK)
+                .extract()
+                .as(PostDetailResponse.class);
+
+        // then
+        WriterResponse writerResponse = response.writer();
+        VoteDetailResponse voteDetailResponse = response.voteInfo();
+
+        assertAll(
+                () -> assertThat(response.title()).isEqualTo("title"),
+                () -> assertThat(response.content()).isEqualTo("content"),
+                () -> assertThat(response.deadline()).isEqualTo(deadline.truncatedTo(ChronoUnit.MINUTES)),
+                () -> assertThat(writerResponse.nickname()).isEqualTo("user9"),
+                () -> assertThat(voteDetailResponse.totalVoteCount()).isEqualTo(-1)
+        );
+    }
+
+    @Test
     @DisplayName("게시글에 대한 전체 투표 통계를 조회한다.")
     void getVoteStatistics() {
         // given


### PR DESCRIPTION
## 🔥 연관 이슈

close: #284 

## 📝 작업 요약

비회원용 게시글 상세 조회 기능 구현했습니다.
filter에 `/guest`라는 suffix가 붙는 경우 필터를 거치지 않도록 수정했습니다.
GET메서드만 비회원일 때 필터를 통과하는 것도 추가했습니다!

## 🔎 작업 상세 설명

이전 메서드 재활용 했습니다.

## 🌟 논의 사항

크루들과 이야기 해보고 싶은 부분을 적어주세요.
