### PR TITLE
전체 게시글 목록 조회 시 카테고리도 함께 조회할 수 있도록 변경

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostController.java
@@ -106,14 +106,19 @@ public class PostController {
     })
     @GetMapping
     public ResponseEntity<List<PostResponse>> getAllPost(
-            final int page,
-            final PostClosingType postClosingType,
-            final PostSortType postSortType,
+            @RequestParam final int page,
+            @RequestParam final PostClosingType postClosingType,
+            @RequestParam final PostSortType postSortType,
+            @RequestParam(name = "category", required = false) final Long categoryId,
             @Auth final Member member
     ) {
-        final List<PostResponse> responses =
-                postService.getAllPostBySortTypeAndClosingType(member, page, postClosingType, postSortType);
-
+        final List<PostResponse> responses = postService.getAllPostBySortTypeAndClosingTypeAndCategoryId(
+                page,
+                postClosingType,
+                postSortType,
+                categoryId,
+                member
+        );
         return ResponseEntity.ok(responses);
     }
 

--- a/backend/src/test/java/com/votogether/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/service/PostServiceTest.java
@@ -62,7 +62,6 @@ import jakarta.persistence.EntityManager;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -604,11 +603,12 @@ class PostServiceTest {
         entityManager.clear();
 
         // when
-        List<PostResponse> responses = postService.getAllPostBySortTypeAndClosingType(
-                memberToAllPostVote,
+        List<PostResponse> responses = postService.getAllPostBySortTypeAndClosingTypeAndCategoryId(
                 0,
                 PostClosingType.PROGRESS,
-                PostSortType.HOT
+                PostSortType.HOT,
+                null,
+                memberToAllPostVote
         );
 
         // then


### PR DESCRIPTION
## 🔥 연관 이슈

close: #360 

## 📝 작업 요약

전체 게시글 목록 조회 시 카테고리도 함께 조회할 수 있도록 변경했습니다.

## ⏰ 소요 시간

1시간

## 🔎 작업 상세 설명

쿼리 스트링에 카테고리 ID도 포함될 수 있도록 수정
하지만 category라는 쿼리스트링이 포함되지 않아도 조회 가능함

## 🌟 논의 사항

없음.
