### PR TITLE
글을 작성하면 리스트 정렬기준이 "최신순"으로 바꾸기, 라우팅 시 스크롤 최상단으로 이동하기

### DIFF
--- a/frontend/src/components/comment/CommentList/index.tsx
+++ b/frontend/src/components/comment/CommentList/index.tsx
@@ -6,7 +6,7 @@ import { useMoreComment } from '@hooks/useMoreComment';
 
 import SquareButton from '@components/common/SquareButton';
 
-import { scrollToTop } from '@utils/scrollToTop';
+import { smoothScrollToTop } from '@utils/scrollToTop';
 
 import CommentItem from './CommentItem';
 import CommentLoginSection from './CommentLoginSection';
@@ -80,7 +80,7 @@ export default function CommentList({ postId, postWriterName }: CommentListProps
       )}
       <S.ButtonContainer>
         <S.TopButtonWrapper>
-          <SquareButton onClick={scrollToTop} theme="blank">
+          <SquareButton onClick={smoothScrollToTop} theme="blank">
             TOP
           </SquareButton>
         </S.TopButtonWrapper>

--- a/frontend/src/components/common/ScrollToTop/index.tsx
+++ b/frontend/src/components/common/ScrollToTop/index.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { defaultScrollToTop } from '@utils/scrollToTop';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    defaultScrollToTop();
+  }, [pathname]);
+
+  return null;
+}

--- a/frontend/src/components/post/PostListPage/index.tsx
+++ b/frontend/src/components/post/PostListPage/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useDrawer } from '@hooks/useDrawer';
@@ -15,13 +15,17 @@ import PostList from '@components/post/PostList';
 
 import { PATH } from '@constants/path';
 
-import { scrollToTop } from '@utils/scrollToTop';
+import { smoothScrollToTop } from '@utils/scrollToTop';
 
 import * as S from './style';
 
 export default function PostListPage() {
   const navigate = useNavigate();
   const { drawerRef, closeDrawer, openDrawer } = useDrawer('left');
+
+  useEffect(() => {
+    window.scroll({ top: 0, behavior: 'auto' });
+  }, []);
 
   return (
     <S.Container>
@@ -44,7 +48,7 @@ export default function PostListPage() {
         </Suspense>
       </ErrorBoundary>
       <S.ButtonContainer>
-        <UpButton onClick={scrollToTop} />
+        <UpButton onClick={smoothScrollToTop} />
         <S.AddButtonWrapper to={PATH.POST_WRITE}>
           <AddButton size="lg" />
         </S.AddButtonWrapper>

--- a/frontend/src/components/post/PostListPage/index.tsx
+++ b/frontend/src/components/post/PostListPage/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect } from 'react';
+import { Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useDrawer } from '@hooks/useDrawer';
@@ -22,10 +22,6 @@ import * as S from './style';
 export default function PostListPage() {
   const navigate = useNavigate();
   const { drawerRef, closeDrawer, openDrawer } = useDrawer('left');
-
-  useEffect(() => {
-    window.scroll({ top: 0, behavior: 'auto' });
-  }, []);
 
   return (
     <S.Container>

--- a/frontend/src/pages/post/CreatePostPage/index.tsx
+++ b/frontend/src/pages/post/CreatePostPage/index.tsx
@@ -15,10 +15,6 @@ export default function CreatePostPage() {
   const { isToastOpen, openToast, toastMessage } = useToast();
 
   useEffect(() => {
-    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
-  }, []);
-
-  useEffect(() => {
     if (isSuccess) {
       navigate('/');
     }

--- a/frontend/src/pages/post/CreatePostPage/index.tsx
+++ b/frontend/src/pages/post/CreatePostPage/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { PostOptionContext } from '@hooks/context/postOption';
 import { useCreatePost } from '@hooks/query/post/useCreatePost';
 import { useToast } from '@hooks/useToast';
 
@@ -8,15 +9,19 @@ import Layout from '@components/common/Layout';
 import Toast from '@components/common/Toast';
 import PostForm from '@components/PostForm';
 
+import { SORTING, STATUS } from '@constants/post';
+
 export default function CreatePostPage() {
   const navigate = useNavigate();
 
   const { mutate, isSuccess, isError, error } = useCreatePost();
   const { isToastOpen, openToast, toastMessage } = useToast();
+  const { setPostOption } = useContext(PostOptionContext);
 
   useEffect(() => {
     if (isSuccess) {
       navigate('/');
+      setPostOption({ sorting: SORTING.LATEST, status: STATUS.PROGRESS });
     }
   }, [isSuccess, navigate]);
 

--- a/frontend/src/pages/post/EditPostPage/EditPost/index.tsx
+++ b/frontend/src/pages/post/EditPostPage/EditPost/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { PostOptionContext } from '@hooks/context/postOption';
 import { useEditPost } from '@hooks/query/post/useEditPost';
 import { usePostDetail } from '@hooks/query/post/usePostDetail';
 import { useToast } from '@hooks/useToast';
@@ -9,6 +10,7 @@ import Toast from '@components/common/Toast';
 import PostForm from '@components/PostForm';
 
 import { PATH } from '@constants/path';
+import { SORTING, STATUS } from '@constants/post';
 
 export default function EditPost() {
   const navigate = useNavigate();
@@ -18,10 +20,12 @@ export default function EditPost() {
   const { data } = usePostDetail(true, Number(postId));
   const { mutate, isSuccess, isError, error } = useEditPost(Number(postId));
   const { isToastOpen, openToast, toastMessage } = useToast();
+  const { setPostOption } = useContext(PostOptionContext);
 
   useEffect(() => {
     if (isSuccess) {
       navigate(`${PATH.POST}/${postId}`);
+      setPostOption({ sorting: SORTING.LATEST, status: STATUS.PROGRESS });
     }
   }, [isSuccess, navigate, postId]);
 

--- a/frontend/src/pages/post/EditPostPage/EditPost/index.tsx
+++ b/frontend/src/pages/post/EditPostPage/EditPost/index.tsx
@@ -20,10 +20,6 @@ export default function EditPost() {
   const { isToastOpen, openToast, toastMessage } = useToast();
 
   useEffect(() => {
-    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
-  }, []);
-
-  useEffect(() => {
     if (isSuccess) {
       navigate(`${PATH.POST}/${postId}`);
     }

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -12,6 +12,8 @@ import PostDetailPage from '@pages/post/PostDetail';
 import RegisterPersonalInfo from '@pages/user/RegisterPersonalInfo';
 import VoteStatisticsPage from '@pages/VoteStatisticsPage';
 
+import ScrollToTop from '@components/common/ScrollToTop';
+
 import { PATH } from '@constants/path';
 
 import PrivateRoute from './PrivateRoute';
@@ -21,6 +23,7 @@ const router = createBrowserRouter([
     path: PATH.HOME,
     element: (
       <PrivateRoute isGuestAllowed={true}>
+        <ScrollToTop />
         <Home />
       </PrivateRoute>
     ),
@@ -30,6 +33,7 @@ const router = createBrowserRouter([
         path: 'search',
         element: (
           <PrivateRoute isGuestAllowed={true}>
+            <ScrollToTop />
             <Home />
           </PrivateRoute>
         ),
@@ -54,6 +58,7 @@ const router = createBrowserRouter([
         path: 'write',
         element: (
           <PrivateRoute>
+            <ScrollToTop />
             <CreatePostPage />
           </PrivateRoute>
         ),
@@ -62,6 +67,7 @@ const router = createBrowserRouter([
         path: 'write/:postId',
         element: (
           <PrivateRoute>
+            <ScrollToTop />
             <EditPostPage />
           </PrivateRoute>
         ),
@@ -70,6 +76,7 @@ const router = createBrowserRouter([
         path: ':postId',
         element: (
           <PrivateRoute isGuestAllowed={true}>
+            <ScrollToTop />
             <PostDetailPage />
           </PrivateRoute>
         ),
@@ -78,6 +85,7 @@ const router = createBrowserRouter([
         path: 'result/:postId',
         element: (
           <PrivateRoute>
+            <ScrollToTop />
             <VoteStatisticsPage />
           </PrivateRoute>
         ),
@@ -86,6 +94,7 @@ const router = createBrowserRouter([
         path: 'category/:categoryId',
         element: (
           <PrivateRoute isGuestAllowed={true}>
+            <ScrollToTop />
             <Home />
           </PrivateRoute>
         ),
@@ -100,6 +109,7 @@ const router = createBrowserRouter([
         path: 'myPage',
         element: (
           <PrivateRoute>
+            <ScrollToTop />
             <MyInfo />
           </PrivateRoute>
         ),
@@ -108,6 +118,7 @@ const router = createBrowserRouter([
         path: 'posts',
         element: (
           <PrivateRoute>
+            <ScrollToTop />
             <Home />
           </PrivateRoute>
         ),
@@ -116,6 +127,7 @@ const router = createBrowserRouter([
         path: 'votes',
         element: (
           <PrivateRoute>
+            <ScrollToTop />
             <Home />
           </PrivateRoute>
         ),

--- a/frontend/src/utils/scrollToTop.ts
+++ b/frontend/src/utils/scrollToTop.ts
@@ -1,3 +1,7 @@
-export const scrollToTop = () => {
+export const smoothScrollToTop = () => {
   window.scroll({ top: 0, behavior: 'smooth' });
+};
+
+export const defaultScrollToTop = () => {
+  window.scrollTo(0, 0);
 };


### PR DESCRIPTION
## 🔥 연관 이슈

close: #419 
글을 작성하면 리스트 정렬기준이 "최신순"으로 바뀌었으면 좋겠어요 
close: #423 
내가 작성한 게시물/투표한 게시물/홈으로 이동할때 최상단으로 이동되지 않아요

## 📝 작업 요약
- 글 작성/수정 시 글 목록 정렬/필터링 기준 초기화
- 페이지 이동 시 최상단으로 이동(상세게시물에서 목록으로 이동할때는 제외)

## ⏰ 소요 시간
2시간
- window.scroll이 작동하지 않는 오류

## 🔎 작업 상세 설명
- 글 작성/수정 시 글 목록 정렬/필터링 기준 초기화
- 페이지 이동 시 최상단으로 이동(상세게시물에서 목록으로 이동할때는 제외)
    - 유틸로 페이지 이동 관련 함수를 분리
    - 컴포넌트로 페이지 이동 컴포넌트를 만듦
    - 라우터에 스크롤 컴포넌트 적용

## 🌟 논의 사항
- 스크롤 컴포넌트가 각 페이지마다 있어서 많이 사용되고 있습니다. 사실 그럴 필요 없이 라우터스에 바로 정의해도 작동되는데 지금 저희가 라우터 크리에이트.. 로 라우터를 정의하고 있어서 해당 방식에는 어떻게 스크롤 컴포넌트를 넣을 수 있을지 몰라 지금 방식을 채택했습니다. 단 한번만 넣어도 된다고 생각되어 방법을 찾으면 리팩토링 하고 싶습니다.
- 왜... 스크롤이 적용되고 적용되지 않는지 모르겠습니다. 아직도 잘 모르겠어요.. 상세페이지에서 리스트로 넘어가는 부분을 조건문으로 확인하려고 했는데 useRef로 하는 방식이 문제가 있어서 일단 삭제했습니다. 없어도 의도대로 돌아가긴 해서 추후 문제가 생겼을때 보완하면 좋을 것 같아요.