### PR TITLE
내 정보 조회 응답 형식 수정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/member/dto/MemberInfoResponse.java
+++ b/backend/src/main/java/com/votogether/domain/member/dto/MemberInfoResponse.java
@@ -1,12 +1,18 @@
 package com.votogether.domain.member.dto;
 
-import com.votogether.domain.member.entity.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "회원 정보 응답")
 public record MemberInfoResponse(
+        @Schema(description = "닉네임", example = "유저")
         String nickname,
-        Gender gender,
+        @Schema(description = "성별", example = "남성")
+        String gender,
+        @Schema(description = "출생년도", example = "2002")
         Integer birthYear,
+        @Schema(description = "작성한 게시글 수", example = "5")
         int postCount,
+        @Schema(description = "투표한 수", example = "10")
         int voteCount
 ) {
 }

--- a/backend/src/main/java/com/votogether/domain/member/entity/Gender.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Gender.java
@@ -1,9 +1,18 @@
 package com.votogether.domain.member.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum Gender {
 
-    MALE,
-    FEMALE,
+    MALE("남성"),
+    FEMALE("여성"),
     ;
+
+    private final String name;
+
+    Gender(final String name) {
+        this.name = name;
+    }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -44,7 +44,7 @@ public class MemberService {
 
         return new MemberInfoResponse(
                 member.getNickname(),
-                member.getGender(),
+                member.getGender().getName(),
                 member.getBirthYear(),
                 numberOfPosts,
                 numberOfVotes

--- a/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
@@ -58,7 +58,7 @@ class MemberControllerTest {
         TokenPayload tokenPayload = new TokenPayload(1L, 1L, 1L);
         MemberInfoResponse memberInfoResponse = new MemberInfoResponse(
                 "저문",
-                Gender.MALE,
+                Gender.MALE.getName(),
                 1988,
                 0,
                 0


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #332

## 📝 작업 요약

내 정보 조회 응답 형식을 수정하였습니다.

## 🔎 작업 상세 설명

기존의 응답 형식에서 추가적으로 성별과 출생년도 정보를 응답할 수 있도록 하였습니다.

## 🌟 논의 사항

성별 정보를 클라이언트에게 전달할 때 Enum명인 `MALE`, `FEMALE`로 전달할지, `남성`, `여성`으로 전달할지 고민이 됩니다 🤔

`MALE`, `FEMALE` 형식으로 전달하면 클라이언트에세 사용하기 위해 클라이언트에서 한번 더 가공할 것 같은데 서버에서 클라이언트에서 바로 사용할 수 있도록 정보를 가공해서 전달해주는 것이 더 좋다고 생각하였는데 다들 분들은 어떻게 생각하시는지 궁금합니다 :)