### PR TITLE
usePostDetail의 인수가 하나라서 발생하는 오류

### DIFF
--- a/frontend/src/pages/post/EditPost/index.tsx
+++ b/frontend/src/pages/post/EditPost/index.tsx
@@ -14,7 +14,8 @@ export default function EditPost() {
 
   const { postId } = useParams();
 
-  const { data } = usePostDetail(Number(postId));
+  //해당 페이지는 게스트는 접근할 수 없으므로 필수적으로 true
+  const { data } = usePostDetail(true, Number(postId));
   const { mutate, isSuccess, isError, error } = useEditPost(Number(postId));
 
   useEffect(() => {


### PR DESCRIPTION
## 🔥 연관 이슈

close: #355
:usePostDetail의 인수가 하나라서 발생하는 오류

## 📝 작업 요약
usePostDetail의 인수가 하나라서 발생하는 오류 해결

## ⏰ 소요 시간
5분..?

## 🔎 작업 상세 설명
해당 부분에서 isGuest가 첫번째 인수로 들어가야 했는데 작성되지 않음.
글 수정페이지라 게스트가 진입할 수 없기 때문에(제로가 진입 못하도록 로직 구현 중이기 때문에) true로 설정해놓음.

## 🌟 논의 사항

