### PR TITLE
비회원 게시글 검색 기능

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostController.java
@@ -269,6 +269,24 @@ public class PostController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "게시글 검색(비회원)", description = "비회원으로 키워드를 통해 게시글을 검색한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 검색 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 쿼리 파라미터값 입력"),
+    })
+    @GetMapping("/search/guest")
+    public ResponseEntity<List<PostResponse>> searchPostsWithKeywordForGuest(
+            @RequestParam final String keyword,
+            @RequestParam final int page,
+            @RequestParam final PostClosingType postClosingType,
+            @RequestParam final PostSortType postSortType,
+            @RequestParam(required = false, name = "category") final Long categoryId
+    ) {
+        final List<PostResponse> responses =
+                postService.searchPostsWithKeywordForGuest(keyword, page, postClosingType, postSortType, categoryId);
+        return ResponseEntity.ok(responses);
+    }
+
 }
 
 

--- a/backend/src/main/java/com/votogether/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostService.java
@@ -301,6 +301,21 @@ public class PostService {
                 .toList();
     }
 
+    public List<PostResponse> searchPostsWithKeywordForGuest(
+            final String keyword,
+            final int page,
+            final PostClosingType postClosingType,
+            final PostSortType postSortType,
+            final Long categoryId
+            ) {
+        final Pageable pageable = PageRequest.of(page, BASIC_PAGING_SIZE);
+        final List<Post> posts =
+                postRepository.findAllWithKeyword(keyword, postClosingType, postSortType, categoryId, pageable);
+
+        return posts.stream()
+                .map(post -> PostResponse.forGuest(post))
+                .toList();
+    }
 
     @Transactional
     public void delete(final Long postId) {


### PR DESCRIPTION
## 🔥 연관 이슈

close: #313 

## 📝 작업 요약

비회원으로 게시글을 검색하는 기능입니다.

## ⏰ 소요 시간

10분 

## 🔎 작업 상세 설명
회원으로 게시글 검색 하는 기능을 복붙하여 구현하였습니다.
컨트롤러와 서비스 계층에 비회원을 위한 게시글 검색 메서드가 추가되었습니다.

## 🌟 논의 사항
없음
