### PR TITLE
로그인 시 응답하는 회원의 필수정보 필드 추가

### DIFF
--- a/backend/src/main/java/com/votogether/domain/auth/dto/LoginResponse.java
+++ b/backend/src/main/java/com/votogether/domain/auth/dto/LoginResponse.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "로그인 응답")
 public record LoginResponse(
         @Schema(description = "인증 토큰", example = "A1B2C3D4")
-        String accessToken
+        String accessToken,
+
+        @Schema(description = "성별, 나이대 정보를 가지고 있는지 여부", example = "true")
+        boolean hasEssentialInfo
 ) {
 }

--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
         final Member member = Member.from(response);
         final Member registeredMember = memberService.register(member);
         final String token = tokenProcessor.generateToken(registeredMember);
-        return new LoginResponse(token);
+        return new LoginResponse(token, registeredMember.hasEssentialInfo());
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -88,6 +88,10 @@ public class Member extends BaseEntity {
         this.birthYear = birthYear;
     }
 
+    public boolean hasEssentialInfo() {
+        return (this.gender != null && this.birthYear != null);
+    }
+
     public String getNickname() {
         return this.nickname.getValue();
     }

--- a/backend/src/test/java/com/votogether/domain/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/auth/controller/AuthControllerTest.java
@@ -39,7 +39,7 @@ class AuthControllerTest {
     void loginByKakao() {
         // given
         String accessToken = "abcdefg";
-        LoginResponse response = new LoginResponse(accessToken);
+        LoginResponse response = new LoginResponse(accessToken, false);
 
         given(authService.register(any())).willReturn(response);
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #374 

## 📝 작업 요약

로그인 시 responseDto에 성별, 나이대가 Null인지 아닌지에 대한 필드 추가

## ⏰ 소요 시간

10분
예상보다 테스트 의존이 많이 걸려있지 않아서 빠르게 수정했다.

## 🔎 작업 상세 설명

없음.

## 🌟 논의 사항

없음.
