### PR TITLE
게시글 수정 시, PostOption 테이블 유니크 값 충돌 문제 해결

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/Post.java
@@ -13,6 +13,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -206,25 +207,32 @@ public class Post extends BaseEntity {
             final List<String> postOptionContents,
             final List<String> oldPostOptionImageUrls,
             final List<String> postOptionImageUrls,
-            final LocalDateTime deadline
-    ) {
+            final LocalDateTime deadline,
+            final EntityManager entityManager
+            ) {
         this.postBody.update(postBody, oldContentImageUrl, contentImageUrls);
         this.postCategories.update(this, categories);
-        updatePostOptions(postOptionContents, oldPostOptionImageUrls, postOptionImageUrls);
+        updatePostOptions(postOptionContents, oldPostOptionImageUrls, postOptionImageUrls, entityManager);
         this.deadline = deadline;
     }
 
     private void updatePostOptions(
             final List<String> postOptionContents,
             final List<String> oldPostOptionImageUrls,
-            final List<String> postOptionImageUrls
+            final List<String> postOptionImageUrls,
+            final EntityManager entityManager
     ) {
         this.postOptions.clear();
-        this.postOptions = new PostOptions();
+        persistenceProgress(entityManager);
         mapPostOptionsByElements(
                 postOptionContents,
                 getPostOptionImageUrls(oldPostOptionImageUrls, postOptionImageUrls)
         );
+    }
+
+    private void persistenceProgress(final EntityManager entityManager) {
+        entityManager.flush();
+        entityManager.clear();
     }
 
     private List<String> getPostOptionImageUrls(

--- a/backend/src/main/java/com/votogether/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/Post.java
@@ -13,7 +13,6 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -208,23 +207,27 @@ public class Post extends BaseEntity {
             final List<String> oldPostOptionImageUrls,
             final List<String> postOptionImageUrls,
             final LocalDateTime deadline
-            ) {
+    ) {
         this.postBody.update(postBody, oldContentImageUrl, contentImageUrls);
         this.postCategories.update(this, categories);
-        updatePostOptions(postOptionContents, oldPostOptionImageUrls, postOptionImageUrls);
+        addAllPostOptions(postOptionContents, oldPostOptionImageUrls, postOptionImageUrls);
         this.deadline = deadline;
     }
 
-    private void updatePostOptions(
+    private void addAllPostOptions(
             final List<String> postOptionContents,
             final List<String> oldPostOptionImageUrls,
             final List<String> postOptionImageUrls
     ) {
-        this.postOptions.clear();
-        mapPostOptionsByElements(
+        this.postOptions.addAll(
+                this,
                 postOptionContents,
                 getPostOptionImageUrls(oldPostOptionImageUrls, postOptionImageUrls)
         );
+    }
+
+    public void postOptionsClear() {
+        this.postOptions.clear();
     }
 
     private List<String> getPostOptionImageUrls(

--- a/backend/src/main/java/com/votogether/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/Post.java
@@ -207,32 +207,24 @@ public class Post extends BaseEntity {
             final List<String> postOptionContents,
             final List<String> oldPostOptionImageUrls,
             final List<String> postOptionImageUrls,
-            final LocalDateTime deadline,
-            final EntityManager entityManager
+            final LocalDateTime deadline
             ) {
         this.postBody.update(postBody, oldContentImageUrl, contentImageUrls);
         this.postCategories.update(this, categories);
-        updatePostOptions(postOptionContents, oldPostOptionImageUrls, postOptionImageUrls, entityManager);
+        updatePostOptions(postOptionContents, oldPostOptionImageUrls, postOptionImageUrls);
         this.deadline = deadline;
     }
 
     private void updatePostOptions(
             final List<String> postOptionContents,
             final List<String> oldPostOptionImageUrls,
-            final List<String> postOptionImageUrls,
-            final EntityManager entityManager
+            final List<String> postOptionImageUrls
     ) {
         this.postOptions.clear();
-        persistenceProgress(entityManager);
         mapPostOptionsByElements(
                 postOptionContents,
                 getPostOptionImageUrls(oldPostOptionImageUrls, postOptionImageUrls)
         );
-    }
-
-    private void persistenceProgress(final EntityManager entityManager) {
-        entityManager.flush();
-        entityManager.clear();
     }
 
     private List<String> getPostOptionImageUrls(

--- a/backend/src/main/java/com/votogether/domain/post/entity/PostOptions.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/PostOptions.java
@@ -26,14 +26,22 @@ public class PostOptions {
             final List<String> optionImageUrls
     ) {
         final PostOptions newInstance = new PostOptions();
-        final List<PostOption> postOptions = IntStream.rangeClosed(FIRST_OPTION_SEQUENCE, postOptionContents.size())
+        final List<PostOption> postOptions = getPostOptions(post, postOptionContents, optionImageUrls);
+
+        newInstance.postOptions.addAll(postOptions);
+        return newInstance;
+    }
+
+    private static List<PostOption> getPostOptions(
+            final Post post,
+            final List<String> postOptionContents,
+            final List<String> optionImageUrls
+    ) {
+        return IntStream.rangeClosed(FIRST_OPTION_SEQUENCE, postOptionContents.size())
                 .mapToObj(postOptionSequence ->
                         toPostOption(post, postOptionContents, optionImageUrls, postOptionSequence)
                 )
                 .toList();
-
-        newInstance.postOptions.addAll(postOptions);
-        return newInstance;
     }
 
     private static PostOption toPostOption(
@@ -60,6 +68,14 @@ public class PostOptions {
                 .findAny()
                 .map(PostOption::getId)
                 .orElse(0L);
+    }
+
+    public void addAll(
+            final Post post,
+            final List<String> postOptionContents,
+            final List<String> postOptionImageUrls
+    ) {
+        this.postOptions.addAll(getPostOptions(post, postOptionContents, postOptionImageUrls));
     }
 
     public void clear() {

--- a/backend/src/main/java/com/votogether/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostService.java
@@ -16,7 +16,6 @@ import com.votogether.domain.post.dto.response.vote.VoteOptionStatisticsResponse
 import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.PostBody;
 import com.votogether.domain.post.entity.PostOption;
-import com.votogether.domain.post.entity.PostOptions;
 import com.votogether.domain.post.entity.vo.PostClosingType;
 import com.votogether.domain.post.entity.vo.PostSortType;
 import com.votogether.domain.post.exception.PostExceptionType;
@@ -337,12 +336,13 @@ public class PostService {
     ) {
         final Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BadRequestException(PostExceptionType.POST_NOT_FOUND));
+
         post.validateExistVote();
         post.validateWriter(member);
         post.validateDeadLine();
         post.validateDeadLineToModify(request.deadline());
 
-        deleteAllPostOptionsByPost(post);
+        postOptionsInit(post);
         post.update(
                 toPostBody(request.title(), request.content()),
                 request.imageUrl(),
@@ -355,9 +355,9 @@ public class PostService {
         );
     }
 
-    private void deleteAllPostOptionsByPost(final Post post) {
-        final PostOptions postOptions = post.getPostOptions();
-        postOptionRepository.deleteAll(postOptions.getPostOptions());
+    private void postOptionsInit(final Post post) {
+        post.postOptionsClear();
+        postRepository.flush();
     }
 
     private <T, R> List<R> transformElements(final List<T> elements, final Function<T, R> process) {

--- a/backend/src/main/java/com/votogether/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostService.java
@@ -26,7 +26,6 @@ import com.votogether.domain.vote.repository.dto.VoteStatus;
 import com.votogether.global.exception.BadRequestException;
 import com.votogether.global.exception.NotFoundException;
 import com.votogether.global.util.ImageUploader;
-import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;

--- a/backend/src/main/java/com/votogether/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostService.java
@@ -26,6 +26,7 @@ import com.votogether.domain.vote.repository.dto.VoteStatus;
 import com.votogether.global.exception.BadRequestException;
 import com.votogether.global.exception.NotFoundException;
 import com.votogether.global.util.ImageUploader;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
@@ -53,20 +54,22 @@ public class PostService {
     private final PostOptionRepository postOptionRepository;
     private final CategoryRepository categoryRepository;
     private final VoteRepository voteRepository;
+    private final EntityManager entityManager;
 
     public PostService(
             final PostRepository postRepository,
             final PostOptionRepository postOptionRepository,
             final CategoryRepository categoryRepository,
-            final VoteRepository voteRepository
+            final VoteRepository voteRepository,
+            final EntityManager entityManager
     ) {
         this.postRepository = postRepository;
         this.postOptionRepository = postOptionRepository;
         this.categoryRepository = categoryRepository;
         this.voteRepository = voteRepository;
-
         this.postsVotedByMemberMapper = new EnumMap<>(PostClosingType.class);
         initPostsVotedByMemberMapper();
+        this.entityManager = entityManager;
     }
 
     private void initPostsVotedByMemberMapper() {
@@ -349,7 +352,8 @@ public class PostService {
                 transformElements(request.postOptions(), PostOptionUpdateRequest::content),
                 transformElements(request.postOptions(), PostOptionUpdateRequest::imageUrl),
                 transformElements(optionImages, ImageUploader::upload),
-                request.deadline()
+                request.deadline(),
+                entityManager
         );
     }
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #448 

## 📝 작업 요약

게시글 수정 시, PostOption 테이블 유니크 값 충돌 문제 해결

## ⏰ 소요 시간

5시간

## 🔎 작업 상세 설명

게시글 수정 시, PostOption 테이블 유니크 값 충돌 문제 해결
