### PR TITLE
회원이 마감 완료된 게시글에 투표할 때 failed to Fetch가 나타나요, 마감된 게시글 투표 통계 보이도록 수정

### DIFF
--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -45,9 +45,17 @@ export default function Post({ postInfo, isPreview }: PostProps) {
 
   const isActive = !checkClosedPost(deadline);
 
+  const isStatisticsVisible =
+    writer.id === loggedInfo.id || !isActive || voteInfo.selectedOptionId !== POST.NOT_VOTE;
+
   const handleVoteClick = (newOptionId: number) => {
     if (!loggedInfo.isLoggedIn) {
       openToast('투표를 하려면 로그인 후에 이용하실 수 있습니다.');
+      return;
+    }
+
+    if (!isActive) {
+      openToast('마감된 게시글에는 투표를 할 수 없습니다.');
       return;
     }
 
@@ -130,7 +138,7 @@ export default function Post({ postInfo, isPreview }: PostProps) {
         )}
       </S.DetailLink>
       <WrittenVoteOptionList
-        isWriter={writer.id === loggedInfo.id}
+        isStatisticsVisible={isStatisticsVisible}
         selectedOptionId={voteInfo.selectedOptionId}
         handleVoteClick={handleVoteClick}
         isPreview={isPreview}

--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/WrittenVoteOption.stories.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/WrittenVoteOption.stories.tsx
@@ -26,7 +26,7 @@ export const Select: Story = {
         peopleCount={2}
         percent={70.9}
         isSelected={true}
-        isVoted={true}
+        isStatisticsVisible={true}
         imageUrl=""
       />
     </WrittenVoteWrapper>
@@ -44,7 +44,7 @@ export const NotSelectAndLongText: Story = {
         percent={80}
         peopleCount={6}
         isSelected={false}
-        isVoted={true}
+        isStatisticsVisible={true}
         imageUrl=""
       />
     </WrittenVoteWrapper>
@@ -63,7 +63,7 @@ export const ImageAndSelect: Story = {
         percent={80}
         peopleCount={6}
         isSelected={true}
-        isVoted={true}
+        isStatisticsVisible={true}
       />
     </WrittenVoteWrapper>
   ),
@@ -80,7 +80,7 @@ export const NotVote: Story = {
         percent={0}
         peopleCount={0}
         isSelected={false}
-        isVoted={false}
+        isStatisticsVisible={false}
         imageUrl=""
       />
     </WrittenVoteWrapper>
@@ -99,7 +99,7 @@ export const ImageAndNotVote: Story = {
         percent={0}
         peopleCount={0}
         isSelected={false}
-        isVoted={false}
+        isStatisticsVisible={false}
       />
     </WrittenVoteWrapper>
   ),
@@ -117,7 +117,7 @@ export const PreviewContent: Story = {
         percent={0}
         peopleCount={0}
         isSelected={false}
-        isVoted={false}
+        isStatisticsVisible={false}
       />
     </WrittenVoteWrapper>
   ),
@@ -135,7 +135,7 @@ export const DetailContent: Story = {
         percent={0}
         peopleCount={0}
         isSelected={false}
-        isVoted={false}
+        isStatisticsVisible={false}
       />
     </WrittenVoteWrapper>
   ),
@@ -152,7 +152,7 @@ export const NoImageAndDetailContent: Story = {
         percent={60}
         peopleCount={8}
         isSelected={true}
-        isVoted={true}
+        isStatisticsVisible={true}
         imageUrl=""
       />
     </WrittenVoteWrapper>
@@ -171,7 +171,7 @@ export const ImageAndSelectAndDetailContent: Story = {
         percent={60}
         peopleCount={8}
         isSelected={true}
-        isVoted={true}
+        isStatisticsVisible={true}
       />
     </WrittenVoteWrapper>
   ),

--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/index.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/index.tsx
@@ -4,7 +4,7 @@ import * as S from './style';
 interface WrittenVoteOptionProps {
   handleVoteClick: () => void;
   text: string;
-  isVoted: boolean;
+  isStatisticsVisible: boolean;
   peopleCount: number;
   percent: number;
   isSelected: boolean;
@@ -16,7 +16,7 @@ interface WrittenVoteOptionProps {
 export default function WrittenVoteOption({
   handleVoteClick,
   text,
-  isVoted,
+  isStatisticsVisible,
   peopleCount,
   percent,
   isSelected,
@@ -40,7 +40,7 @@ export default function WrittenVoteOption({
       ) : (
         <S.DetailContent aria-label="선택지 내용">{text}</S.DetailContent>
       )}
-      {isVoted && (
+      {isStatisticsVisible && (
         <>
           <S.ProgressContainer aria-label={''}>
             <ProgressBar percent={percent} isSelected={isSelected} />

--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOptionList.stories.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOptionList.stories.tsx
@@ -89,7 +89,7 @@ export const PreviewNotVoted: Story = {
   render: () => (
     <WrittenVoteWrapper>
       <WrittenVoteOptionList
-        isWriter={true}
+        isStatisticsVisible={true}
         selectedOptionId={MOCK_NOT_VOTED_DATA.selectedOptionId}
         handleVoteClick={() => {}}
         isPreview={true}
@@ -103,7 +103,7 @@ export const PreviewVoted: Story = {
   render: () => (
     <WrittenVoteWrapper>
       <WrittenVoteOptionList
-        isWriter={true}
+        isStatisticsVisible={true}
         selectedOptionId={MOCK_VOTED_DATA.selectedOptionId}
         handleVoteClick={() => {}}
         isPreview={true}
@@ -117,7 +117,7 @@ export const DetailNotVoted: Story = {
   render: () => (
     <WrittenVoteWrapper>
       <WrittenVoteOptionList
-        isWriter={true}
+        isStatisticsVisible={true}
         selectedOptionId={MOCK_NOT_VOTED_DATA.selectedOptionId}
         handleVoteClick={() => {}}
         isPreview={false}
@@ -131,7 +131,7 @@ export const DetailVoted: Story = {
   render: () => (
     <WrittenVoteWrapper>
       <WrittenVoteOptionList
-        isWriter={true}
+        isStatisticsVisible={true}
         selectedOptionId={MOCK_VOTED_DATA.selectedOptionId}
         handleVoteClick={() => {}}
         isPreview={false}

--- a/frontend/src/components/optionList/WrittenVoteOptionList/index.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/index.tsx
@@ -1,13 +1,11 @@
 import { WrittenVoteOptionType } from '@type/post';
 
-import { POST } from '@constants/vote';
-
 import * as S from './style';
 import WrittenVoteOption from './WrittenVoteOption';
 
 interface WrittenVoteOptionListProps {
   isPreview: boolean;
-  isWriter: boolean;
+  isStatisticsVisible: boolean;
   selectedOptionId: number;
   voteOptionList: WrittenVoteOptionType[];
   handleVoteClick: (newOptionId: number) => void;
@@ -15,7 +13,7 @@ interface WrittenVoteOptionListProps {
 
 export default function WrittenVoteOptionList({
   isPreview,
-  isWriter,
+  isStatisticsVisible,
   voteOptionList,
   selectedOptionId,
   handleVoteClick,
@@ -28,7 +26,7 @@ export default function WrittenVoteOptionList({
           key={voteOption.id}
           {...voteOption}
           isPreview={isPreview}
-          isVoted={selectedOptionId !== POST.NOT_VOTE || isWriter}
+          isStatisticsVisible={isStatisticsVisible}
           isSelected={selectedOptionId === voteOption.id}
           handleVoteClick={() => handleVoteClick(voteOption.id)}
         />

--- a/frontend/src/pages/VoteStatisticsPage/OptionStatistics/index.tsx
+++ b/frontend/src/pages/VoteStatisticsPage/OptionStatistics/index.tsx
@@ -50,7 +50,7 @@ export default function OptionStatistics({
         key={voteOption.id}
         {...voteOption}
         isPreview={false}
-        isVoted={true}
+        isStatisticsVisible={true}
         isSelected={isSelectedOption}
         handleVoteClick={toggleOptionStatistics}
       />


### PR DESCRIPTION
## 🔥 연관 이슈

close: #399 

## 📝 작업 요약

- 회원이 마감 완료된 게시글에 투표할 때 '마감된 게시글에는 투표를 할 수 없습니다.' 라는 토스트를 보여줌
- 마감 완료된 게시글은 투표 통계가 보이도록 수정

## ⏰ 소요 시간

20분

## 🔎 작업 상세 설명

- 기존에 투표 통계가 보이도록 하는 isVoted와 isWriter를 좀 더 넓은 범위라고 생각되는 isStatisticsVisible(통계가 보이는 지)로 변경

- 마감 시간이 지난 게시글에 투표했을 때 토스트가 올라오는 이미지
![image](https://github.com/woowacourse-teams/2023-votogether/assets/80146176/0986ba89-5021-4657-a602-a5d87d53a259)


## 🌟 논의 사항

문구가 적당한가요? 아니면 마감 시간이 지난 게시글을 투표했을 때 바로 return해서 토스트가 안 나오는 것도 괜찮은지 논의해보고 싶어요
