### PR TITLE
utils의 fetch 함수 리팩터링, ErrorBoundary 구현, query를 이용한 에러핸들링

### DIFF
--- a/frontend/src/api/example.ts
+++ b/frontend/src/api/example.ts
@@ -20,7 +20,7 @@ export const createCart = async () => {
 };
 
 export const editCart = async () => {
-  return await putFetch<Cart, { id: number }>('api/cart', { id: 12, text: '생성' });
+  return await putFetch<{ id: number }>('api/cart', { id: 12 });
 };
 
 // remove or delete

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -139,13 +139,6 @@ export default function PostForm({ data, mutate, isError, error }: PostFormProps
       formData.append('request', JSON.stringify(updatedPostTexts));
 
       mutate(formData);
-
-      if (isError && error instanceof Error) {
-        alert(error.message);
-        return;
-      }
-
-      navigate('/');
     }
   };
 

--- a/frontend/src/components/post/PostListPage/index.tsx
+++ b/frontend/src/components/post/PostListPage/index.tsx
@@ -4,6 +4,8 @@ import { AuthContext } from '@hooks/context/auth';
 import { useCategoryList } from '@hooks/query/category/useCategoryList';
 import { useDrawer } from '@hooks/useDrawer';
 
+import ErrorBoundary from '@pages/ErrorBoundary';
+
 import AddButton from '@components/common/AddButton';
 import Dashboard from '@components/common/Dashboard';
 import Drawer from '@components/common/Drawer';
@@ -40,9 +42,11 @@ export default function PostListPage() {
           />
         </Drawer>
       </S.DrawerWrapper>
-      <Suspense fallback={<Skeleton />}>
-        <PostList />
-      </Suspense>
+      <ErrorBoundary fallback={<div>에러발생</div>}>
+        <Suspense fallback={<Skeleton />}>
+          <PostList />
+        </Suspense>
+      </ErrorBoundary>
       <S.ButtonContainer>
         <UpButton onClick={scrollToTop} />
         <S.AddButtonWrapper to={PATH.POST_WRITE}>

--- a/frontend/src/hooks/query/post/useCreatePost.ts
+++ b/frontend/src/hooks/query/post/useCreatePost.ts
@@ -7,20 +7,23 @@ import { QUERY_KEY } from '@constants/queryKey';
 
 export const useCreatePost = () => {
   const queryClient = useQueryClient();
-  const { mutate, isLoading, isError, error } = useMutation((post: FormData) => createPost(post), {
-    onSuccess: () => {
-      queryClient.invalidateQueries([
-        QUERY_KEY.POSTS,
-        SORTING.LATEST,
-        STATUS.PROGRESS,
-        DEFAULT_CATEGORY_ID,
-        DEFAULT_KEYWORD,
-      ]);
-    },
-    onError: error => {
-      window.console.log('createPost error', error);
-    },
-  });
+  const { mutate, isLoading, isSuccess, isError, error } = useMutation(
+    (post: FormData) => createPost(post),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries([
+          QUERY_KEY.POSTS,
+          SORTING.LATEST,
+          STATUS.PROGRESS,
+          DEFAULT_CATEGORY_ID,
+          DEFAULT_KEYWORD,
+        ]);
+      },
+      onError: error => {
+        window.console.log('createPost error', error);
+      },
+    }
+  );
 
-  return { mutate, isLoading, isError, error };
+  return { mutate, isLoading, isSuccess, isError, error };
 };

--- a/frontend/src/pages/ErrorBoundary.tsx
+++ b/frontend/src/pages/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  #errorMessage = '';
+
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // You can also log the error to an error reporting service
+    window.console.log(error, errorInfo);
+    this.#errorMessage = error.message;
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>{this.#errorMessage}</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/pages/post/CreatePost/index.tsx
+++ b/frontend/src/pages/post/CreatePost/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { useCreatePost } from '@hooks/query/post/useCreatePost';
 
@@ -6,11 +7,25 @@ import Layout from '@components/common/Layout';
 import PostForm from '@components/PostForm';
 
 export default function CreatePost() {
-  const { mutate, isError, error } = useCreatePost();
+  const navigate = useNavigate();
+
+  const { mutate, isSuccess, isError, error } = useCreatePost();
 
   useEffect(() => {
     window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
   }, []);
+
+  useEffect(() => {
+    if (isSuccess) {
+      navigate('/');
+    }
+  }, [isSuccess, navigate]);
+
+  useEffect(() => {
+    if (isError && error instanceof Error) {
+      alert(error.message);
+    }
+  }, [isError, error]);
 
   return (
     <Layout isSidebarVisible={false}>

--- a/frontend/src/utils/fetch.ts
+++ b/frontend/src/utils/fetch.ts
@@ -23,102 +23,129 @@ const makeFetchMultiHeaders = () => {
 };
 
 export const getFetch = async <T>(url: string): Promise<T> => {
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: makeFetchHeaders(),
-  });
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: makeFetchHeaders(),
+    });
 
-  if (!response.ok) {
-    throw new Error('에러');
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      throw new Error(errorMessage);
+    }
+
+    const data = await response.json();
+
+    return data;
+  } catch (e) {
+    const error = e as Error;
+    throw new Error(error.message);
   }
-
-  const data = await response.json();
-  return data;
 };
 
-export const postFetch = async <T>(url: string, body: T): Promise<void> => {
-  const response = await fetch(url, {
-    method: 'POST',
-    body: JSON.stringify(body),
-    headers: makeFetchHeaders(),
-  });
+export const postFetch = async <T>(url: string, body: T) => {
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: makeFetchHeaders(),
+    });
 
-  if (!response.ok) {
-    throw new Error('에러');
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      throw new Error(errorMessage);
+    }
+  } catch (e) {
+    const error = e as Error;
+    throw new Error(error.message);
   }
-
-  // const data = await response.json();
-
-  return;
 };
 
-export const putFetch = async <T, R>(url: string, body: T): Promise<R | void> => {
-  const response = await fetch(url, {
-    method: 'PUT',
-    body: JSON.stringify(body),
-    headers: makeFetchHeaders(),
-  });
+export const putFetch = async <T>(url: string, body: T) => {
+  try {
+    const response = await fetch(url, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+      headers: makeFetchHeaders(),
+    });
 
-  // const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error('error');
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      throw new Error(errorMessage);
+    }
+  } catch (e) {
+    const error = e as Error;
+    throw new Error(error.message);
   }
-
-  return;
 };
 
 export const patchFetch = async <T>(url: string, body?: T) => {
-  const response = await fetch(url, {
-    method: 'PATCH',
-    headers: makeFetchHeaders(),
-    body: JSON.stringify(body),
-  });
+  try {
+    const response = await fetch(url, {
+      method: 'PATCH',
+      headers: makeFetchHeaders(),
+      body: JSON.stringify(body),
+    });
 
-  if (!response.ok) {
-    throw new Error('에러');
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      throw new Error(errorMessage);
+    }
+  } catch (e) {
+    const error = e as Error;
+    throw new Error(error.message);
   }
-
-  return response;
 };
 
 export const deleteFetch = async (url: string) => {
-  const response = await fetch(url, {
-    method: 'DELETE',
-    headers: makeFetchHeaders(),
-  });
+  try {
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: makeFetchHeaders(),
+    });
 
-  return response;
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      throw new Error(errorMessage);
+    }
+  } catch (e) {
+    const error = e as Error;
+    throw new Error(error.message);
+  }
 };
 
 export const multiPostFetch = async (url: string, body: FormData) => {
-  const response = await fetch(url, {
-    method: 'POST',
-    body,
-    headers: makeFetchMultiHeaders(),
-  });
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      body,
+      headers: makeFetchMultiHeaders(),
+    });
 
-  // const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error('error');
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      throw new Error(errorMessage);
+    }
+  } catch (e) {
+    const error = e as Error;
+    throw new Error(error.message);
   }
-
-  return;
 };
 
 export const multiPutFetch = async (url: string, body: FormData) => {
-  const response = await fetch(url, {
-    method: 'PUT',
-    body,
-    headers: makeFetchMultiHeaders(),
-  });
+  try {
+    const response = await fetch(url, {
+      method: 'PUT',
+      body,
+      headers: makeFetchMultiHeaders(),
+    });
 
-  const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error(data.message);
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      throw new Error(errorMessage);
+    }
+  } catch (e) {
+    const error = e as Error;
+    throw new Error(error.message);
   }
-
-  return data;
 };


### PR DESCRIPTION
## 🔥 연관 이슈

close: #158 

## 📝 작업 요약
* utils의 fetch 함수 리팩터링
* ErrorBoundary 구현
* query를 이용한 에러핸들링

## 🔎 작업 상세 설명
* 페어프로그래밍을 통해 기존의 fetch 함수를 try-catch 구문으로 리팩터링하였습니다.
* API 응답으로 오는 에러 객체의 메시지를 화면(필요한 컴포넌트)에 보여줄 수 있게 되었습니다.
* ErrorBoundary를 class 로 구현하였습니다.
* 게시글 조회 및 생성 query를 이용하여 에러 핸들링을 하였습니다.
