### PR TITLE
모바일에서 검색창 눌러서 검색이 가능하도록 수정

### DIFF
--- a/frontend/src/components/common/NarrowMainHeader/index.tsx
+++ b/frontend/src/components/common/NarrowMainHeader/index.tsx
@@ -1,3 +1,5 @@
+import { MouseEvent } from 'react';
+
 import { useToggle } from '@hooks/useToggle';
 
 import IconButton from '../IconButton';
@@ -23,7 +25,7 @@ export default function NarrowMainHeader({
 
   return isSearchInputOpen ? (
     <S.Background onClick={closeSearchInput}>
-      <S.Container>
+      <S.Container onClick={(event: MouseEvent) => event.stopPropagation()}>
         <SearchBar size="free" />
       </S.Container>
     </S.Background>

--- a/frontend/src/components/common/NarrowMainHeader/index.tsx
+++ b/frontend/src/components/common/NarrowMainHeader/index.tsx
@@ -26,7 +26,7 @@ export default function NarrowMainHeader({
   return isSearchInputOpen ? (
     <S.Background onClick={closeSearchInput}>
       <S.Container onClick={(event: MouseEvent) => event.stopPropagation()}>
-        <SearchBar size="free" />
+        <SearchBar size="free" autoFocus />
       </S.Container>
     </S.Background>
   ) : (

--- a/frontend/src/components/common/SearchBar/index.tsx
+++ b/frontend/src/components/common/SearchBar/index.tsx
@@ -1,4 +1,4 @@
-import { FormHTMLAttributes } from 'react';
+import { HTMLAttributes } from 'react';
 
 import { Size } from '@type/style';
 
@@ -9,14 +9,14 @@ import searchIcon from '@assets/search_black.svg';
 
 import * as S from './style';
 
-interface SearchBarProps extends FormHTMLAttributes<HTMLFormElement> {
+interface SearchBarProps extends HTMLAttributes<HTMLInputElement> {
   size: Size | 'free';
 }
 
 export default function SearchBar({ size, ...rest }: SearchBarProps) {
   return (
-    <S.Form size={size} {...rest} action={PATH.SEARCH}>
-      <S.Input type="search" name={SEARCH_KEYWORD} />
+    <S.Form size={size} action={PATH.SEARCH}>
+      <S.Input type="search" name={SEARCH_KEYWORD} {...rest} />
       <S.Button type="submit">
         <img src={searchIcon} alt="검색버튼" />
       </S.Button>

--- a/frontend/src/components/post/PostListPage/style.ts
+++ b/frontend/src/components/post/PostListPage/style.ts
@@ -40,6 +40,8 @@ export const ButtonContainer = styled.div`
   align-items: end;
   gap: 20px;
 
+  padding-right: 10px;
+
   position: sticky;
   bottom: 24px;
 `;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #403 

## 📝 작업 요약

- 검색창을 눌러도 검색창이 안닫히도록 수정
- 모바일에서 검색창 열었을 때 오토포커스 되도록 구현
- 홈페이지에서 위로가기, 작성 버튼에 padding-right:10px 추가 ( 너무 붙어있어서 )

## ⏰ 소요 시간

20분

## 🔎 작업 상세 설명

동영상


https://github.com/woowacourse-teams/2023-votogether/assets/80146176/1c7e76f0-4873-41e2-8641-52e8e296bf46



