### PR TITLE
게시글과 댓글이 신고 5번 이상이어도 보이는 버그 픽스

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/repository/CommentRepository.java
+++ b/backend/src/main/java/com/votogether/domain/post/repository/CommentRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = {"member"})
-    List<Comment> findAllByPostOrderByCreatedAtAsc(final Post post);
+    List<Comment> findAllByPostAndIsHiddenFalseOrderByCreatedAtAsc(final Post post);
 
     List<Comment> findAllByMember(final Member member);
 

--- a/backend/src/main/java/com/votogether/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/votogether/domain/post/repository/PostCustomRepositoryImpl.java
@@ -36,7 +36,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .leftJoin(post.postCategories.postCategories, postCategory)
                 .where(
                         categoryIdEq(categoryId),
-                        deadlineEq(postClosingType)
+                        deadlineEq(postClosingType),
+                        post.isHidden.eq(false)
                 )
                 .orderBy(orderBy(postSortType))
                 .offset(pageable.getOffset())
@@ -58,7 +59,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .where(
                         categoryIdEq(categoryId),
                         deadlineEq(postClosingType),
-                        post.writer.eq(writer)
+                        post.writer.eq(writer),
+                        post.isHidden.eq(false)
                 )
                 .orderBy(orderBy(postSortType))
                 .offset(pageable.getOffset())
@@ -109,7 +111,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .where(
                         containsKeywordInTitleOrContent(keyword),
                         categoryIdEq(categoryId),
-                        deadlineEq(postClosingType)
+                        deadlineEq(postClosingType),
+                        post.isHidden.eq(false)
                 )
                 .orderBy(orderBy(postSortType))
                 .offset(pageable.getOffset())

--- a/backend/src/main/java/com/votogether/domain/post/service/PostCommentService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostCommentService.java
@@ -45,7 +45,7 @@ public class PostCommentService {
         final Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException(PostExceptionType.POST_NOT_FOUND));
 
-        return commentRepository.findAllByPostOrderByCreatedAtAsc(post)
+        return commentRepository.findAllByPostAndIsHiddenFalseOrderByCreatedAtAsc(post)
                 .stream()
                 .map(CommentResponse::from)
                 .toList();

--- a/backend/src/test/java/com/votogether/domain/post/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/repository/CommentRepositoryTest.java
@@ -55,7 +55,7 @@ class CommentRepositoryTest {
         );
 
         // when
-        List<Comment> result = commentRepository.findAllByPostOrderByCreatedAtAsc(post);
+        List<Comment> result = commentRepository.findAllByPostAndIsHiddenFalseOrderByCreatedAtAsc(post);
 
         // then
         assertThat(result).containsExactly(commentA, commentB);

--- a/backend/src/test/java/com/votogether/domain/report/service/ReportServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/report/service/ReportServiceTest.java
@@ -2,15 +2,21 @@ package com.votogether.domain.report.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.member.repository.MemberRepository;
+import com.votogether.domain.post.dto.response.post.PostResponse;
 import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.PostBody;
 import com.votogether.domain.post.entity.comment.Comment;
+import com.votogether.domain.post.entity.vo.PostClosingType;
+import com.votogether.domain.post.entity.vo.PostSortType;
 import com.votogether.domain.post.repository.CommentRepository;
 import com.votogether.domain.post.repository.PostRepository;
+import com.votogether.domain.post.service.PostCommentService;
+import com.votogether.domain.post.service.PostService;
 import com.votogether.domain.report.dto.request.ReportRequest;
 import com.votogether.domain.report.entity.vo.ReportType;
 import com.votogether.domain.report.repository.ReportRepository;
@@ -19,6 +25,7 @@ import com.votogether.global.exception.NotFoundException;
 import com.votogether.test.annotation.ServiceTest;
 import com.votogether.test.fixtures.MemberFixtures;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,6 +48,12 @@ class ReportServiceTest {
 
     @Autowired
     CommentRepository commentRepository;
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    PostCommentService postCommentService;
 
     @Nested
     @DisplayName("게시글 신고기능은")
@@ -208,7 +221,17 @@ class ReportServiceTest {
             reportService.report(reporter5, request);
 
             // then
-            assertThat(post.isHidden()).isTrue();
+            final List<PostResponse> responses = postService.getPostsGuest(
+                    0,
+                    PostClosingType.ALL,
+                    PostSortType.HOT,
+                    null
+            );
+
+            assertAll(
+                    () -> assertThat(post.isHidden()).isTrue(),
+                    () -> assertThat(responses).isEmpty()
+            );
         }
 
     }
@@ -413,7 +436,10 @@ class ReportServiceTest {
             reportService.report(reporter5, request);
 
             // then
-            assertThat(comment.isHidden()).isTrue();
+            assertAll(
+                    () -> assertThat(comment.isHidden()).isTrue(),
+                    () -> assertThat(postCommentService.getComments(post.getId())).isEmpty()
+            );
         }
 
     }
@@ -486,7 +512,6 @@ class ReportServiceTest {
             // then
             assertThat(reported.getNickname()).contains("Pause1");
         }
-
     }
 
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #438 

## 📝 작업 요약

게시글과 댓글이 신고 5번 이상이어도 보이는 버그 픽스

## ⏰ 소요 시간

30분

## 🔎 작업 상세 설명

게시글과 댓글이 신고 5번 이상이어도 보이는 상황에서 안보이도록 수정
