### PR TITLE
NarrowMainHeader, Select, Searchbar, Skeleton 컴포넌트 웹접근성 개선 / 닉네임 변경 및 신고 API 실패 시 Toast 띄우기

### DIFF
--- a/frontend/src/components/comment/CommentList/CommentItem/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentItem/index.tsx
@@ -88,7 +88,7 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
     <S.Container>
       <S.Header>
         <S.UserContainer>
-          <S.Title>{member.nickname}</S.Title>
+          <S.Nickname>{member.nickname}</S.Nickname>
           <S.SubTitleContainer>
             <S.SubTitle>{createdAt}</S.SubTitle>
             {isEdit && <S.SubTitle>(수정됨)</S.SubTitle>}

--- a/frontend/src/components/comment/CommentList/CommentItem/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentItem/index.tsx
@@ -52,7 +52,12 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
         openToast('댓글을 신고했습니다.');
       })
       .catch(e => {
-        openToast(e instanceof Error ? e.message : '댓글 신고가 실패했습니다');
+        if (e instanceof Error) {
+          const errorResposne = JSON.parse(e.message);
+          openToast(errorResposne.message);
+          return;
+        }
+        openToast('댓글 신고가 실패했습니다.');
       });
   };
 
@@ -64,7 +69,12 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
         openToast('작성자 닉네임을 신고했습니다.');
       })
       .catch(e => {
-        openToast(e instanceof Error ? e.message : '작성자 닉네임 신고가 실패했습니다.');
+        if (e instanceof Error) {
+          const errorResposne = JSON.parse(e.message);
+          openToast(errorResposne.message);
+          return;
+        }
+        openToast('작성자 닉네임 신고가 실패했습니다.');
       });
   };
 

--- a/frontend/src/components/comment/CommentList/CommentItem/style.ts
+++ b/frontend/src/components/comment/CommentList/CommentItem/style.ts
@@ -25,8 +25,8 @@ export const Header = styled.div`
   margin-bottom: 7px;
 `;
 
-export const Title = styled.span`
-  font-weight: 500;
+export const Nickname = styled.span`
+  font-weight: 600;
 `;
 
 export const UserContainer = styled.div`

--- a/frontend/src/components/common/LogoButton/index.tsx
+++ b/frontend/src/components/common/LogoButton/index.tsx
@@ -9,7 +9,7 @@ type Content = 'icon' | 'text' | 'full';
 
 const contentCategory: Record<Content, { name: string; url: string }> = {
   icon: {
-    name: '로고 아이콘',
+    name: '보투게더 로고 아이콘',
     url: logo,
   },
   text: {

--- a/frontend/src/components/common/NarrowMainHeader/index.tsx
+++ b/frontend/src/components/common/NarrowMainHeader/index.tsx
@@ -26,7 +26,7 @@ export default function NarrowMainHeader({
   return isSearchInputOpen ? (
     <S.Background onClick={closeSearchInput}>
       <S.Container onClick={(event: MouseEvent) => event.stopPropagation()}>
-        <SearchBar size="free" autoFocus />
+        <SearchBar size="free" isOpen={isSearchInputOpen} autoFocus />
       </S.Container>
     </S.Background>
   ) : (

--- a/frontend/src/components/common/NarrowMainHeader/style.ts
+++ b/frontend/src/components/common/NarrowMainHeader/style.ts
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 
-export const Container = styled.div`
+export const Container = styled.header`
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/frontend/src/components/common/SearchBar/index.tsx
+++ b/frontend/src/components/common/SearchBar/index.tsx
@@ -11,15 +11,21 @@ import * as S from './style';
 
 interface SearchBarProps extends HTMLAttributes<HTMLInputElement> {
   size: Size | 'free';
+  isOpen?: boolean;
 }
 
-export default function SearchBar({ size, ...rest }: SearchBarProps) {
+export default function SearchBar({ size, isOpen, ...rest }: SearchBarProps) {
   return (
     <S.Form size={size} action={PATH.SEARCH}>
       <S.Input type="search" name={SEARCH_KEYWORD} {...rest} />
       <S.Button type="submit">
         <img src={searchIcon} alt="검색버튼" />
       </S.Button>
+      {isOpen && (
+        <S.ScreenReaderDirection aria-live="polite">
+          검색창을 닫으려면 검색창 외부를 클릭해주세요.
+        </S.ScreenReaderDirection>
+      )}
     </S.Form>
   );
 }

--- a/frontend/src/components/common/SearchBar/index.tsx
+++ b/frontend/src/components/common/SearchBar/index.tsx
@@ -17,7 +17,12 @@ interface SearchBarProps extends HTMLAttributes<HTMLInputElement> {
 export default function SearchBar({ size, isOpen, ...rest }: SearchBarProps) {
   return (
     <S.Form size={size} action={PATH.SEARCH}>
-      <S.Input type="search" name={SEARCH_KEYWORD} {...rest} />
+      <S.Input
+        aria-label="게시글 제목 및 내용 검색창"
+        type="search"
+        name={SEARCH_KEYWORD}
+        {...rest}
+      />
       <S.Button type="submit">
         <img src={searchIcon} alt="검색버튼" />
       </S.Button>

--- a/frontend/src/components/common/SearchBar/style.ts
+++ b/frontend/src/components/common/SearchBar/style.ts
@@ -45,3 +45,8 @@ export const Button = styled.button`
 
   cursor: pointer;
 `;
+
+export const ScreenReaderDirection = styled.p`
+  position: absolute;
+  left: -9999px;
+`;

--- a/frontend/src/components/common/Select/index.tsx
+++ b/frontend/src/components/common/Select/index.tsx
@@ -61,7 +61,11 @@ export default function Select<T extends string>({
         <S.OptionListParent>
           <S.OptionListContainer>
             {optionKeyList.map((optionKey: T) => (
-              <S.OptionContainer key={optionKey} onClick={() => handleSelectClick(optionKey)}>
+              <S.OptionContainer
+                tabIndex={0}
+                key={optionKey}
+                onClick={() => handleSelectClick(optionKey)}
+              >
                 {optionList[optionKey]}
               </S.OptionContainer>
             ))}

--- a/frontend/src/components/common/Select/index.tsx
+++ b/frontend/src/components/common/Select/index.tsx
@@ -53,6 +53,11 @@ export default function Select<T extends string>({
         <S.Image src={isOpen ? chevronUp : chevronDown} alt="" $isSelected={isOpen} />
       </S.SelectedContainer>
       {isOpen && (
+        <S.ScreenReaderDirection aria-live="polite">
+          이 요소를 닫으려면 한번 더 클릭해주세요.
+        </S.ScreenReaderDirection>
+      )}
+      {isOpen && (
         <S.OptionListParent>
           <S.OptionListContainer>
             {optionKeyList.map((optionKey: T) => (

--- a/frontend/src/components/common/Select/style.ts
+++ b/frontend/src/components/common/Select/style.ts
@@ -84,3 +84,8 @@ export const Image = styled.img<{ $isSelected: boolean }>`
   border-left: 1px solid var(--slate);
   padding-left: 8px;
 `;
+
+export const ScreenReaderDirection = styled.p`
+  position: absolute;
+  left: -9999px;
+`;

--- a/frontend/src/components/common/Skeleton/index.tsx
+++ b/frontend/src/components/common/Skeleton/index.tsx
@@ -6,7 +6,7 @@ interface SkeletonProps {
 
 export default function Skeleton({ isLarge }: SkeletonProps) {
   return (
-    <S.Container aria-label="현재 페이지의 내용을 불러오는 중입니다.">
+    <S.Container tabIndex={0} aria-label="현재 페이지의 내용을 불러오는 중입니다.">
       <S.FirstBox $isLarge={isLarge} />
       <S.SecondBox />
       <S.ThirdBox />

--- a/frontend/src/components/common/Skeleton/index.tsx
+++ b/frontend/src/components/common/Skeleton/index.tsx
@@ -6,7 +6,7 @@ interface SkeletonProps {
 
 export default function Skeleton({ isLarge }: SkeletonProps) {
   return (
-    <S.Container>
+    <S.Container aria-label="현재 페이지의 내용을 불러오는 중입니다.">
       <S.FirstBox $isLarge={isLarge} />
       <S.SecondBox />
       <S.ThirdBox />

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -54,6 +54,8 @@ export default function PostList() {
       <S.SelectContainer>
         <S.SelectWrapper>
           <Select<PostStatus>
+            role="select"
+            aria-label={`마감 여부로 게시글 정렬 선택, 현재 옵션은 ${STATUS_OPTION[selectedStatusOption]}`}
             handleOptionChange={(value: PostStatus) => {
               setPostOption({
                 ...postOption,
@@ -67,6 +69,8 @@ export default function PostList() {
         </S.SelectWrapper>
         <S.SelectWrapper>
           <Select<PostSorting>
+            role="select"
+            aria-label={`인기순/최신순으로 게시글 정렬 선택, 현재 옵션은 ${SORTING_OPTION[selectedSortingOption]}`}
             handleOptionChange={(value: PostSorting) => {
               setPostOption({
                 ...postOption,

--- a/frontend/src/hooks/query/user/useModifyUser.ts
+++ b/frontend/src/hooks/query/user/useModifyUser.ts
@@ -6,7 +6,7 @@ import { QUERY_KEY } from '@constants/queryKey';
 
 export const useModifyUser = () => {
   const queryClient = useQueryClient();
-  const { mutate, isLoading } = useMutation({
+  const { mutate, isLoading, isSuccess, isError, error } = useMutation({
     mutationFn: (nickname: string) => modifyNickname(nickname),
     onMutate: async newNickname => {
       await queryClient.cancelQueries({ queryKey: [QUERY_KEY.USER_INFO] });
@@ -18,12 +18,11 @@ export const useModifyUser = () => {
     onError: (error, __, context) => {
       queryClient.setQueryData([QUERY_KEY.USER_INFO], context?.previousNickname);
       window.console.error('닉네임 변경에 실패했습니다.');
-      alert('닉네임 변경에 실패했습니다.');
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER_INFO] });
     },
   });
 
-  return { mutate, isLoading };
+  return { mutate, isLoading, isSuccess, isError, error };
 };

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -57,9 +57,10 @@ export default function MyInfo() {
   }, [isWithdrawalMembershipSuccess, clearLoggedInfo, navigate]);
 
   useEffect(() => {
-    isWithdrawalMembershipError &&
-      withdrawalMembershipError instanceof Error &&
+    if (isWithdrawalMembershipError && withdrawalMembershipError instanceof Error) {
       openToast(withdrawalMembershipError.message);
+      return;
+    }
   }, [isWithdrawalMembershipError, openToast, withdrawalMembershipError]);
 
   return (

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -25,7 +25,12 @@ import * as S from './style';
 export default function MyInfo() {
   const navigate = useNavigate();
 
-  const { mutate: modifyNickname } = useModifyUser();
+  const {
+    mutate: modifyNickname,
+    isSuccess: isModifyNicknameSuccess,
+    isError: isModifyNicknameError,
+    error: modifyNicknameError,
+  } = useModifyUser();
   const {
     mutate: withdrawalMembership,
     isSuccess: isWithdrawalMembershipSuccess,
@@ -50,6 +55,21 @@ export default function MyInfo() {
   };
 
   useEffect(() => {
+    if (isModifyNicknameSuccess) {
+      openToast('닉네임을 성공적으로 변경했습니다.');
+      return;
+    }
+  }, [isModifyNicknameSuccess, openToast]);
+
+  useEffect(() => {
+    if (isModifyNicknameError && modifyNicknameError instanceof Error) {
+      const errorResponse = JSON.parse(modifyNicknameError.message);
+      openToast(errorResponse.message);
+      return;
+    }
+  }, [isModifyNicknameError, openToast, modifyNicknameError]);
+
+  useEffect(() => {
     if (isWithdrawalMembershipSuccess) {
       clearLoggedInfo();
       navigate('/');
@@ -58,7 +78,8 @@ export default function MyInfo() {
 
   useEffect(() => {
     if (isWithdrawalMembershipError && withdrawalMembershipError instanceof Error) {
-      openToast(withdrawalMembershipError.message);
+      const errorResponse = JSON.parse(withdrawalMembershipError.message);
+      openToast(errorResponse.message);
       return;
     }
   }, [isWithdrawalMembershipError, openToast, withdrawalMembershipError]);

--- a/frontend/src/pages/post/PostDetail/PostDetail/index.tsx
+++ b/frontend/src/pages/post/PostDetail/PostDetail/index.tsx
@@ -85,7 +85,12 @@ export default function PostDetail() {
           openToast('게시물을 신고했습니다.');
         })
         .catch(e => {
-          openToast(e instanceof Error ? e.message : '게시물 신고가 실패했습니다');
+          if (e instanceof Error) {
+            const errorResposne = JSON.parse(e.message);
+            openToast(errorResposne.message);
+            return;
+          }
+          openToast('게시글 신고가 실패했습니다.');
         });
     },
     reportNickname: async (reason: string) => {
@@ -100,7 +105,12 @@ export default function PostDetail() {
           openToast('작성자 닉네임을 신고했습니다.');
         })
         .catch(e => {
-          openToast(e instanceof Error ? e.message : '작성자 닉네임 신고가 실패했습니다.');
+          if (e instanceof Error) {
+            const errorResposne = JSON.parse(e.message);
+            openToast(errorResposne.message);
+            return;
+          }
+          openToast('작성자 닉네임 신고가 실패했습니다.');
         });
     },
   };

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -25,7 +25,7 @@ export const GlobalStyle = createGlobalStyle`
 
   :root {
     /* Colors *****************************************/
-    --primary-color: #FA7D7C;
+    --primary-color: #F85554;
     --white: #ffffff;
     --slate: #94A3B8;
     --gray: #F4F4F4;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #349 
close: #407 

## 📝 작업 요약
* 닉네임 변경 및 신고 API 통신 실패 시 백엔드에서 주는 에러 메시지를 Toast로 띄웁니다.
* NarrowMainHeader, Select, Searchbar, Skeleton 컴포넌트 웹접근성 개선
## ⏰ 소요 시간
* 4시간 
## 🔎 작업 상세 설명
* aria-label, aria-live 속성을 이용하여 웹접근성을 개선하였습니다.
* 모바일 안드로이드로 테스트하여서 데스크탑도 잘되는지 장담할 수 없습니다..😅🤔
