### PR TITLE
[BUG] 게시물 상세페이지 반응성 적용 오류

### DIFF
--- a/frontend/__test__/api/user.test.ts
+++ b/frontend/__test__/api/user.test.ts
@@ -23,12 +23,12 @@ describe('서버와 통신하여 유저의 정보를 불러올 수 있어야 한
     expect(data).toEqual(transformUserInfoResponse(MOCK_USER_INFO));
   });
 
-  test('클라이언트에서 사용하는 유저 정보 API 명세가 [nickname, postCount, userPoint, userPoint, badge]으로 존재해야한다', async () => {
+  test('클라이언트에서 사용하는 유저 정보 API 명세가 [nickname, postCount, voteCount, gender, birthYear]으로 존재해야한다', async () => {
     const data = await getUserInfo(isLoggedIn);
 
     const userInfoKeys = Object.keys(data ?? {});
 
-    expect(userInfoKeys).toEqual(['nickname', 'postCount', 'userPoint', 'voteCount', 'badge']);
+    expect(userInfoKeys).toEqual(['nickname', 'postCount', 'gender', 'voteCount', 'birthYear']);
   });
 
   test('유저의 닉네임을 수정한다', async () => {

--- a/frontend/src/api/post.ts
+++ b/frontend/src/api/post.ts
@@ -74,8 +74,7 @@ export const editPost = async (postId: number, updatedPost: FormData) => {
   return await multiPutFetch(`${BASE_URL}/posts/${postId}`, updatedPost);
 };
 
-
-export const removePost = async (postId: number) => {
+export const deletePost = async (postId: number) => {
   return await deleteFetch(`${MOCK_URL}/posts/${postId}`);
 };
 

--- a/frontend/src/api/userInfo.ts
+++ b/frontend/src/api/userInfo.ts
@@ -3,14 +3,14 @@ import type { UserInfoResponse, User, ModifyNicknameRequest } from '@type/user';
 import { deleteFetch, getFetch, patchFetch } from '@utils/fetch';
 
 export const transformUserInfoResponse = (userInfo: UserInfoResponse): User => {
-  const { nickname, postCount, userPoint, voteCount, badge } = userInfo;
+  const { nickname, postCount, gender, voteCount, birthYear } = userInfo;
 
   return {
     nickname,
     postCount,
-    userPoint,
+    gender,
     voteCount,
-    badge,
+    birthYear,
   };
 };
 

--- a/frontend/src/components/PostForm/ContentImageSection/style.ts
+++ b/frontend/src/components/PostForm/ContentImageSection/style.ts
@@ -7,14 +7,14 @@ export const ContentImageContainer = styled.div`
   grid-template-columns: 40px auto;
 `;
 
-const imageSize = {
+const IMAGE_SIZE = {
   sm: '25%',
   md: '50%',
   lg: '100%',
 };
 
 export const ContentImageWrapper = styled.div<{ $size: Size }>`
-  width: ${props => imageSize[props.$size]};
+  width: ${props => IMAGE_SIZE[props.$size]};
   height: 100%;
 
   position: relative;

--- a/frontend/src/components/VoteStatistics/GraphStyle.ts
+++ b/frontend/src/components/VoteStatistics/GraphStyle.ts
@@ -11,7 +11,7 @@ export const GENDER_COLOR: Record<Gender, string> = {
   MALE: 'var(--graph-color-green)',
 };
 
-const size: Record<Size, { height: string; linePositionTop: string }> = {
+const SIZE: Record<Size, { height: string; linePositionTop: string }> = {
   sm: { height: '200px', linePositionTop: '165px' },
   md: { height: '230px', linePositionTop: '194px' },
   lg: { height: '260px', linePositionTop: '224px' },
@@ -20,7 +20,7 @@ const size: Record<Size, { height: string; linePositionTop: string }> = {
 export const GraphContainer = styled.div<{ $size: Size }>`
   display: flex;
 
-  height: ${props => `${size[props.$size].height}`};
+  height: ${props => `${SIZE[props.$size].height}`};
 
   position: relative;
 
@@ -36,5 +36,5 @@ export const Line = styled.div<{ $size: Size }>`
   border-bottom: 2px solid black;
 
   position: absolute;
-  top: ${props => `${size[props.$size].linePositionTop}`};
+  top: ${props => `${SIZE[props.$size].linePositionTop}`};
 `;

--- a/frontend/src/components/VoteStatistics/GraphStyle.ts
+++ b/frontend/src/components/VoteStatistics/GraphStyle.ts
@@ -4,6 +4,13 @@ import { Size } from '@type/style';
 
 import { theme } from '@styles/theme';
 
+import { Gender } from './type';
+
+export const GENDER_COLOR: Record<Gender, string> = {
+  FEMALE: 'var(--graph-color-purple)',
+  MALE: 'var(--graph-color-green)',
+};
+
 const size: Record<Size, { height: string; linePositionTop: string }> = {
   sm: { height: '200px', linePositionTop: '165px' },
   md: { height: '230px', linePositionTop: '194px' },

--- a/frontend/src/components/VoteStatistics/TwoLineGraph/index.tsx
+++ b/frontend/src/components/VoteStatistics/TwoLineGraph/index.tsx
@@ -15,16 +15,16 @@ export default function TwoLineGraph({ ageGroup, size }: GraphProps) {
         return (
           <S.OptionContainer key={ageResult.name} $size={size}>
             <S.DataWrapper>
-              <S.OptionLengthWrapper $gender="female">
+              <S.OptionLengthWrapper $gender="FEMALE">
                 <span aria-label="투표한 여자수">{ageResult.female}</span>
                 <S.OptionLength
                   $amount={(ageResult.female / maxVoteAmount) * 100}
-                  $gender="female"
+                  $gender="FEMALE"
                 />
               </S.OptionLengthWrapper>
-              <S.OptionLengthWrapper $gender="male">
+              <S.OptionLengthWrapper $gender="MALE">
                 <span aria-label="투표한 남자수">{ageResult.male}</span>
-                <S.OptionLength $amount={(ageResult.male / maxVoteAmount) * 100} $gender="male" />
+                <S.OptionLength $amount={(ageResult.male / maxVoteAmount) * 100} $gender="MALE" />
               </S.OptionLengthWrapper>
             </S.DataWrapper>
             <span aria-label="투표한 나이대">{ageResult.name}</span>

--- a/frontend/src/components/VoteStatistics/TwoLineGraph/style.ts
+++ b/frontend/src/components/VoteStatistics/TwoLineGraph/style.ts
@@ -4,6 +4,9 @@ import { Size } from '@type/style';
 
 import { theme } from '@styles/theme';
 
+import { GENDER_COLOR } from '../GraphStyle';
+import { Gender } from '../type';
+
 export const OptionContainer = styled.div<{ $size: Size }>`
   display: flex;
   flex-direction: column;
@@ -37,7 +40,7 @@ export const DataWrapper = styled.div`
   }
 `;
 
-export const OptionLengthWrapper = styled.div<{ $gender: 'female' | 'male' }>`
+export const OptionLengthWrapper = styled.div<{ $gender: Gender }>`
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -49,16 +52,15 @@ export const OptionLengthWrapper = styled.div<{ $gender: 'female' | 'male' }>`
 
   & > :first-child {
     position: relative;
-    left: ${props => props.$gender === 'male' && '3px'};
-    right: ${props => props.$gender === 'female' && '3px'};
+    left: ${props => props.$gender === 'MALE' && '3px'};
+    right: ${props => props.$gender === 'FEMALE' && '3px'};
   }
 `;
 
-export const OptionLength = styled.div<{ $amount: number; $gender: 'female' | 'male' }>`
+export const OptionLength = styled.div<{ $amount: number; $gender: Gender }>`
   height: ${props => `${props.$amount}% `};
   width: 100%;
   border-radius: 5px 5px 0 0;
 
-  background-color: ${props =>
-    props.$gender === 'female' ? 'var(--graph-color-purple)' : 'var(--graph-color-green)'};
+  background-color: ${props => GENDER_COLOR[props.$gender]};
 `;

--- a/frontend/src/components/VoteStatistics/index.tsx
+++ b/frontend/src/components/VoteStatistics/index.tsx
@@ -58,6 +58,18 @@ export default function VoteStatistics({ voteResultResponse, size }: VoteStatist
           );
         })}
       </S.CategoryWrapper>
+      <S.GenderExplain>
+        {currentRadioMode === 'gender' && (
+          <>
+            <label>
+              <S.ColorIcon $gender="FEMALE" /> 여자
+            </label>
+            <label>
+              <S.ColorIcon $gender="MALE" /> 남자
+            </label>
+          </>
+        )}
+      </S.GenderExplain>
       {currentRadioMode === 'all' && <OneLineGraph size={size} ageGroup={voteResult.ageGroup} />}
       {currentRadioMode === 'gender' && <TwoLineGraph size={size} ageGroup={voteResult.ageGroup} />}
     </S.Container>

--- a/frontend/src/components/VoteStatistics/style.ts
+++ b/frontend/src/components/VoteStatistics/style.ts
@@ -6,7 +6,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 15px;
+  gap: 5px;
 
   font: var(--text-small);
 
@@ -23,4 +23,34 @@ export const CategoryWrapper = styled.fieldset`
 export const RadioLabel = styled.label`
   display: flex;
   gap: 5px;
+`;
+
+export const GenderExplain = styled.span`
+  display: flex;
+  gap: 10px;
+
+  height: 20px;
+
+  & > * {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+
+    line-height: initial;
+  }
+`;
+
+type Gender = 'FEMALE' | 'MALE';
+
+const GENDER_COLOR: Record<Gender, string> = {
+  FEMALE: 'var(--graph-color-purple)',
+  MALE: 'var(--graph-color-green)',
+};
+
+export const ColorIcon = styled.span<{ $gender: Gender }>`
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+
+  background-color: ${props => GENDER_COLOR[props.$gender]};
 `;

--- a/frontend/src/components/VoteStatistics/style.ts
+++ b/frontend/src/components/VoteStatistics/style.ts
@@ -2,6 +2,9 @@ import { styled } from 'styled-components';
 
 import { theme } from '@styles/theme';
 
+import { GENDER_COLOR } from './GraphStyle';
+import { Gender } from './type';
+
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -39,13 +42,6 @@ export const GenderExplain = styled.span`
     line-height: initial;
   }
 `;
-
-type Gender = 'FEMALE' | 'MALE';
-
-const GENDER_COLOR: Record<Gender, string> = {
-  FEMALE: 'var(--graph-color-purple)',
-  MALE: 'var(--graph-color-green)',
-};
 
 export const ColorIcon = styled.span<{ $gender: Gender }>`
   width: 12px;

--- a/frontend/src/components/VoteStatistics/type.ts
+++ b/frontend/src/components/VoteStatistics/type.ts
@@ -43,3 +43,5 @@ export interface VoteResultResponse {
   totalFemaleCount: number;
   totalMaleCount: number;
 }
+
+export type Gender = 'FEMALE' | 'MALE';

--- a/frontend/src/components/common/Dashboard/Dashboard.stories.tsx
+++ b/frontend/src/components/common/Dashboard/Dashboard.stories.tsx
@@ -16,7 +16,8 @@ const MOCK_USER_INFO: User = {
   nickname: '우아한 코끼리',
   postCount: 4,
   voteCount: 128,
-  userPoint: 200,
+  gender: 'MALE',
+  birthYear: 1997,
 };
 
 const MOCK_CATEGORIES: Category[] = [

--- a/frontend/src/components/common/Dashboard/UserProfile/UserProfile.stories.tsx
+++ b/frontend/src/components/common/Dashboard/UserProfile/UserProfile.stories.tsx
@@ -15,7 +15,8 @@ const MOCK_USER_INFO: User = {
   nickname: '우아한 코끼리',
   postCount: 4,
   voteCount: 128,
-  userPoint: 200,
+  gender: 'FEMALE',
+  birthYear: 1997,
 };
 
 export const NoBadge: Story = {
@@ -23,5 +24,5 @@ export const NoBadge: Story = {
 };
 
 export const Badge: Story = {
-  render: () => <UserProfile userInfo={{ ...MOCK_USER_INFO, badge: '만근자' }} />,
+  render: () => <UserProfile userInfo={MOCK_USER_INFO} />,
 };

--- a/frontend/src/components/common/Dashboard/UserProfile/index.tsx
+++ b/frontend/src/components/common/Dashboard/UserProfile/index.tsx
@@ -13,11 +13,10 @@ interface UserProfileProps {
 }
 
 export default function UserProfile({ userInfo }: UserProfileProps) {
-  const { nickname, postCount, voteCount, badge } = userInfo;
+  const { nickname, postCount, voteCount } = userInfo;
 
   return (
     <PS.ProfileContainer>
-      {badge && <S.Badge>[{badge}]</S.Badge>}
       <S.NickName>{nickname}</S.NickName>
       <S.UserInfoContainer>
         <S.TextCardLink to={PATH.USER_POST}>

--- a/frontend/src/components/common/Drawer/Drawer.stories.tsx
+++ b/frontend/src/components/common/Drawer/Drawer.stories.tsx
@@ -20,7 +20,8 @@ const MOCK_USER_INFO: User = {
   nickname: '우아한 코끼리',
   postCount: 4,
   voteCount: 128,
-  userPoint: 200,
+  gender: 'MALE',
+  birthYear: 1997,
 };
 
 const MOCK_CATEGORIES: Category[] = [

--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -56,12 +56,7 @@ export default function Post({ postInfo, isPreview }: PostProps) {
   const checkIncludeImage = () => {
     if (imageUrl !== '') return true;
 
-    const hasOptionImageUrl = voteInfo.options
-      .map(option => option.imageUrl)
-      .some(url => url !== '');
-    if (hasOptionImageUrl) return true;
-
-    return false;
+    return voteInfo.options.map(option => option.imageUrl).some(url => url !== '');
   };
 
   return (

--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -75,7 +75,7 @@ export default function Post({ postInfo, isPreview }: PostProps) {
         <S.Category aria-label="카테고리">
           {category.map(category => category.name).join(' | ')}
         </S.Category>
-        {checkIncludeImage() && (
+        {isPreview && checkIncludeImage() && (
           <S.ImageIconWrapper>
             <S.ImageIcon src={photoIcon} alt="해당 게시물은 사진을 포함하고 있습니다." />
           </S.ImageIconWrapper>

--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -29,7 +29,7 @@ export default function Post({ postInfo, isPreview }: PostProps) {
   const { mutate: createVote } = useCreateVote({ isPreview, postId });
   const { mutate: editVote } = useEditVote({ isPreview, postId });
 
-  const imageBaseUrl = process.env.VOTOGETHER_BASE_URL.replace(/api\./, '');
+  const IMAGE_BASE_URL = process.env.VOTOGETHER_BASE_URL.replace(/api\./, '');
 
   const isActive = !checkClosedPost(deadline);
 
@@ -102,7 +102,7 @@ export default function Post({ postInfo, isPreview }: PostProps) {
           {content}
         </S.Content>
         {!isPreview && imageUrl && (
-          <S.Image src={`${imageBaseUrl}/${imageUrl}`} alt={'본문에 포함된 이미지'} />
+          <S.Image src={`${IMAGE_BASE_URL}/${imageUrl}`} alt={'본문에 포함된 이미지'} />
         )}
       </S.DetailLink>
       <WrittenVoteOptionList

--- a/frontend/src/components/common/Post/style.ts
+++ b/frontend/src/components/common/Post/style.ts
@@ -31,7 +31,6 @@ export const ImageIconWrapper = styled.div`
   justify-content: center;
   align-items: center;
 
-  background-color: var(--header);
   width: 15px;
   height: 15px;
   border-radius: 50%;
@@ -39,6 +38,8 @@ export const ImageIconWrapper = styled.div`
   position: absolute;
   right: 25px;
   top: 0;
+
+  background-color: var(--header);
 `;
 
 export const ImageIcon = styled.img`
@@ -94,11 +95,11 @@ export const Wrapper = styled.div`
 export const Content = styled.p<{ $isPreview: boolean }>`
   display: -webkit-box;
 
+  margin: 10px 0;
+
   font: var(--text-caption);
   text-overflow: ellipsis;
   word-break: break-word;
-
-  margin: 10px 0;
 
   overflow: hidden;
 
@@ -119,10 +120,9 @@ export const DetailLink = styled(Link)<{ $isPreview: boolean }>`
 `;
 
 export const Image = styled.img`
+  width: 100%;
   border-radius: 4px;
   margin-bottom: 10px;
-
-  width: 100%;
 
   aspect-ratio: 1/1;
   object-fit: cover;

--- a/frontend/src/components/common/Post/style.ts
+++ b/frontend/src/components/common/Post/style.ts
@@ -5,6 +5,8 @@ import { styled } from 'styled-components';
 import { theme } from '@styles/theme';
 
 export const Container = styled.li`
+  width: 100%;
+
   font: var(--text-small);
   letter-spacing: 0.5px;
   line-height: 1.5;

--- a/frontend/src/components/common/Post/style.ts
+++ b/frontend/src/components/common/Post/style.ts
@@ -6,7 +6,7 @@ import { theme } from '@styles/theme';
 
 export const Container = styled.li`
   width: 100%;
-  
+
   position: relative;
 
   font: var(--text-small);
@@ -24,6 +24,26 @@ export const Category = styled.span`
   @media (min-width: ${theme.breakpoint.sm}) {
     font: var(--text-caption);
   }
+`;
+
+export const ImageIconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: var(--header);
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+
+  position: absolute;
+  right: 25px;
+  top: 0;
+`;
+
+export const ImageIcon = styled.img`
+  width: 13px;
+  height: 13px;
 `;
 
 export const ActivateState = styled.div<{ $isActive: boolean }>`
@@ -96,4 +116,18 @@ export const DetailLink = styled(Link)<{ $isPreview: boolean }>`
   gap: 10px;
 
   pointer-events: ${({ $isPreview }) => !$isPreview && 'none'};
+`;
+
+export const Image = styled.img`
+  border-radius: 4px;
+  margin-bottom: 10px;
+
+  width: 100%;
+
+  aspect-ratio: 1/1;
+  object-fit: cover;
+
+  @media (min-width: ${theme.breakpoint.md}) {
+    margin-bottom: 20px;
+  }
 `;

--- a/frontend/src/components/common/TagButton/style.ts
+++ b/frontend/src/components/common/TagButton/style.ts
@@ -6,7 +6,7 @@ interface ButtonProps {
   $size: Size;
 }
 
-const size = {
+const SIZE = {
   sm: { width: '80px', height: '40px', fontSize: '14px' },
   md: { width: '100px', height: '50px', fontSize: '20px' },
   lg: { width: '120px', height: '60px', fontSize: '24px' },
@@ -15,14 +15,14 @@ const size = {
 export const Button = styled.button<ButtonProps>`
   display: block;
 
-  width: ${props => size[props.$size].width};
-  height: ${props => size[props.$size].height};
+  width: ${props => SIZE[props.$size].width};
+  height: ${props => SIZE[props.$size].height};
   border-radius: 0 0 5px 5px;
 
   background-color: var(--primary-color);
   color: var(--white);
 
-  font-size: ${props => size[props.$size].fontSize};
+  font-size: ${props => SIZE[props.$size].fontSize};
 
   cursor: pointer;
 `;

--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/index.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/index.tsx
@@ -24,7 +24,7 @@ export default function WrittenVoteOption({
   imageUrl,
   ariaLabel,
 }: WrittenVoteOptionProps) {
-  const imageBaseUrl = process.env.VOTOGETHER_BASE_URL.replace(/api\./, '');
+  const IMAGE_BASE_URL = process.env.VOTOGETHER_BASE_URL.replace(/api\./, '');
 
   return (
     <S.Container
@@ -33,7 +33,7 @@ export default function WrittenVoteOption({
       onClick={handleVoteClick}
     >
       {!isPreview && imageUrl && (
-        <S.Image src={`${imageBaseUrl}/${imageUrl}`} alt={'선택지에 포함된 이미지'} />
+        <S.Image src={`${IMAGE_BASE_URL}/${imageUrl}`} alt={'선택지에 포함된 이미지'} />
       )}
       {isPreview ? (
         <S.PreviewContent aria-label="선택지 내용">{text}</S.PreviewContent>

--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/index.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/index.tsx
@@ -28,11 +28,13 @@ export default function WrittenVoteOption({
 
   return (
     <S.Container
-      aria-label={`${ariaLabel}${isSelected ? ' 선택된 선택지' : ''}`}
+      aria-label={`${ariaLabel}${isSelected ? '선택된 선택지' : ''}`}
       $isSelected={isSelected}
       onClick={handleVoteClick}
     >
-      {!isPreview && imageUrl && <S.Image src={`${imageBaseUrl}/${imageUrl}`} alt={text} />}
+      {!isPreview && imageUrl && (
+        <S.Image src={`${imageBaseUrl}/${imageUrl}`} alt={'선택지에 포함된 이미지'} />
+      )}
       {isPreview ? (
         <S.PreviewContent aria-label="선택지 내용">{text}</S.PreviewContent>
       ) : (

--- a/frontend/src/mocks/mockData/user.ts
+++ b/frontend/src/mocks/mockData/user.ts
@@ -4,5 +4,6 @@ export const MOCK_USER_INFO: UserInfoResponse = {
   nickname: '우아한 코끼리',
   postCount: 4,
   voteCount: 128,
-  userPoint: 200,
+  gender: 'FEMALE',
+  birthYear: 1997,
 };

--- a/frontend/src/pages/post/PostDetail/index.tsx
+++ b/frontend/src/pages/post/PostDetail/index.tsx
@@ -42,10 +42,10 @@ export default function PostDetailPage() {
             <></>
           </NarrowTemplateHeader>
         </S.HeaderContainer>
-        <S.Container>
+        <S.MainContainer>
           {isLoading && 'loading'}
           {errorMessage && errorMessage}
-        </S.Container>
+        </S.MainContainer>
       </Layout>
     );
   }
@@ -115,21 +115,23 @@ export default function PostDetailPage() {
           />
         </NarrowTemplateHeader>
       </S.HeaderContainer>
-      <S.Container>
+      <S.MainContainer>
         <Post postInfo={postData} isPreview={false} />
         <BottomButtonPart
           isClosed={isClosed}
           isWriter={isWriter}
           handleEvent={{ movePage, controlPost }}
         />
-      </S.Container>
-      {!isCommentLoading && commentData && (
-        <CommentList
-          commentList={commentData}
-          memberId={memberId}
-          isGuest={false}
-          postWriterName={'익명의손님1'}
-        />
+      </S.MainContainer>
+      {!isCommentLoading && (
+        <S.BottomContainer>
+          <CommentList
+            commentList={commentData ?? []}
+            memberId={memberId}
+            isGuest={false}
+            postWriterName={'익명의손님1'}
+          />
+        </S.BottomContainer>
       )}
     </Layout>
   );

--- a/frontend/src/pages/post/PostDetail/index.tsx
+++ b/frontend/src/pages/post/PostDetail/index.tsx
@@ -9,7 +9,6 @@ import { useDeletePost } from '@hooks/query/post/useDeletePost';
 import { useEarlyClosePost } from '@hooks/query/post/useEarlyClosePost';
 import { usePostDetail } from '@hooks/query/post/usePostDetail';
 
-
 import { reportContent } from '@api/report';
 
 import CommentList from '@components/comment/CommentList';
@@ -128,8 +127,8 @@ export default function PostDetailPage() {
           <CommentList
             commentList={commentData ?? []}
             memberId={memberId}
-            isGuest={false}
-            postWriterName={'익명의손님1'}
+            isGuest={!loggedInfo.isLoggedIn}
+            postWriterName={postData.writer.nickname}
           />
         </S.BottomContainer>
       )}

--- a/frontend/src/pages/post/PostDetail/style.ts
+++ b/frontend/src/pages/post/PostDetail/style.ts
@@ -2,7 +2,19 @@ import { styled } from 'styled-components';
 
 import { theme } from '@styles/theme';
 
-export const Container = styled.div`
+export const HeaderContainer = styled.div`
+  position: fixed;
+  width: 100%;
+  top: 0;
+
+  z-index: ${theme.zIndex.header};
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    display: none;
+  }
+`;
+
+export const MainContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -14,14 +26,7 @@ export const Container = styled.div`
   }
 `;
 
-export const HeaderContainer = styled.div`
-  position: fixed;
-  width: 100%;
-  top: 0;
-
-  z-index: ${theme.zIndex.header};
-
-  @media (min-width: ${theme.breakpoint.sm}) {
-    display: none;
-  }
+export const BottomContainer = styled.div`
+  margin: 10px;
+  margin-bottom: 30px;
 `;

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,17 +1,17 @@
 export interface User {
   nickname: string;
-  userPoint: number;
+  gender: 'FEMALE' | 'MALE';
+  birthYear: number;
   postCount: number;
   voteCount: number;
-  badge?: string;
 }
 
 export interface UserInfoResponse {
   nickname: string;
-  userPoint: number;
+  gender: 'FEMALE' | 'MALE';
+  birthYear: number;
   postCount: number;
   voteCount: number;
-  badge?: string;
 }
 
 export interface ModifyNicknameRequest {


### PR DESCRIPTION
## 🔥 연관 이슈

close: #334

## 📝 작업 요약
- 게시물 상세페이지 반응성 적용 오류
- 변화한 사용자 정보 api 적용
- 게시물에 사진이 포함되어 있으면 활성화 표시 옆에 표시
- 통계 페이지 여자/남자 색상 안내 표시

## 🔎 작업 상세 설명
- 게시물 상세페이지 반응성 적용 오류
    - 상세페이지 게시글 본문이 작아지는 오류 수정 : width 적용
    - 상세페이지 모바일버전에서 댓글이 본문과 가로길이가 다른 점 수정: 댓글에 margin 동일하게 적용
- 변화한 사용자 정보 api 적용
    - 사용자 정보 api: 포인트/칭호 삭제 > 성별/나이 받기
    - 게시글 목록 get api은 게시글 상세 response의 array형태라 수정할 부분 없음(서버에서는 원래 목록일때 imageUrl이 없었음)
- 게시물에 사진이 포함되어 있으면 활성화 표시 옆에 표시
    - 목록/상세 모두 보임
- 통계 페이지 여자/남자 색상 안내 표시
    - 성별보기로 갔을 때에만 보임 

## 🌟 논의 사항
아직 게시글 목록 get api가 서버에서 변경되지 않아 목록에서는 image가 다 있는 것으로 표시되나 상세페이지를 들어갔을 때 잘 적용되는 것을 확인함. 
