### PR TITLE
카카오 회원가입/로그인 응답 형식 수정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/votogether/domain/auth/dto/LoginResponse.java
@@ -1,7 +1,10 @@
 package com.votogether.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 응답")
 public record LoginResponse(
-        String accessToken,
-        String nickname
+        @Schema(description = "인증 토큰", example = "A1B2C3D4")
+        String accessToken
 ) {
 }

--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
         final Member member = Member.from(response);
         final Member registeredMember = memberService.register(member);
         final String token = tokenProcessor.generateToken(registeredMember);
-        return new LoginResponse(token, registeredMember.getNickname());
+        return new LoginResponse(token);
     }
 
 }

--- a/backend/src/test/java/com/votogether/domain/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/auth/controller/AuthControllerTest.java
@@ -39,8 +39,7 @@ class AuthControllerTest {
     void loginByKakao() {
         // given
         String accessToken = "abcdefg";
-        String nickname = "jeomxon";
-        LoginResponse response = new LoginResponse(accessToken, nickname);
+        LoginResponse response = new LoginResponse(accessToken);
 
         given(authService.register(any())).willReturn(response);
 


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #331

## 📝 작업 요약

카카오 회원가입/로그인 응답 형식을 수정하였습니다.

## 🔎 작업 상세 설명

기존에 로그인 응답으로 전달하던 사용하지 않는 닉네임 필드를 제거하였습니다.

## 🌟 논의 사항

남은 레벨3 퐈이팅 🔥