### PR TITLE
성별, 출생년도 null 반환 가능하도록 수정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/member/dto/MemberInfoResponse.java
+++ b/backend/src/main/java/com/votogether/domain/member/dto/MemberInfoResponse.java
@@ -1,17 +1,22 @@
 package com.votogether.domain.member.dto;
 
+import com.votogether.domain.member.entity.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "회원 정보 응답")
 public record MemberInfoResponse(
         @Schema(description = "닉네임", example = "유저")
         String nickname,
+
         @Schema(description = "성별", example = "남성")
-        String gender,
+        Gender gender,
+
         @Schema(description = "출생년도", example = "2002")
         Integer birthYear,
+
         @Schema(description = "작성한 게시글 수", example = "5")
         int postCount,
+
         @Schema(description = "투표한 수", example = "10")
         int voteCount
 ) {

--- a/backend/src/main/java/com/votogether/domain/member/entity/Gender.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Gender.java
@@ -1,18 +1,9 @@
 package com.votogether.domain.member.entity;
 
-import lombok.Getter;
-
-@Getter
 public enum Gender {
 
-    MALE("남성"),
-    FEMALE("여성"),
+    MALE,
+    FEMALE,
     ;
-
-    private final String name;
-
-    Gender(final String name) {
-        this.name = name;
-    }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -44,7 +44,7 @@ public class MemberService {
 
         return new MemberInfoResponse(
                 member.getNickname(),
-                member.getGender().getName(),
+                member.getGender(),
                 member.getBirthYear(),
                 numberOfPosts,
                 numberOfVotes

--- a/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
@@ -58,7 +58,7 @@ class MemberControllerTest {
         TokenPayload tokenPayload = new TokenPayload(1L, 1L, 1L);
         MemberInfoResponse memberInfoResponse = new MemberInfoResponse(
                 "저문",
-                Gender.MALE.getName(),
+                Gender.MALE,
                 1988,
                 0,
                 0


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #341

## 📝 작업 요약

성별, 출생년도 `null` 반환이 가능하도록 수정하였습니다.

## ⏰ 소요 시간

3분

## 🔎 작업 상세 설명

- 프론트 요청에 따라 성별 응답 형식을 `MALE`, `FEMALE`로 정하였습니다.
- 성별, 출생년도는 `null`이 들어갈 수 있기 때문에 `null` 반환이 가능하도록 하였습니다.

## 🌟 논의 사항

VoTogether팀 화이팅 🔥