### PR TITLE
상세 게시글에서 강력 새로고침 시 투표 인원수가 -1명으로 변하는 버그 수정

### DIFF
--- a/frontend/src/hooks/query/post/useCreateVote.ts
+++ b/frontend/src/hooks/query/post/useCreateVote.ts
@@ -6,6 +6,7 @@ import { QUERY_KEY } from '@constants/queryKey';
 
 export const useCreateVote = ({ isPreview, postId }: { isPreview: boolean; postId: number }) => {
   const queryClient = useQueryClient();
+  const LOGGED_IN = true;
 
   const { mutate, isError, error } = useMutation({
     mutationFn: (optionId: number) => votePost(postId, optionId),
@@ -19,7 +20,7 @@ export const useCreateVote = ({ isPreview, postId }: { isPreview: boolean; postI
         return;
       }
 
-      queryClient.invalidateQueries([QUERY_KEY.POST_DETAIL, postId]);
+      queryClient.invalidateQueries([QUERY_KEY.POST_DETAIL, postId, LOGGED_IN]);
     },
     onError: error => {
       window.console.log('투표 선택지 생성에 실패했습니다.', error);

--- a/frontend/src/hooks/query/post/useEarlyClosePost.ts
+++ b/frontend/src/hooks/query/post/useEarlyClosePost.ts
@@ -6,11 +6,12 @@ import { QUERY_KEY } from '@constants/queryKey';
 
 export const useEarlyClosePost = (postId: number) => {
   const queryClient = useQueryClient();
+  const LOGGED_IN = true;
 
   const { mutate, isError, error } = useMutation({
     mutationFn: () => setEarlyClosePost(postId),
     onSuccess: () => {
-      queryClient.invalidateQueries([QUERY_KEY.POST_DETAIL, postId]);
+      queryClient.invalidateQueries([QUERY_KEY.POST_DETAIL, postId, LOGGED_IN]);
     },
     onError: error => {
       window.console.log('조기마감에 실패했습니다.', error);

--- a/frontend/src/hooks/query/post/useEditVote.ts
+++ b/frontend/src/hooks/query/post/useEditVote.ts
@@ -6,6 +6,7 @@ import { QUERY_KEY } from '@constants/queryKey';
 
 export const useEditVote = ({ isPreview, postId }: { isPreview: boolean; postId: number }) => {
   const queryClient = useQueryClient();
+  const LOGGED_IN = true;
 
   const { mutate, isError, error } = useMutation({
     mutationFn: (optionData: OptionData) => changeVotedOption(postId, optionData),
@@ -17,7 +18,7 @@ export const useEditVote = ({ isPreview, postId }: { isPreview: boolean; postId:
         return;
       }
 
-      queryClient.invalidateQueries([QUERY_KEY.POST_DETAIL, postId]);
+      queryClient.invalidateQueries([QUERY_KEY.POST_DETAIL, postId, LOGGED_IN]);
     },
     onError: error => {
       window.console.log('투표 선택지 생성에 실패했습니다.', error);

--- a/frontend/src/hooks/query/post/usePostDetail.ts
+++ b/frontend/src/hooks/query/post/usePostDetail.ts
@@ -6,11 +6,11 @@ import { getPost, getPostForGuest } from '@api/post';
 
 import { QUERY_KEY } from '@constants/queryKey';
 
-export const usePostDetail = (isGuest: boolean, postId: number) => {
-  const fetchApi = isGuest ? getPostForGuest : getPost;
+export const usePostDetail = (isLoggedIn: boolean, postId: number) => {
+  const fetchApi = isLoggedIn ? getPost : getPostForGuest;
 
   const { data, isError, isLoading, error } = useQuery<PostInfo>(
-    [QUERY_KEY.POST_DETAIL, postId],
+    [QUERY_KEY.POST_DETAIL, postId, isLoggedIn],
     () => fetchApi(postId),
     {
       suspense: true,

--- a/frontend/src/pages/post/PostDetail/PostDetail/index.tsx
+++ b/frontend/src/pages/post/PostDetail/PostDetail/index.tsx
@@ -37,7 +37,7 @@ export default function PostDetail() {
   const { loggedInfo } = useContext(AuthContext);
   const memberId = loggedInfo.id;
 
-  const { data: postData } = usePostDetail(!loggedInfo.isLoggedIn, postId);
+  const { data: postData } = usePostDetail(loggedInfo.isLoggedIn, postId);
   const {
     mutate: deletePost,
     isSuccess: isDeleteSuccess,


### PR DESCRIPTION
## 🔥 연관 이슈

close: #369 

## 📝 작업 요약

- usePostDetail에서 로그인 정보를 키 값으로 추가하여 새로고침시에도 올바르게 나오도록 수정 및 적용


## ⏰ 소요 시간

30분


## 🔎 작업 상세 설명

### 버그가 일어나는 원인

상세 게시글에서 새로고침 시

1. 상세 게시글 게스트용 패치
2. 로그인

이 때 다시 회원용 상세 게시글을 패치해와야 하는데 5분간 캐싱이 되어 있기 때문에 로그인하여도 값을 새로고침하지 않았음

### 해결 방법

상세 게시글 쿼리 키값에 로그인 여부를 추가하여 로그인했을 때 새롭게 패치해오도록 수정

투표 생성, 수정, 조기마감은 로그인한 경우에만 가능하니 기존에 상세 게시글을 초기화 하는 로직에서 로그인 정보 =true를 추가


