### PR TITLE
회원 탈퇴 기능 수정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/category/service/CategoryService.java
+++ b/backend/src/main/java/com/votogether/domain/category/service/CategoryService.java
@@ -60,7 +60,7 @@ public class CategoryService {
     @Transactional(readOnly = true)
     public List<CategoryResponse> getAllCategories(final Member member) {
         final List<Category> categories = categoryRepository.findAll();
-        final List<MemberCategory> memberCategories = memberCategoryRepository.findByMember(member);
+        final List<MemberCategory> memberCategories = memberCategoryRepository.findAllByMember(member);
 
         final List<Category> favoriteCategories = memberCategories.stream()
                 .map(MemberCategory::getCategory)

--- a/backend/src/main/java/com/votogether/domain/member/repository/MemberCategoryRepository.java
+++ b/backend/src/main/java/com/votogether/domain/member/repository/MemberCategoryRepository.java
@@ -11,6 +11,6 @@ public interface MemberCategoryRepository extends JpaRepository<MemberCategory, 
 
     Optional<MemberCategory> findByMemberAndCategory(final Member member, final Category category);
 
-    List<MemberCategory> findByMember(final Member member);
+    List<MemberCategory> findAllByMember(final Member member);
 
 }

--- a/backend/src/main/java/com/votogether/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/Post.java
@@ -74,15 +74,14 @@ public class Post extends BaseEntity {
     private Post(
             final Member writer,
             final PostBody postBody,
-            final LocalDateTime deadline,
-            final boolean isHidden
+            final LocalDateTime deadline
     ) {
         this.writer = writer;
         this.postBody = postBody;
         this.deadline = deadline;
         this.postCategories = new PostCategories();
         this.postOptions = new PostOptions();
-        this.isHidden = isHidden;
+        this.isHidden = false;
     }
 
     public void mapCategories(final List<Category> categories) {

--- a/backend/src/main/java/com/votogether/domain/post/entity/comment/Comment.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/comment/Comment.java
@@ -50,13 +50,12 @@ public class Comment extends BaseEntity {
     private Comment(
             final Post post,
             final Member member,
-            final String content,
-            final boolean isHidden
+            final String content
     ) {
         this.post = post;
         this.member = member;
         this.content = new Content(content);
-        this.isHidden = isHidden;
+        this.isHidden = false;
     }
 
     public void validateWriter(final Member member) {

--- a/backend/src/main/java/com/votogether/domain/post/repository/CommentRepository.java
+++ b/backend/src/main/java/com/votogether/domain/post/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package com.votogether.domain.post.repository;
 
+import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.comment.Comment;
 import java.util.List;
@@ -10,5 +11,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = {"member"})
     List<Comment> findAllByPostOrderByCreatedAtAsc(final Post post);
+
+    List<Comment> findAllByMember(final Member member);
 
 }

--- a/backend/src/main/java/com/votogether/domain/report/repository/ReportRepository.java
+++ b/backend/src/main/java/com/votogether/domain/report/repository/ReportRepository.java
@@ -3,6 +3,7 @@ package com.votogether.domain.report.repository;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.report.entity.Report;
 import com.votogether.domain.report.entity.ReportType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,5 +16,9 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
             final ReportType reportType,
             final Long targetId
     );
+
+    List<Report> findAllByMember(final Member member);
+
+    List<Report> findAllByReportTypeAndTargetId(final ReportType reportType, final Long targetId);
 
 }

--- a/backend/src/main/java/com/votogether/domain/vote/repository/VoteRepository.java
+++ b/backend/src/main/java/com/votogether/domain/vote/repository/VoteRepository.java
@@ -30,12 +30,15 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
             " ORDER BY m.birthYear DESC"
     )
     List<VoteStatus> findVoteCountByPostOptionIdGroupByAgeRangeAndGender(
-            @Param("postOptionId") final Long postOptionId);
+            @Param("postOptionId") final Long postOptionId
+    );
 
     Optional<Vote> findByMemberAndPostOption(final Member member, final PostOption postOption);
 
     List<Vote> findAllByMemberAndPostOptionIn(final Member member, final List<PostOption> postOptions);
 
     int countByMember(final Member member);
+
+    List<Vote> findAllByMember(final Member member);
 
 }

--- a/backend/src/test/java/com/votogether/domain/member/repository/MemberCategoryRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/repository/MemberCategoryRepositoryTest.java
@@ -90,7 +90,7 @@ class MemberCategoryRepositoryTest {
         memberCategoryRepository.save(memberCategoryB);
 
         // when
-        List<MemberCategory> memberCategories = memberCategoryRepository.findByMember(member);
+        List<MemberCategory> memberCategories = memberCategoryRepository.findAllByMember(member);
 
         // then
         assertAll(

--- a/backend/src/test/java/com/votogether/domain/report/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/report/service/ReportServiceTest.java
@@ -129,14 +129,15 @@ class ReportServiceTest {
                     .writer(writer)
                     .postBody(postBody)
                     .deadline(LocalDateTime.of(2100, 7, 12, 0, 0))
-                    .isHidden(true)
                     .build();
+            post.blind();
 
             postRepository.save(post);
 
             ReportRequest request = new ReportRequest(ReportType.POST, post.getId(), "불건전한 게시글");
 
             // when, then
+
             assertThatThrownBy(() -> reportService.report(reporter, request))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 블라인드 처리된 글입니다.");
@@ -313,7 +314,6 @@ class ReportServiceTest {
                     .writer(writer)
                     .postBody(postBody)
                     .deadline(LocalDateTime.of(2100, 7, 12, 0, 0))
-                    .isHidden(true)
                     .build();
 
             Comment comment = Comment.builder()

--- a/backend/src/test/java/com/votogether/domain/report/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/report/service/ReportServiceTest.java
@@ -238,7 +238,6 @@ class ReportServiceTest {
                     .post(post)
                     .member(writer)
                     .content("으어어어어")
-                    .isHidden(false)
                     .build();
 
             postRepository.save(post);
@@ -285,7 +284,6 @@ class ReportServiceTest {
                     .post(post)
                     .member(writer)
                     .content("으어어어어")
-                    .isHidden(false)
                     .build();
 
             postRepository.save(post);
@@ -322,7 +320,6 @@ class ReportServiceTest {
                     .post(post)
                     .member(writer)
                     .content("으어어어어")
-                    .isHidden(true)
                     .build();
 
             postRepository.save(post);
@@ -331,6 +328,7 @@ class ReportServiceTest {
             ReportRequest request = new ReportRequest(ReportType.COMMENT, comment.getId(), "불건전한 댓글");
 
             // when, then
+            comment.blind();
             assertThatThrownBy(() -> reportService.report(reporter, request))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 블라인드 처리된 댓글입니다.");
@@ -358,7 +356,6 @@ class ReportServiceTest {
                     .post(post)
                     .member(writer)
                     .content("으어어어어")
-                    .isHidden(false)
                     .build();
 
             postRepository.save(post);
@@ -401,7 +398,6 @@ class ReportServiceTest {
                     .post(post)
                     .member(writer)
                     .content("으어어어어")
-                    .isHidden(false)
                     .build();
 
             postRepository.save(post);


### PR DESCRIPTION
## 🔥 연관 이슈

close: #396 

## 📝 작업 요약

회원 탈퇴 시 연관된 데이터들도 함께 삭제해주는 기능을 구현했습니다.

## ⏰ 소요 시간

3시간, 생각보다 엮여있는 엔티티가 너무 많아서 테스트를 하면서 잡아내느라 1시간 정도 더 걸렸습니다.

## 🔎 작업 상세 설명

없음.

## 🌟 논의 사항

로직이 많이 어지럽네요. 확인해주시고 개선사항 있으면 말씀해주시는대로 바로 반영해볼게요!
