### PR TITLE
전체 게시글 목록을 조회할 때 중복된 컬럼으로 인해 default page size에 맞지 않게 조회가 되는 문제 수정, 총 투표 수가 0일 때 투표 퍼센트가 NaN으로 반환되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/dto/request/post/PostCreateRequest.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/request/post/PostCreateRequest.java
@@ -14,7 +14,7 @@ import org.hibernate.validator.constraints.Length;
 @Schema(description = "게시글 작성 요청")
 @Builder
 public record PostCreateRequest(
-        @Schema(description = "카테고리의 여러 아이디", example = "[0, 2]")
+        @Schema(description = "카테고리의 여러 아이디", example = "[1, 3]")
         @Size(min = 1, message = "게시글에 해당하는 카테고리는 최소 1개 이상이어야 합니다.")
         List<Long> categoryIds,
 

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/post/PostOptionResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/post/PostOptionResponse.java
@@ -30,7 +30,7 @@ public record PostOptionResponse(
                 postOption.getContent(),
                 convertImageUrl(postOption.getImageUrl()),
                 post.isClosed() ? postOption.getVoteCount() : HIDDEN_COUNT,
-                post.isClosed() ? ((double) postOption.getVoteCount() / post.getTotalVoteCount()) * 100 : HIDDEN_COUNT
+                postOption.getVotePercent(post.getTotalVoteCount())
         );
     }
 

--- a/backend/src/main/java/com/votogether/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/votogether/domain/post/repository/PostCustomRepositoryImpl.java
@@ -32,6 +32,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     ) {
         return jpaQueryFactory
                 .selectFrom(post)
+                .distinct()
                 .join(post.writer).fetchJoin()
                 .leftJoin(post.postCategories.postCategories, postCategory)
                 .where(
@@ -104,6 +105,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     ) {
         return jpaQueryFactory
                 .selectFrom(post)
+                .distinct()
                 .join(post.writer).fetchJoin()
                 .leftJoin(post.postCategories.postCategories, postCategory)
                 .where(


### PR DESCRIPTION
## 🔥 연관 이슈

close: #436 

## 📝 작업 요약

- 전체 게시글 목록을 조회할 때 중복된 컬럼으로 인해 default page size에 맞지 않게 조회가 되는 문제 수정
- 게시글 작성 시 swagger에 표출되는 categoryId 예시를 수정
- 총 투표 수가 0일 때 투표 퍼센트가 NaN으로 반환되는 오류 수정

## ⏰ 소요 시간

2시간

## 🔎 작업 상세 설명

없음.

## 🌟 논의 사항

다즐은 진짜 신이 아닐까..?
