### PR TITLE
현재 유저가 어떤 게시글 종류를 보고 있는지 정보를 반환하는 함수 구현 및 적용

### DIFF
--- a/frontend/__test__/getPathFragment.test.ts
+++ b/frontend/__test__/getPathFragment.test.ts
@@ -1,6 +1,6 @@
 import { getPathFragment } from '@utils/getPathFragment';
 
-describe('useUrlDetection를 사용했을 때 path의 값만 나오도록 한다.', () => {
+describe('getPathFragment 사용했을 때 path의 값만 나오도록 한다.', () => {
   test('/posts/category/12인 경우, /posts/category를 반환한다.', () => {
     const result = getPathFragment('/posts/category/12');
 

--- a/frontend/__test__/getSelectedState.test.ts
+++ b/frontend/__test__/getSelectedState.test.ts
@@ -1,62 +1,100 @@
-import { getSelectedState } from '@utils/post/getSelectedState';
+import { SelectedState, getSelectedState } from '@utils/post/getSelectedState';
 
 import { MOCK_CATEGORY_LIST } from '@mocks/mockData/categoryList';
 
 describe('getSelectedState 사용했을 때 현재 유저에게 어떤 게시글에 대한 종류를 보고 있는지에 대한 정보를 반환한다.', () => {
   test('현재 카테고리가 선택되어 있고, 카테고리 아이디가 1번일 때 해당하는 카테고리 이름을 반환한다.', () => {
     const categoryId = 1;
-
-    const result = getSelectedState({
+    const state: SelectedState = {
       postType: 'category',
       categoryId,
       keyword: '',
       categoryList: MOCK_CATEGORY_LIST,
-    });
+    };
+
+    const result = getSelectedState(state);
 
     expect(categoryId).toBe(MOCK_CATEGORY_LIST[0].id);
     expect(result).toBe(MOCK_CATEGORY_LIST[0].name);
   });
 
   test('현재 검색을 한 상태이면, 검색 키워드를 반환한다.', () => {
-    const result = getSelectedState({
+    const keyword = '갤럭시';
+    const state: SelectedState = {
       postType: 'search',
       categoryId: 0,
-      keyword: '갤럭시',
+      keyword,
       categoryList: MOCK_CATEGORY_LIST,
-    });
+    };
 
-    expect(result).toBe('갤럭시');
+    const result = getSelectedState(state);
+
+    expect(result).toBe(keyword);
+  });
+
+  test('검색어를 길게 설정한 경우 10자만 보여주고 ...으로 표시해서 보여준다.', () => {
+    const keyword = '아이폰갤럭시뉴진스아이브세븐틴슈퍼주니어임';
+    const state: SelectedState = {
+      postType: 'search',
+      categoryId: 0,
+      keyword,
+      categoryList: MOCK_CATEGORY_LIST,
+    };
+
+    const result = getSelectedState(state);
+
+    expect(result).toBe('아이폰갤럭시뉴진스아...');
+  });
+
+  test('검색어를 10글자인 경우 10글자 전부 표시해서 보여준다.', () => {
+    const keyword = '아이폰갤럭시뉴진스아';
+    const state: SelectedState = {
+      postType: 'search',
+      categoryId: 0,
+      keyword,
+      categoryList: MOCK_CATEGORY_LIST,
+    };
+
+    const result = getSelectedState(state);
+
+    expect(result).toBe('아이폰갤럭시뉴진스아');
   });
 
   test('현재 홈 화면에 있다면, "전체"를 반환한다', () => {
-    const result = getSelectedState({
+    const state: SelectedState = {
       postType: 'posts',
       categoryId: 0,
       keyword: '',
       categoryList: MOCK_CATEGORY_LIST,
-    });
+    };
+
+    const result = getSelectedState(state);
 
     expect(result).toBe('전체');
   });
 
   test('현재 내가 작성한 글 페이지에 있다면, "내가 작성한 글"을 반환한다.', () => {
-    const result = getSelectedState({
+    const state: SelectedState = {
       postType: 'myPost',
       categoryId: 0,
       keyword: '',
       categoryList: MOCK_CATEGORY_LIST,
-    });
+    };
+
+    const result = getSelectedState(state);
 
     expect(result).toBe('내가 작성한 글');
   });
 
   test('현재 내가 투표한 글 페이지에 있다면, "내가 투표한 글"을 반환한다.', () => {
-    const result = getSelectedState({
+    const state: SelectedState = {
       postType: 'myVote',
       categoryId: 0,
       keyword: '',
       categoryList: MOCK_CATEGORY_LIST,
-    });
+    };
+
+    const result = getSelectedState(state);
 
     expect(result).toBe('내가 투표한 글');
   });

--- a/frontend/__test__/getSelectedState.test.ts
+++ b/frontend/__test__/getSelectedState.test.ts
@@ -1,0 +1,63 @@
+import { getSelectedState } from '@utils/post/getSelectedState';
+
+import { MOCK_CATEGORY_LIST } from '@mocks/mockData/categoryList';
+
+describe('getSelectedState 사용했을 때 현재 유저에게 어떤 게시글에 대한 종류를 보고 있는지에 대한 정보를 반환한다.', () => {
+  test('현재 카테고리가 선택되어 있고, 카테고리 아이디가 1번일 때 해당하는 카테고리 이름을 반환한다.', () => {
+    const categoryId = 1;
+
+    const result = getSelectedState({
+      postType: 'category',
+      categoryId,
+      keyword: '',
+      categoryList: MOCK_CATEGORY_LIST,
+    });
+
+    expect(categoryId).toBe(MOCK_CATEGORY_LIST[0].id);
+    expect(result).toBe(MOCK_CATEGORY_LIST[0].name);
+  });
+
+  test('현재 검색을 한 상태이면, 검색 키워드를 반환한다.', () => {
+    const result = getSelectedState({
+      postType: 'search',
+      categoryId: 0,
+      keyword: '갤럭시',
+      categoryList: MOCK_CATEGORY_LIST,
+    });
+
+    expect(result).toBe('갤럭시');
+  });
+
+  test('현재 홈 화면에 있다면, "전체"를 반환한다', () => {
+    const result = getSelectedState({
+      postType: 'posts',
+      categoryId: 0,
+      keyword: '',
+      categoryList: MOCK_CATEGORY_LIST,
+    });
+
+    expect(result).toBe('전체');
+  });
+
+  test('현재 내가 작성한 글 페이지에 있다면, "내가 작성한 글"을 반환한다.', () => {
+    const result = getSelectedState({
+      postType: 'myPost',
+      categoryId: 0,
+      keyword: '',
+      categoryList: MOCK_CATEGORY_LIST,
+    });
+
+    expect(result).toBe('내가 작성한 글');
+  });
+
+  test('현재 내가 투표한 글 페이지에 있다면, "내가 투표한 글"을 반환한다.', () => {
+    const result = getSelectedState({
+      postType: 'myVote',
+      categoryId: 0,
+      keyword: '',
+      categoryList: MOCK_CATEGORY_LIST,
+    });
+
+    expect(result).toBe('내가 투표한 글');
+  });
+});

--- a/frontend/src/components/common/Dashboard/Dashboard.stories.tsx
+++ b/frontend/src/components/common/Dashboard/Dashboard.stories.tsx
@@ -66,6 +66,7 @@ export const LoggedIn: Story = {
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_CATEGORIES}
       handleLogoutClick={() => {}}
+      selectedState="전체"
     />
   ),
 };
@@ -76,6 +77,7 @@ export const FavoriteCategory: Story = {
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_FAVORITE_CATEGORIES}
       handleLogoutClick={() => {}}
+      selectedState="전체"
     />
   ),
 };
@@ -85,7 +87,7 @@ export const SelectedCategory: Story = {
     <Dashboard
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_FAVORITE_CATEGORIES}
-      selectedCategory="패션"
+      selectedState="패션"
       handleLogoutClick={() => {}}
     />
   ),
@@ -97,10 +99,13 @@ export const LongCategoryList: Story = {
       userInfo={MOCK_USER_INFO}
       categoryList={MOCK_LONG_CATEGORIES}
       handleLogoutClick={() => {}}
+      selectedState="전체"
     />
   ),
 };
 
 export const Guest: Story = {
-  render: () => <Dashboard categoryList={MOCK_CATEGORIES} handleLogoutClick={() => {}} />,
+  render: () => (
+    <Dashboard selectedState="전체" categoryList={MOCK_CATEGORIES} handleLogoutClick={() => {}} />
+  ),
 };

--- a/frontend/src/components/common/Dashboard/index.tsx
+++ b/frontend/src/components/common/Dashboard/index.tsx
@@ -12,7 +12,7 @@ import UserProfile from './UserProfile';
 
 interface DashboardProps {
   categoryList: Category[];
-  selectedCategory?: string;
+  selectedState: string;
   handleLogoutClick: () => void;
   userInfo?: User;
 }
@@ -20,7 +20,7 @@ interface DashboardProps {
 export default function Dashboard({
   userInfo,
   categoryList,
-  selectedCategory = '전체',
+  selectedState,
   handleLogoutClick,
 }: DashboardProps) {
   const favoriteCategory = categoryList.filter(category => category.isFavorite === true);
@@ -31,7 +31,7 @@ export default function Dashboard({
       {userInfo ? <UserProfile userInfo={userInfo} /> : <GuestProfile />}
       <S.SelectCategoryWrapper>
         <S.Circle />
-        <S.SelectCategoryText>{selectedCategory}</S.SelectCategoryText>
+        <S.SelectCategoryText>{selectedState}</S.SelectCategoryText>
       </S.SelectCategoryWrapper>
       <S.ContentContainer>
         <S.CategoryToggleContainer>

--- a/frontend/src/components/common/Drawer/Drawer.stories.tsx
+++ b/frontend/src/components/common/Drawer/Drawer.stories.tsx
@@ -41,6 +41,7 @@ export const LeftSideBar = () => {
           userInfo={MOCK_USER_INFO}
           categoryList={MOCK_CATEGORIES}
           handleLogoutClick={() => {}}
+          selectedState="전체"
         />
       </Drawer>
     </div>
@@ -58,6 +59,7 @@ export const RightSideBar = () => {
           userInfo={MOCK_USER_INFO}
           categoryList={MOCK_CATEGORIES}
           handleLogoutClick={() => {}}
+          selectedState="전체"
         />
       </Drawer>
     </div>

--- a/frontend/src/components/common/Layout/index.tsx
+++ b/frontend/src/components/common/Layout/index.tsx
@@ -3,11 +3,13 @@ import { useNavigate } from 'react-router-dom';
 
 import { AuthContext } from '@hooks/context/auth';
 import { useCategoryList } from '@hooks/query/category/useCategoryList';
+import { usePostRequestInfo } from '@hooks/usePostRequestInfo';
 
 import Dashboard from '@components/common/Dashboard';
 import WideHeader from '@components/common/WideHeader';
 
 import { clearCookieToken } from '@utils/cookie';
+import { getSelectedState } from '@utils/post/getSelectedState';
 
 import * as S from './style';
 
@@ -21,7 +23,15 @@ export default function Layout({ children, isSidebarVisible }: LayoutProps) {
   const { loggedInfo, clearLoggedInfo } = useContext(AuthContext);
 
   const { data: categoryList } = useCategoryList(loggedInfo.isLoggedIn);
-  const selectedCategory = undefined;
+  const { postOptionalOption, postType } = usePostRequestInfo();
+  const { categoryId, keyword } = postOptionalOption;
+
+  const selectedState = getSelectedState({
+    categoryId,
+    keyword,
+    categoryList: categoryList ?? [],
+    postType,
+  });
 
   const handleLogoutClick = () => {
     clearCookieToken('accessToken');
@@ -43,7 +53,7 @@ export default function Layout({ children, isSidebarVisible }: LayoutProps) {
             <Dashboard
               userInfo={loggedInfo.userInfo}
               categoryList={categoryList ?? []}
-              selectedCategory={selectedCategory}
+              selectedState={selectedState}
               handleLogoutClick={handleLogoutClick}
             />
           </S.DashboardWrapper>

--- a/frontend/src/components/post/PostListPage/index.tsx
+++ b/frontend/src/components/post/PostListPage/index.tsx
@@ -3,6 +3,7 @@ import { Suspense, useContext } from 'react';
 import { AuthContext } from '@hooks/context/auth';
 import { useCategoryList } from '@hooks/query/category/useCategoryList';
 import { useDrawer } from '@hooks/useDrawer';
+import { usePostRequestInfo } from '@hooks/usePostRequestInfo';
 
 import ErrorBoundary from '@pages/ErrorBoundary';
 
@@ -16,6 +17,7 @@ import PostList from '@components/post/PostList';
 
 import { PATH } from '@constants/path';
 
+import { getSelectedState } from '@utils/post/getSelectedState';
 import { scrollToTop } from '@utils/scrollToTop';
 
 import * as S from './style';
@@ -25,6 +27,15 @@ export default function PostListPage() {
 
   const { isLoggedIn: isLogged, userInfo } = useContext(AuthContext).loggedInfo;
   const { data: categoryList } = useCategoryList(isLogged);
+  const { postOptionalOption, postType } = usePostRequestInfo();
+  const { categoryId, keyword } = postOptionalOption;
+
+  const selectedState = getSelectedState({
+    categoryId,
+    keyword,
+    categoryList: categoryList ?? [],
+    postType,
+  });
 
   const handleLogoutClick = () => {};
 
@@ -39,6 +50,7 @@ export default function PostListPage() {
             userInfo={userInfo}
             categoryList={categoryList ?? []}
             handleLogoutClick={handleLogoutClick}
+            selectedState={selectedState}
           />
         </Drawer>
       </S.DrawerWrapper>

--- a/frontend/src/utils/post/getSelectedState.ts
+++ b/frontend/src/utils/post/getSelectedState.ts
@@ -2,12 +2,14 @@ import { Category } from '@type/category';
 
 import { PostRequestKind } from '@components/post/PostListPage/types';
 
-interface SelectedState {
+export interface SelectedState {
   postType: PostRequestKind;
   categoryId: number;
   keyword: string;
   categoryList: Category[];
 }
+
+const SLICED_LENGTH_NUMBER = 10;
 
 export const getSelectedState = ({
   postType,
@@ -22,7 +24,9 @@ export const getSelectedState = ({
   }
 
   if (postType === 'search') {
-    return keyword;
+    return keyword.length > SLICED_LENGTH_NUMBER
+      ? `${keyword.slice(0, SLICED_LENGTH_NUMBER)}...`
+      : keyword;
   }
 
   if (postType === 'myPost') {

--- a/frontend/src/utils/post/getSelectedState.ts
+++ b/frontend/src/utils/post/getSelectedState.ts
@@ -1,0 +1,37 @@
+import { Category } from '@type/category';
+
+import { PostRequestKind } from '@components/post/PostListPage/types';
+
+interface SelectedState {
+  postType: PostRequestKind;
+  categoryId: number;
+  keyword: string;
+  categoryList: Category[];
+}
+
+export const getSelectedState = ({
+  postType,
+  categoryId,
+  keyword,
+  categoryList,
+}: SelectedState) => {
+  if (postType === 'category') {
+    const selectedCategory = categoryList.find(category => category.id === categoryId);
+
+    return selectedCategory?.name;
+  }
+
+  if (postType === 'search') {
+    return keyword;
+  }
+
+  if (postType === 'myPost') {
+    return '내가 작성한 글';
+  }
+
+  if (postType === 'myVote') {
+    return '내가 투표한 글';
+  }
+
+  return '전체';
+};

--- a/frontend/src/utils/post/getSelectedState.ts
+++ b/frontend/src/utils/post/getSelectedState.ts
@@ -18,7 +18,7 @@ export const getSelectedState = ({
   if (postType === 'category') {
     const selectedCategory = categoryList.find(category => category.id === categoryId);
 
-    return selectedCategory?.name;
+    return selectedCategory?.name ?? '전체';
   }
 
   if (postType === 'search') {


### PR DESCRIPTION
## 🔥 연관 이슈

close: #310 

## 📝 작업 요약

- 유저가 어떤 게시글을 보고 있는지 정보를 반환하는 함수를 구현
- selectedCategory라는 props 변수명을 selectedState로 변경
- 대쉬보드, 모바일용 대쉬보드에 적용

## 🔎 작업 상세 설명

usePostRequestInfo 훅에서 반환하는 정보를 이용하여 함수를 구현
```tsx
  const { postOptionalOption, postType } = usePostRequestInfo();
```

전체 - 전체
검색 - 검색한 키워드
카테고리 - 선택한 카테고리 이름
내가 작성한 글 - 내가 작성한 글
내가 투표한 글 - 내가 투표한 글


위와 같이 보이도록 구현했습니다

예시 동영상

https://github.com/woowacourse-teams/2023-votogether/assets/80146176/8f2bb4d8-5be5-460d-a817-9a33d61865fc


