### PR TITLE
전체 게시글 조회시, 마감된 글은 투표 결과 전부 공개 기능 구현

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/PostResponse.java
@@ -40,7 +40,7 @@ public record PostResponse(
                 post.getCreatedAt(),
                 post.getDeadline(),
                 VoteResponse.of(
-                        post.getPostOptions().getSelectedOptionId(loginMember),
+                        post.getSelectedOptionId(loginMember),
                         post.getFinalTotalVoteCount(loginMember),
                         getOptions(post, loginMember)
                 )

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/detail/PostDetailResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/detail/PostDetailResponse.java
@@ -47,7 +47,7 @@ public record PostDetailResponse(
                 post.getCreatedAt(),
                 post.getDeadline(),
                 VoteDetailResponse.of(
-                        post.getPostOptions().getSelectedOptionId(loginMember),
+                        post.getSelectedOptionId(loginMember),
                         post.getFinalTotalVoteCount(loginMember),
                         getOptions(post, loginMember)
                 )

--- a/backend/src/main/java/com/votogether/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/Post.java
@@ -125,6 +125,10 @@ public class Post extends BaseEntity {
         }
     }
 
+    public long getSelectedOptionId(final Member member) {
+        return this.postOptions.getSelectedOptionId(member);
+    }
+
     public Vote makeVote(final Member voter, final PostOption postOption) {
         validateDeadLine();
         validateVoter(voter);
@@ -181,7 +185,9 @@ public class Post extends BaseEntity {
     }
 
     public boolean isVisibleVoteResult(final Member member) {
-        return this.postOptions.getSelectedOptionId(member) != 0 || this.writer.equals(member);
+        return this.postOptions.getSelectedOptionId(member) != 0
+                || this.writer.equals(member)
+                || isClosed();
     }
 
     public void blind() {

--- a/backend/src/test/java/com/votogether/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/service/PostServiceTest.java
@@ -32,6 +32,7 @@ import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.PostBody;
 import com.votogether.domain.post.entity.PostClosingType;
 import com.votogether.domain.post.entity.PostOption;
+import com.votogether.domain.post.entity.PostOptions;
 import com.votogether.domain.post.entity.PostSortType;
 import com.votogether.domain.post.exception.PostExceptionType;
 import com.votogether.domain.post.repository.PostOptionRepository;
@@ -653,11 +654,11 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("한 게시글의 상세를 조회한다.")
-    void getPost() throws IOException {
+    @DisplayName("한 게시글의 상세를 조회할 시, 작성자면 투표 결과를 알 수 있다.")
+    void getPostByWriter() throws IOException {
         Category category1 = categoryRepository.save(CategoryFixtures.DEVELOP.get());
         Category category2 = categoryRepository.save(CategoryFixtures.FOOD.get());
-        Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+        Member writer = memberRepository.save(MemberFixtures.MALE_20.get());
 
         MockMultipartFile file1 = new MockMultipartFile(
                 "image1",
@@ -690,14 +691,14 @@ class PostServiceTest {
                 .deadline(deadline)
                 .build();
 
-        Long savedPostId = postService.save(postCreateRequest, member, List.of(), List.of(file1, file2));
+        Long savedPostId = postService.save(postCreateRequest, writer, List.of(), List.of(file1, file2));
 
         // when
-        PostDetailResponse response = postService.getPostById(savedPostId, member);
+        PostDetailResponse response = postService.getPostById(savedPostId, writer);
 
         // then
         List<CategoryResponse> categories = response.categories();
-        WriterResponse writer = response.writer();
+        WriterResponse writerResponse = response.writer();
         VoteDetailResponse voteDetailResponse = response.voteInfo();
         List<PostOptionDetailResponse> options = voteDetailResponse.options();
 
@@ -705,12 +706,209 @@ class PostServiceTest {
                 () -> assertThat(response.postId()).isEqualTo(savedPostId),
                 () -> assertThat(response.title()).isEqualTo("title"),
                 () -> assertThat(response.content()).isEqualTo("content"),
-                () -> assertThat(response.deadline()).isEqualTo(deadline),
                 () -> assertThat(categories).hasSize(2),
                 () -> assertThat(categories.get(0).name()).isEqualTo("개발"),
-                () -> assertThat(writer.id()).isEqualTo(member.getId()),
-                () -> assertThat(writer.nickname()).isEqualTo("user7"),
+                () -> assertThat(writerResponse.id()).isEqualTo(writer.getId()),
+                () -> assertThat(writerResponse.nickname()).isEqualTo("user7"),
                 () -> assertThat(voteDetailResponse.totalVoteCount()).isZero(),
+                () -> assertThat(options).hasSize(2),
+                () -> assertThat(options.get(0).imageUrl()).contains("test1.png")
+        );
+    }
+
+    @Test
+    @DisplayName("한 게시글의 상세를 조회할 시, 해당 게시글의 투표자면 결과를 알 수 있다.")
+    void getPostByVoter() throws IOException {
+        Category category1 = categoryRepository.save(CategoryFixtures.DEVELOP.get());
+        Category category2 = categoryRepository.save(CategoryFixtures.FOOD.get());
+        Member voter = memberRepository.save(MemberFixtures.MALE_20.get());
+        Member writer = memberRepository.save(MemberFixtures.FEMALE_30.get());
+
+        MockMultipartFile file1 = new MockMultipartFile(
+                "image1",
+                "test1.png",
+                "image/png",
+                new FileInputStream("src/test/resources/images/testImage1.PNG")
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "image1",
+                "test2.png",
+                "image/png",
+                new FileInputStream("src/test/resources/images/testImage2.PNG")
+        );
+
+        LocalDateTime deadline = LocalDateTime.now().plusDays(3);
+
+        PostOptionCreateRequest option1 = PostOptionCreateRequest.builder()
+                .content("option1")
+                .build();
+
+        PostOptionCreateRequest option2 = PostOptionCreateRequest.builder()
+                .content("option2")
+                .build();
+
+        PostCreateRequest postCreateRequest = PostCreateRequest.builder()
+                .categoryIds(List.of(category1.getId(), category2.getId()))
+                .title("title")
+                .content("content")
+                .postOptions(List.of(option1, option2))
+                .deadline(deadline)
+                .build();
+
+        Long savedPostId = postService.save(postCreateRequest, writer, List.of(), List.of(file1, file2));
+        Post post = postRepository.findById(savedPostId).get();
+        PostOptions postOptions = post.getPostOptions();
+        PostOption postOption = postOptions.getPostOptions().get(0);
+        voteService.vote(voter, savedPostId, postOption.getId());
+
+        entityManager.clear();
+
+        // when
+        PostDetailResponse response = postService.getPostById(savedPostId, voter);
+
+        // then
+        List<CategoryResponse> categories = response.categories();
+        WriterResponse writerResponse = response.writer();
+        VoteDetailResponse voteDetailResponse = response.voteInfo();
+        List<PostOptionDetailResponse> options = voteDetailResponse.options();
+
+        assertAll(
+                () -> assertThat(response.postId()).isEqualTo(savedPostId),
+                () -> assertThat(response.title()).isEqualTo("title"),
+                () -> assertThat(response.content()).isEqualTo("content"),
+                () -> assertThat(categories).hasSize(2),
+                () -> assertThat(categories.get(0).name()).isEqualTo("개발"),
+                () -> assertThat(writerResponse.id()).isEqualTo(writer.getId()),
+                () -> assertThat(writerResponse.nickname()).isEqualTo("user10"),
+                () -> assertThat(voteDetailResponse.totalVoteCount()).isOne(),
+                () -> assertThat(options).hasSize(2),
+                () -> assertThat(options.get(0).imageUrl()).contains("test1.png")
+        );
+    }
+
+    @Test
+    @DisplayName("한 게시글의 상세를 조회할 시, 마감된 게시글이면 투표 결과를 알 수 있다.")
+    void getClosedPost() throws IOException {
+        Category category1 = categoryRepository.save(CategoryFixtures.DEVELOP.get());
+        Category category2 = categoryRepository.save(CategoryFixtures.FOOD.get());
+        Member member = memberRepository.save(MemberFixtures.FEMALE_10.get());
+        Member writer = memberRepository.save(MemberFixtures.MALE_20.get());
+
+        MockMultipartFile file1 = new MockMultipartFile(
+                "image1",
+                "test1.png",
+                "image/png",
+                new FileInputStream("src/test/resources/images/testImage1.PNG")
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "image1",
+                "test2.png",
+                "image/png",
+                new FileInputStream("src/test/resources/images/testImage2.PNG")
+        );
+
+        LocalDateTime deadline = LocalDateTime.now();
+
+        PostOptionCreateRequest option1 = PostOptionCreateRequest.builder()
+                .content("option1")
+                .build();
+
+        PostOptionCreateRequest option2 = PostOptionCreateRequest.builder()
+                .content("option2")
+                .build();
+
+        PostCreateRequest postCreateRequest = PostCreateRequest.builder()
+                .categoryIds(List.of(category1.getId(), category2.getId()))
+                .title("title")
+                .content("content")
+                .postOptions(List.of(option1, option2))
+                .deadline(deadline)
+                .build();
+
+        Long savedPostId = postService.save(postCreateRequest, writer, List.of(), List.of(file1, file2));
+
+        // when
+        PostDetailResponse response = postService.getPostById(savedPostId, member);
+
+        // then
+        List<CategoryResponse> categories = response.categories();
+        WriterResponse writerResponse = response.writer();
+        VoteDetailResponse voteDetailResponse = response.voteInfo();
+        List<PostOptionDetailResponse> options = voteDetailResponse.options();
+
+        assertAll(
+                () -> assertThat(response.postId()).isEqualTo(savedPostId),
+                () -> assertThat(response.title()).isEqualTo("title"),
+                () -> assertThat(response.content()).isEqualTo("content"),
+                () -> assertThat(categories).hasSize(2),
+                () -> assertThat(categories.get(0).name()).isEqualTo("개발"),
+                () -> assertThat(writerResponse.id()).isEqualTo(writer.getId()),
+                () -> assertThat(writerResponse.nickname()).isEqualTo("user7"),
+                () -> assertThat(voteDetailResponse.totalVoteCount()).isZero(),
+                () -> assertThat(options).hasSize(2),
+                () -> assertThat(options.get(0).imageUrl()).contains("test1.png")
+        );
+    }
+
+    @Test
+    @DisplayName("한 게시글의 상세를 조회할 시, 작성자, 투표자, 마감된 게시글이 전부 아니면 투표 결과를 알 수 없다.")
+    void getPostInvisibleResult() throws IOException {
+        Category category1 = categoryRepository.save(CategoryFixtures.DEVELOP.get());
+        Category category2 = categoryRepository.save(CategoryFixtures.FOOD.get());
+        Member member = memberRepository.save(MemberFixtures.FEMALE_10.get());
+        Member writer = memberRepository.save(MemberFixtures.MALE_20.get());
+
+        MockMultipartFile file1 = new MockMultipartFile(
+                "image1",
+                "test1.png",
+                "image/png",
+                new FileInputStream("src/test/resources/images/testImage1.PNG")
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "image1",
+                "test2.png",
+                "image/png",
+                new FileInputStream("src/test/resources/images/testImage2.PNG")
+        );
+
+        LocalDateTime deadline = LocalDateTime.now().plusDays(3);
+
+        PostOptionCreateRequest option1 = PostOptionCreateRequest.builder()
+                .content("option1")
+                .build();
+
+        PostOptionCreateRequest option2 = PostOptionCreateRequest.builder()
+                .content("option2")
+                .build();
+
+        PostCreateRequest postCreateRequest = PostCreateRequest.builder()
+                .categoryIds(List.of(category1.getId(), category2.getId()))
+                .title("title")
+                .content("content")
+                .postOptions(List.of(option1, option2))
+                .deadline(deadline)
+                .build();
+
+        Long savedPostId = postService.save(postCreateRequest, writer, List.of(), List.of(file1, file2));
+
+        // when
+        PostDetailResponse response = postService.getPostById(savedPostId, member);
+
+        // then
+        List<CategoryResponse> categories = response.categories();
+        WriterResponse writerResponse = response.writer();
+        VoteDetailResponse voteDetailResponse = response.voteInfo();
+        List<PostOptionDetailResponse> options = voteDetailResponse.options();
+
+        assertAll(
+                () -> assertThat(response.postId()).isEqualTo(savedPostId),
+                () -> assertThat(response.title()).isEqualTo("title"),
+                () -> assertThat(response.content()).isEqualTo("content"),
+                () -> assertThat(categories).hasSize(2),
+                () -> assertThat(categories.get(0).name()).isEqualTo("개발"),
+                () -> assertThat(writerResponse.id()).isEqualTo(writer.getId()),
+                () -> assertThat(writerResponse.nickname()).isEqualTo("user7"),
+                () -> assertThat(voteDetailResponse.totalVoteCount()).isEqualTo(-1),
                 () -> assertThat(options).hasSize(2),
                 () -> assertThat(options.get(0).imageUrl()).contains("test1.png")
         );


### PR DESCRIPTION
## 🔥 연관 이슈

close: #317 

## 📝 작업 요약

전체 게시글 조회시, 마감된 글은 투표 결과 전부 공개 기능 구현

## 🔎 작업 상세 설명

전체 게시글 조회시, 마감된 글은 투표 결과 전부 공개 기능 구현
