### PR TITLE
게시글 수정을 할 때 마감시간이 설정되도록 구현

### DIFF
--- a/frontend/__test__/calculateDeadlineTime.test.ts
+++ b/frontend/__test__/calculateDeadlineTime.test.ts
@@ -65,4 +65,30 @@ describe('calculateDeadlineTime 함수를 이용해서 시작시간과 마감시
       minute: 59,
     });
   });
+
+  test('시작 시간이 undefined, 마감 시간: 2023-07-14 23:59 일 때 0일 0시간 0분을 반환한다.', () => {
+    const createdAt = undefined;
+    const deadline = '2023-07-14 23:59';
+
+    const result = calculateDeadlineTime(createdAt, deadline);
+
+    expect(result).toEqual({
+      day: 0,
+      hour: 0,
+      minute: 0,
+    });
+  });
+
+  test('시작 시간이 2023-07-14 23:59, 마감 시간: undefined 일 때 0일 0시간 0분을 반환한다.', () => {
+    const createdAt = '2023-07-14 23:59';
+    const deadline = undefined;
+
+    const result = calculateDeadlineTime(createdAt, deadline);
+
+    expect(result).toEqual({
+      day: 0,
+      hour: 0,
+      minute: 0,
+    });
+  });
 });

--- a/frontend/__test__/calculateDeadlineTime.test.ts
+++ b/frontend/__test__/calculateDeadlineTime.test.ts
@@ -1,0 +1,68 @@
+import { calculateDeadlineTime } from '@utils/post/calculateDeadlineTime';
+
+describe('calculateDeadlineTime 함수를 이용해서 시작시간과 마감시간으로 몇일, 몇시간, 몇분을 설정했는지 구한다.', () => {
+  test('시작 시간: 2023-07-12 12:40, 마감 시간: 2023-07-13 12:40 일 때 하루를 반환한다.', () => {
+    const createdAt = '2023-07-12 12:40';
+    const deadline = '2023-07-13 12:40';
+
+    const result = calculateDeadlineTime(createdAt, deadline);
+
+    expect(result).toEqual({
+      day: 1,
+      hour: 0,
+      minute: 0,
+    });
+  });
+
+  test('시작 시간: 2023-07-12 12:40, 마감 시간: 2023-07-13 18:40 일 때 1일 6시간을 반환한다.', () => {
+    const createdAt = '2023-07-12 12:40';
+    const deadline = '2023-07-13 18:40';
+
+    const result = calculateDeadlineTime(createdAt, deadline);
+
+    expect(result).toEqual({
+      day: 1,
+      hour: 6,
+      minute: 0,
+    });
+  });
+
+  test('시작 시간: 2023-07-12 12:40, 마감 시간: 2023-07-13 18:20 일 때 1일 5시간 40분을 반환한다.', () => {
+    const createdAt = '2023-07-12 12:40';
+    const deadline = '2023-07-13 18:20';
+
+    const result = calculateDeadlineTime(createdAt, deadline);
+
+    expect(result).toEqual({
+      day: 1,
+      hour: 5,
+      minute: 40,
+    });
+  });
+
+  test('시작 시간: 2023-07-12 12:40, 마감 시간: 2023-07-12 12:50 일 때 10분을 반환한다.', () => {
+    const createdAt = '2023-07-12 12:40';
+    const deadline = '2023-07-12 12:50';
+
+    const result = calculateDeadlineTime(createdAt, deadline);
+
+    expect(result).toEqual({
+      day: 0,
+      hour: 0,
+      minute: 10,
+    });
+  });
+
+  test('시작 시간: 2023-07-12 00:00, 마감 시간: 2023-07-14 23:59 일 때 2일 23시간 59분을 반환한다.', () => {
+    const createdAt = '2023-07-12 00:00';
+    const deadline = '2023-07-14 23:59';
+
+    const result = calculateDeadlineTime(createdAt, deadline);
+
+    expect(result).toEqual({
+      day: 2,
+      hour: 23,
+      minute: 59,
+    });
+  });
+});

--- a/frontend/__test__/getSelectedTimeOption.test.ts
+++ b/frontend/__test__/getSelectedTimeOption.test.ts
@@ -1,0 +1,99 @@
+import { getSelectedTimeOption } from '@utils/post/getSelectedTimeOption';
+
+describe('getSelectedTimeOption 함수에서 day, hour, minute 객체를 입력받아 "10분" | "30분" | "1시간" | "6시간" | "1일" | "사용자 지정" | null 을 반환한다.', () => {
+  test('10분 객체를 입력했을 때 10분을 반환한다.', () => {
+    const time = {
+      day: 0,
+      hour: 0,
+      minute: 10,
+    };
+
+    const result = getSelectedTimeOption(time);
+
+    expect(result).toBe('10분');
+  });
+
+  test('30분 객체를 입력했을 때 30분을 반환한다.', () => {
+    const time = {
+      day: 0,
+      hour: 0,
+      minute: 30,
+    };
+
+    const result = getSelectedTimeOption(time);
+
+    expect(result).toBe('30분');
+  });
+
+  test('1시간 객체를 입력했을 때 1시간을 반환한다.', () => {
+    const time = {
+      day: 0,
+      hour: 1,
+      minute: 0,
+    };
+
+    const result = getSelectedTimeOption(time);
+
+    expect(result).toBe('1시간');
+  });
+
+  test('6시간 객체를 입력했을 때 6시간을 반환한다.', () => {
+    const time = {
+      day: 0,
+      hour: 6,
+      minute: 0,
+    };
+
+    const result = getSelectedTimeOption(time);
+
+    expect(result).toBe('6시간');
+  });
+
+  test('1일 객체를 입력했을 때 1일을 반환한다.', () => {
+    const time = {
+      day: 1,
+      hour: 0,
+      minute: 0,
+    };
+
+    const result = getSelectedTimeOption(time);
+
+    expect(result).toBe('1일');
+  });
+
+  test('2일 객체를 입력했을 때 사용자지정을 반환한다.', () => {
+    const time = {
+      day: 2,
+      hour: 0,
+      minute: 0,
+    };
+
+    const result = getSelectedTimeOption(time);
+
+    expect(result).toBe('사용자지정');
+  });
+
+  test('3분 객체를 입력했을 때 사용자지정을 반환한다.', () => {
+    const time = {
+      day: 0,
+      hour: 0,
+      minute: 3,
+    };
+
+    const result = getSelectedTimeOption(time);
+
+    expect(result).toBe('사용자지정');
+  });
+
+  test('0일 0시간 0분 객체를 입력했을 때 null을 반환한다.', () => {
+    const time = {
+      day: 0,
+      hour: 0,
+      minute: 0,
+    };
+
+    const result = getSelectedTimeOption(time);
+
+    expect(result).toBe(null);
+  });
+});

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -24,9 +24,11 @@ import WritingVoteOptionList from '@components/optionList/WritingVoteOptionList'
 import { PATH } from '@constants/path';
 import { CATEGORY_COUNT_LIMIT, POST_CONTENT, POST_TITLE } from '@constants/post';
 
+import { calculateDeadlineTime } from '@utils/post/calculateDeadlineTime';
 import { checkWriter } from '@utils/post/checkWriter';
 import { addTimeToDate, formatTimeWithOption } from '@utils/post/formatTime';
 import { getDeadlineTime } from '@utils/post/getDeadlineTime';
+import { getSelectedTimeOption } from '@utils/post/getSelectedTimeOption';
 import { checkIrreplaceableTime } from '@utils/time';
 
 import CategoryWrapper from './CategoryWrapper';
@@ -56,13 +58,11 @@ export default function PostForm({ data, mutate }: PostFormProps) {
   const writingOptionHook = useWritingOption(voteInfo?.options);
   const contentImageHook = useContentImage(imageUrl);
   const { isToastOpen, openToast, toastMessage } = useToast();
-  const [selectTimeOption, setSelectTimeOption] = useState<DeadlineOption | '사용자지정'>();
+  const [selectTimeOption, setSelectTimeOption] = useState<DeadlineOption | '사용자지정' | null>(
+    getSelectedTimeOption(calculateDeadlineTime(createTime, deadline))
+  );
   const { isOpen, openComponent, closeComponent } = useToggle();
-  const [time, setTime] = useState({
-    day: 0,
-    hour: 0,
-    minute: 0,
-  });
+  const [time, setTime] = useState(calculateDeadlineTime(createTime, deadline));
   const baseTime = createTime ? new Date(createTime) : new Date();
   const closeModal = () => {
     if (data && checkIrreplaceableTime(time, data.createTime)) {
@@ -73,10 +73,10 @@ export default function PostForm({ data, mutate }: PostFormProps) {
         minute: 0,
       };
       setTime(updatedTime);
-      setSelectTimeOption(undefined);
+      setSelectTimeOption(null);
     }
 
-    setSelectTimeOption(Object.values(time).every(time => time === 0) ? undefined : '사용자지정');
+    setSelectTimeOption(Object.values(time).every(time => time === 0) ? null : '사용자지정');
     closeComponent();
   };
 

--- a/frontend/src/utils/post/calculateDeadlineTime.ts
+++ b/frontend/src/utils/post/calculateDeadlineTime.ts
@@ -1,4 +1,12 @@
-export const calculateDeadlineTime = (createdAt: string, deadLine: string) => {
+export const calculateDeadlineTime = (createdAt?: string, deadLine?: string) => {
+  if (!createdAt || !deadLine) {
+    return {
+      day: 0,
+      hour: 0,
+      minute: 0,
+    };
+  }
+
   const createTimeNumber = new Date(createdAt);
 
   const deadlineTimeNumber = new Date(deadLine);

--- a/frontend/src/utils/post/calculateDeadlineTime.ts
+++ b/frontend/src/utils/post/calculateDeadlineTime.ts
@@ -1,0 +1,24 @@
+export const calculateDeadlineTime = (createdAt: string, deadLine: string) => {
+  const createTimeNumber = new Date(createdAt);
+
+  const deadlineTimeNumber = new Date(deadLine);
+
+  const timeDifference = Number(deadlineTimeNumber) - Number(createTimeNumber);
+
+  const minuteUnit = 60_000;
+  const hourUnit = minuteUnit * 60;
+  const dayUnit = hourUnit * 24;
+
+  const hourTimeInMilliseconds = timeDifference % dayUnit;
+  const minuteTimeInMilliseconds = hourTimeInMilliseconds % hourUnit;
+
+  const day = Math.floor(timeDifference / dayUnit);
+  const hour = Math.floor(hourTimeInMilliseconds / hourUnit);
+  const minute = Math.floor(minuteTimeInMilliseconds / minuteUnit);
+
+  return {
+    day,
+    hour,
+    minute,
+  };
+};

--- a/frontend/src/utils/post/getSelectedTimeOption.ts
+++ b/frontend/src/utils/post/getSelectedTimeOption.ts
@@ -1,0 +1,20 @@
+import { DeadlineOption } from '@components/PostForm/constants';
+
+export const getSelectedTimeOption = ({
+  day,
+  hour,
+  minute,
+}: {
+  day: number;
+  hour: number;
+  minute: number;
+}): DeadlineOption | '사용자지정' | null => {
+  if (day === 0 && hour === 0 && minute === 0) return null;
+  if (day === 0 && hour === 0 && minute === 10) return '10분';
+  if (day === 0 && hour === 0 && minute === 30) return '30분';
+  if (day === 0 && hour === 1 && minute === 0) return '1시간';
+  if (day === 0 && hour === 6 && minute === 0) return '6시간';
+  if (day === 1 && hour === 0 && minute === 0) return '1일';
+
+  return '사용자지정';
+};


### PR DESCRIPTION
## 🔥 연관 이슈

close: #370 

## 📝 작업 요약

- 수정할 때 글에서 설정한 마감시간이 초기값이 설정되도록 구현


## ⏰ 소요 시간

1시간 30분

살려주세요

## 🔎 작업 상세 설명

- 선택된 시간 문자를 반환하는 함수에서 null을 반환하도록 함 , undefined를 반환하는 것이 자연스럽지 않게 느껴졌어요
- 그래서 PostForm에서 null을 사용하도록 함
```tsx
  const [selectTimeOption, setSelectTimeOption] = useState<DeadlineOption | '사용자지정' | null>(
    getSelectedTimeOption(calculateDeadlineTime(createTime, deadline))
  );
```


수정시 사진

<img width="1436" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/0beecaee-f822-4c5f-a864-658f9d921198">


<img width="1439" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/96d15fd1-6fe5-4a0d-809a-9b9121bb7328">

![image](https://github.com/woowacourse-teams/2023-votogether/assets/80146176/46e2006d-e238-416f-bdb2-5f51bf2dacbb)


게시글 생성시 사진 ( 마감시간을 선택해달라고 잘 되는 모습)

<img width="1440" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/e2801090-e01e-4337-8fd4-90cb4210e40b">



## 🌟 논의 사항

게시글 수정이 안되는 것은 왜 안되는지 잘 모르겠습니다  백앤드 로그에서 왜 실패 했는지를 확인해봐야 할 것 같아요 

그래서 마감시간만 수정해서 PR 올려요



