### PR TITLE
카테고리가 길 경우 스크롤이 되도록 변경, 리다이렉션 페이지에서 멤버 아이디를 설정하도록 수정

### DIFF
--- a/frontend/src/components/common/Dashboard/CategorySection/style.ts
+++ b/frontend/src/components/common/Dashboard/CategorySection/style.ts
@@ -1,11 +1,15 @@
 import { styled } from 'styled-components';
 
+import { theme } from '@styles/theme';
+
 export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: start;
 
   width: 100%;
+  height: calc(100vh - 320px);
+
   margin-bottom: 85px;
 
   overflow-y: scroll;
@@ -15,6 +19,10 @@ export const ContentContainer = styled.div`
 
   &::-webkit-scrollbar {
     display: none;
+  }
+
+  @media (min-width: ${theme.breakpoint.md}) {
+    height: calc(100vh - 400px);
   }
 `;
 

--- a/frontend/src/pages/auth/Redirection.tsx
+++ b/frontend/src/pages/auth/Redirection.tsx
@@ -9,7 +9,7 @@ import Error from '@pages/Error';
 
 import LoadingSpinner from '@components/common/LoadingSpinner';
 
-import { getCookieToken, setCookieToken } from '@utils/cookie';
+import { getCookieToken, getMemberId, setCookieToken } from '@utils/cookie';
 import { getFetch } from '@utils/fetch';
 
 const getAuthInfo = async (url: string): Promise<AuthResponse> => {
@@ -47,8 +47,12 @@ export default function Redirection() {
           const { accessToken } = res;
           setCookieToken('accessToken', accessToken);
 
+          const decodedPayload = getMemberId(accessToken);
+          const id = decodedPayload.memberId;
+
           setLoggedInfo({
             ...loggedInfo,
+            id,
             accessToken: getCookieToken().accessToken,
             isLoggedIn: true,
           });


### PR DESCRIPTION
## 🔥 연관 이슈

close: #358
close: #381
close: #384

## 📝 작업 요약

- 카테고리가 스크롤 되도록 CSS 수정
- 엑세스 토큰이 없을 때 리다이렉션 페이지를 통해 로그인 시에도 멤버 아이디를 전역변수에 설정되도록 수정


## ⏰ 소요 시간

30분

## 🔎 작업 상세 설명

- 로그인 후 내가 작성한 글의 통계가 보이지 않거나, 상세 페이지에서 내가 작성한 글에 신고가 뜨는 이유가 리다이렉션 페이지에서 멤버 아이디를 전역 변수로 설정
- 카테고리가 길 경우 스크롤 되도록 CSS 설정
  -  헤더, 유저인포, 로그아웃 버튼 등의 높이값을 계산하여서 스크롤 되는 높이를 100vh - 400px(유저 정보창 + 헤더창 + 선택된 게시글 종류 + 로그아웃 버튼) 으로 지정


카테고리 스크롤 동영상


https://github.com/woowacourse-teams/2023-votogether/assets/80146176/69fe4acf-6ff6-426f-8508-9528b19c41a2



