### PR TITLE
회원 탈퇴 시 연관된 fk로 인해 회원이 탈퇴되지 않는 문제 수정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -95,16 +95,13 @@ public class MemberService {
 
     @Transactional
     public void deleteMember(final Member member) {
-        final Member existentMember = memberRepository.findById(member.getId())
-                .orElseThrow(() -> new NotFoundException(MemberExceptionType.NONEXISTENT_MEMBER));
+        final List<Post> posts = deletePosts(member);
+        final List<Comment> comments = deleteComments(member);
+        deleteVotes(member);
+        deleteMemberCategories(member);
+        deleteReports(member, posts, comments);
 
-        final List<Post> posts = deletePosts(existentMember);
-        final List<Comment> comments = deleteComments(existentMember);
-        deleteVotes(existentMember);
-        deleteMemberCategories(existentMember);
-        deleteReports(existentMember, posts, comments);
-
-        memberRepository.delete(existentMember);
+        memberRepository.delete(member);
     }
 
     private List<Post> deletePosts(final Member member) {
@@ -112,26 +109,25 @@ public class MemberService {
         final List<Long> postIds = posts.stream()
                 .map(Post::getId)
                 .toList();
-        postRepository.deleteAllByIdInBatch(postIds);
+        postRepository.deleteAllById(postIds);
         return posts;
     }
 
-    private List<Comment> deleteComments(final Member existentMember) {
-        final List<Comment> comments = commentRepository.findAllByMember(existentMember);
-        final List<Long> commentIds = comments
-                .stream()
+    private List<Comment> deleteComments(final Member member) {
+        final List<Comment> comments = commentRepository.findAllByMember(member);
+        final List<Long> commentIds = comments.stream()
                 .map(Comment::getId)
                 .toList();
-        commentRepository.deleteAllByIdInBatch(commentIds);
+        commentRepository.deleteAllById(commentIds);
         return comments;
     }
 
-    private void deleteVotes(final Member existentMember) {
-        final List<Long> voteIds = voteRepository.findAllByMember(existentMember)
+    private void deleteVotes(final Member member) {
+        final List<Long> voteIds = voteRepository.findAllByMember(member)
                 .stream()
                 .map(Vote::getId)
                 .toList();
-        voteRepository.deleteAllByIdInBatch(voteIds);
+        voteRepository.deleteAllById(voteIds);
     }
 
     private void deleteMemberCategories(final Member member) {
@@ -139,7 +135,7 @@ public class MemberService {
                 .stream()
                 .map(MemberCategory::getId)
                 .toList();
-        memberCategoryRepository.deleteAllByIdInBatch(memberCategoryIds);
+        memberCategoryRepository.deleteAllById(memberCategoryIds);
     }
 
     private void deleteReports(
@@ -159,28 +155,28 @@ public class MemberService {
                     .stream()
                     .map(Report::getId)
                     .toList();
-            reportRepository.deleteAllByIdInBatch(reportIds);
+            reportRepository.deleteAllById(reportIds);
         }
     }
 
     private void deleteReportByComment(final List<Comment> comments) {
         for (final Comment comment : comments) {
-            final List<Long> reportIds = reportRepository.findAllByReportTypeAndTargetId(ReportType.COMMENT,
-                            comment.getId())
-                    .stream()
-                    .map(Report::getId)
-                    .toList();
-            reportRepository.deleteAllByIdInBatch(reportIds);
+            final List<Long> reportIds =
+                    reportRepository.findAllByReportTypeAndTargetId(ReportType.COMMENT, comment.getId())
+                            .stream()
+                            .map(Report::getId)
+                            .toList();
+            reportRepository.deleteAllById(reportIds);
         }
     }
 
     private void deleteReportByNickname(final Member member) {
-        final List<Long> reportIdsByTargetId = reportRepository.findAllByReportTypeAndTargetId(ReportType.NICKNAME,
-                        member.getId())
-                .stream()
-                .map(Report::getId)
-                .toList();
-        reportRepository.deleteAllByIdInBatch(reportIdsByTargetId);
+        final List<Long> reportIdsByTargetId =
+                reportRepository.findAllByReportTypeAndTargetId(ReportType.NICKNAME, member.getId())
+                        .stream()
+                        .map(Report::getId)
+                        .toList();
+        reportRepository.deleteAllById(reportIdsByTargetId);
     }
 
     private void deleteReportByMember(final Member member) {
@@ -188,7 +184,7 @@ public class MemberService {
                 .stream()
                 .map(Report::getId)
                 .toList();
-        reportRepository.deleteAllByIdInBatch(reportIdsByMember);
+        reportRepository.deleteAllById(reportIdsByMember);
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostService.java
@@ -313,7 +313,7 @@ public class PostService {
                 postRepository.findAllWithKeyword(keyword, postClosingType, postSortType, categoryId, pageable);
 
         return posts.stream()
-                .map(post -> PostResponse.forGuest(post))
+                .map(PostResponse::forGuest)
                 .toList();
     }
 

--- a/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
@@ -25,6 +25,7 @@ import com.votogether.domain.report.repository.ReportRepository;
 import com.votogether.exception.BadRequestException;
 import com.votogether.fixtures.MemberFixtures;
 import com.votogether.test.persister.MemberTestPersister;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -61,6 +62,9 @@ class MemberServiceTest {
 
     @Autowired
     MemberTestPersister memberTestPersister;
+
+    @Autowired
+    EntityManager em;
 
     @Test
     @DisplayName("멤버가 존재하지 않으면 저장한다.")
@@ -405,6 +409,9 @@ class MemberServiceTest {
                     .reason("불건전한 댓글")
                     .build();
             reportRepository.save(report);
+
+            em.flush();
+            em.clear();
 
             // when
             memberService.deleteMember(member);


### PR DESCRIPTION
## 🔥 연관 이슈

close: #413 

## 📝 작업 요약

deleteAllByIdInBatch -> deleteAllById로 변경

## ⏰ 소요 시간

2시간

## 🔎 작업 상세 설명

주요 기능 및 로직에 관해 설명해주세요.

## 🌟 논의 사항

백엔드 여러분 사랑합니다❤️