### PR TITLE
본문과 내용에 사진을 추가할 때 안될 때가 있다

### DIFF
--- a/frontend/src/api/post.ts
+++ b/frontend/src/api/post.ts
@@ -10,7 +10,6 @@ import {
 } from '@utils/fetch';
 
 const BASE_URL = process.env.VOTOGETHER_BASE_URL ?? '';
-const MOCK_URL = process.env.VOTOGETHER_MOCKING_URL;
 
 export const transformPostResponse = (post: PostInfoResponse): PostInfo => {
   return {
@@ -75,7 +74,7 @@ export const editPost = async (postId: number, updatedPost: FormData) => {
 };
 
 export const deletePost = async (postId: number) => {
-  return await deleteFetch(`${MOCK_URL}/posts/${postId}`);
+  return await deleteFetch(`${BASE_URL}/posts/${postId}`);
 };
 
 export const setEarlyClosePost = async (postId: number) => {

--- a/frontend/src/api/report.ts
+++ b/frontend/src/api/report.ts
@@ -2,7 +2,7 @@ import { ReportRequest } from '@type/report';
 
 import { postFetch } from '@utils/fetch';
 
-const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
+const BASE_URL = process.env.VOTOGETHER_BASE_URL;
 
 export const reportContent = async (reportData: ReportRequest) => {
   return await postFetch(`${BASE_URL}/report`, reportData);

--- a/frontend/src/components/PostForm/ContentImageSection/index.tsx
+++ b/frontend/src/components/PostForm/ContentImageSection/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, MutableRefObject } from 'react';
 
 import { Size } from '@type/style';
 
@@ -10,12 +10,13 @@ interface ContentImageSectionProps {
   size: Size;
   contentImageHook: {
     contentImage: string;
+    contentInputRef: MutableRefObject<HTMLInputElement | null>;
     removeImage: () => void;
     handleUploadImage: (event: ChangeEvent<HTMLInputElement>) => void;
   };
 }
 export default function ContentImageSection({ contentImageHook, size }: ContentImageSectionProps) {
-  const { contentImage, removeImage, handleUploadImage } = contentImageHook;
+  const { contentImage, contentInputRef, removeImage, handleUploadImage } = contentImageHook;
 
   return (
     <>
@@ -39,6 +40,7 @@ export default function ContentImageSection({ contentImageHook, size }: ContentI
           </S.Label>
           <S.FileInput
             id="content-image-upload"
+            ref={contentInputRef}
             type="file"
             accept="image/*"
             onChange={handleUploadImage}

--- a/frontend/src/hooks/useContentImage.ts
+++ b/frontend/src/hooks/useContentImage.ts
@@ -1,12 +1,14 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 
 import { MAX_FILE_SIZE } from '@components/PostForm/constants';
 
 export const useContentImage = (imageUrl: string = '') => {
   const [contentImage, setContentImage] = useState(imageUrl);
+  const contentInputRef = useRef<HTMLInputElement | null>(null);
 
   const removeImage = () => {
     setContentImage('');
+    if (contentInputRef.current) contentInputRef.current.value = '';
   };
 
   const handleUploadImage = (event: ChangeEvent<HTMLInputElement>) => {
@@ -34,5 +36,5 @@ export const useContentImage = (imageUrl: string = '') => {
     };
   };
 
-  return { contentImage, removeImage, handleUploadImage };
+  return { contentImage, contentInputRef, removeImage, handleUploadImage };
 };


### PR DESCRIPTION
## 🔥 연관 이슈

close: # 280 (보류)
close: #391

## 📝 작업 요약
본문과 내용에 사진을 추가할 때 안될 때가 있다

## ⏰ 소요 시간
1시간.. 해결 못함..

## 🔎 작업 상세 설명
문제 설명
- 이미지 업로드 (changeEvent) > 이미지 삭제 (state로 관리하는 url만 삭제 - 미리보기 삭제) > 이미지 업로드 (changeEvent) 시 동일한 파일이라 changeEvent 발생하지 않음
- 때문에 본문 이미지 문제 해결을 위해 ref로 이미지 삭제시 해당 input.value를 ""처리 
- 선택지는 ref를 html[]로 만드려고 했는데 계속 null값이 나오며 element가 지정되지 않음..

## 🌟 논의 사항
일단 문제점과 해결책을 알았으니 다음 기회에 개선하면 좋을 것 같습니다.
배포가 더 중요하다고 생각되어 PR올립니다.