### PR TITLE
유저 정보, 카테고리 목록에서 캐싱, 스테일 타임을 1시간으로 수정

### DIFF
--- a/frontend/src/hooks/query/category/useCategoryList.ts
+++ b/frontend/src/hooks/query/category/useCategoryList.ts
@@ -9,7 +9,11 @@ import { QUERY_KEY } from '@constants/queryKey';
 export const useCategoryList = (isLoggedIn: boolean) => {
   const { data, error, isLoading, isError } = useQuery<Category[]>(
     [QUERY_KEY.CATEGORIES, isLoggedIn],
-    isLoggedIn ? getUserCategoryList : getGuestCategoryList
+    isLoggedIn ? getUserCategoryList : getGuestCategoryList,
+    {
+      cacheTime: 60 * 60 * 1000,
+      staleTime: 60 * 60 * 1000,
+    }
   );
 
   return { data, error, isLoading, isError };

--- a/frontend/src/hooks/query/user/useUserInfo.ts
+++ b/frontend/src/hooks/query/user/useUserInfo.ts
@@ -9,7 +9,11 @@ import { QUERY_KEY } from '@constants/queryKey';
 export const useUserInfo = (isLogged: boolean) => {
   const { data, error, isLoading, isError } = useQuery<User>(
     [QUERY_KEY.USER_INFO, isLogged],
-    getUserInfo
+    getUserInfo,
+    {
+      cacheTime: 60 * 60 * 1000,
+      staleTime: 60 * 60 * 1000,
+    }
   );
 
   return { data, error, isLoading, isError };


### PR DESCRIPTION
## 🔥 연관 이슈

close: #308 

## 작업 소요 시간

10분

## 📝 작업 요약

- 유저 정보, 카테고리 목록에서 캐싱, 스테일 타임을 1시간으로 수정


## 🌟 논의 사항


현재 게시글 삭제가 dev에 머지되지 않았기에 때문에 추후 게시글 삭제시에 유저 정보 캐시를 초기화 해줘야 게시글 숫자가 적용될 것 같습니다


