### PR TITLE
PostForm/ReportModal/WritingVoteOptionList 웹 접근성 도입 및 정책안내문구 적용

### DIFF
--- a/frontend/src/components/PostForm/ContentImageSection/index.tsx
+++ b/frontend/src/components/PostForm/ContentImageSection/index.tsx
@@ -18,6 +18,10 @@ interface ContentImageSectionProps {
 export default function ContentImageSection({ contentImageHook, size }: ContentImageSectionProps) {
   const { contentImage, contentInputRef, removeImage, handleUploadImage } = contentImageHook;
 
+  const handleButtonClick = () => {
+    contentInputRef.current && contentInputRef.current.click();
+  };
+
   return (
     <>
       {contentImage && (
@@ -30,20 +34,21 @@ export default function ContentImageSection({ contentImageHook, size }: ContentI
       )}
       {
         <S.FileInputContainer>
-          <S.Label
-            htmlFor="content-image-upload"
-            aria-label="본문 이미지 업로드 버튼"
-            title="이미지 업로드"
+          <S.Button
+            type="button"
             $isVisible={!!contentImage}
+            aria-label="본문 이미지 업로드"
+            onClick={handleButtonClick}
           >
-            본문에 사진 넣기
-          </S.Label>
+            <S.Label htmlFor="content-image-upload">본문에 사진 넣기</S.Label>
+          </S.Button>
           <S.FileInput
             id="content-image-upload"
             ref={contentInputRef}
             type="file"
             accept="image/*"
             onChange={handleUploadImage}
+            tabIndex={-1}
           />
         </S.FileInputContainer>
       }

--- a/frontend/src/components/PostForm/ContentImageSection/style.ts
+++ b/frontend/src/components/PostForm/ContentImageSection/style.ts
@@ -37,7 +37,7 @@ export const FileInput = styled.input`
   visibility: hidden;
 `;
 
-export const Label = styled.label<{ $isVisible: boolean }>`
+export const Button = styled.button<{ $isVisible: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -48,11 +48,19 @@ export const Label = styled.label<{ $isVisible: boolean }>`
   padding: 5px 0;
 
   background-color: var(--primary-color);
+
+  visibility: ${props => (props.$isVisible ? 'hidden' : '')};
+  cursor: pointer;
+`;
+
+export const Label = styled.label`
+  width: 100%;
+  height: 100%;
+
   color: var(--white);
 
   font: var(--text-body);
   text-align: center;
 
-  visibility: ${props => (props.$isVisible ? 'hidden' : '')};
   cursor: pointer;
 `;

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -22,6 +22,7 @@ import Toast from '@components/common/Toast';
 import WritingVoteOptionList from '@components/optionList/WritingVoteOptionList';
 
 import { PATH } from '@constants/path';
+import { CONTENT_PLACEHOLDER, POST_TITLE_POLICY } from '@constants/policyMessage';
 import { CATEGORY_COUNT_LIMIT, IMAGE_BASE_URL, POST_CONTENT, POST_TITLE } from '@constants/post';
 
 import { calculateDeadlineTime } from '@utils/post/calculateDeadlineTime';
@@ -201,7 +202,7 @@ export default function PostForm({ data, mutate }: PostFormProps) {
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 handleTitleChange(e, POST_TITLE)
               }
-              placeholder="제목을 입력해주세요"
+              placeholder={POST_TITLE_POLICY.DEFAULT}
               maxLength={POST_TITLE.MAX_LENGTH}
               minLength={POST_TITLE.MIN_LENGTH}
               required
@@ -211,7 +212,7 @@ export default function PostForm({ data, mutate }: PostFormProps) {
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
                 handleContentChange(e, POST_CONTENT)
               }
-              placeholder="내용을 입력해주세요"
+              placeholder={CONTENT_PLACEHOLDER}
               maxLength={POST_CONTENT.MAX_LENGTH}
               minLength={POST_CONTENT.MIN_LENGTH}
               required

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -22,7 +22,11 @@ import Toast from '@components/common/Toast';
 import WritingVoteOptionList from '@components/optionList/WritingVoteOptionList';
 
 import { PATH } from '@constants/path';
-import { CONTENT_PLACEHOLDER, POST_TITLE_POLICY } from '@constants/policyMessage';
+import {
+  CONTENT_PLACEHOLDER,
+  POST_DEADLINE_POLICY,
+  POST_TITLE_POLICY,
+} from '@constants/policyMessage';
 import { CATEGORY_COUNT_LIMIT, IMAGE_BASE_URL, POST_CONTENT, POST_TITLE } from '@constants/post';
 
 import { calculateDeadlineTime } from '@utils/post/calculateDeadlineTime';
@@ -225,18 +229,31 @@ export default function PostForm({ data, mutate }: PostFormProps) {
             <S.OptionListWrapper>
               <WritingVoteOptionList writingOptionHook={writingOptionHook} />
             </S.OptionListWrapper>
-            <S.Deadline>
-              <S.DeadlineDescription>
+            <S.Deadline aria-label="마감시간 설정">
+              <S.DeadlineDescription
+                aria-label={getDeadlineTime({
+                  hour: time.hour,
+                  day: time.day,
+                  minute: time.minute,
+                })}
+                aria-live="polite"
+              >
                 {getDeadlineTime({ hour: time.hour, day: time.day, minute: time.minute })}
                 {data && (
-                  <S.Description>
+                  <S.Description tabIndex={0}>
                     현재 시간으로부터 글 작성일({createTime})로부터 3일 이내 (
                     {addTimeToDate({ day: 3, hour: 0, minute: 0 }, baseTime)})까지만 선택
                     가능합니다.
                   </S.Description>
                 )}
-                {data && <S.Description>* 작성일시로부터 마감시간이 계산됩니다. </S.Description>}
-                {data && <S.Description>* 기존 마감 시간은 {deadline}입니다. </S.Description>}
+                {data && (
+                  <S.Description tabIndex={0}>
+                    * 작성일시로부터 마감시간이 계산됩니다.{' '}
+                  </S.Description>
+                )}
+                {data && (
+                  <S.Description tabIndex={0}>* 기존 마감 시간은 {deadline}입니다. </S.Description>
+                )}
               </S.DeadlineDescription>
               <S.ButtonWrapper>
                 {DEADLINE_OPTION.map(option => (
@@ -262,24 +279,38 @@ export default function PostForm({ data, mutate }: PostFormProps) {
               </S.ButtonWrapper>
             </S.Deadline>
             <S.SaveButtonWrapper>
-              <SquareButton theme="fill" type="submit" form="form-post">
+              <SquareButton
+                aria-label="글쓰기가 저장됩니다. 저장이 완료되면 메인화면으로 이동됩니다."
+                theme="fill"
+                type="submit"
+                form="form-post"
+              >
                 저장
               </SquareButton>
             </S.SaveButtonWrapper>
           </S.RightSide>
         </S.Wrapper>
         {isOpen && (
-          <Modal size="sm" onModalClose={closeModal}>
+          <Modal size="sm" onModalClose={closeModal} aria-label="마감시간 설정 모달">
             <>
               <S.ModalHeader>
                 <h3>마감 시간 선택</h3>
-                <S.CloseButton onClick={closeModal}>X</S.CloseButton>
+                <S.CloseButton onClick={closeModal} aria-label="마감시간 설정 모달 끄기">
+                  X
+                </S.CloseButton>
               </S.ModalHeader>
               <S.ModalBody>
-                <S.Description>최대 3일을 넘을 수 없습니다.</S.Description>
+                <S.Description aria-label={POST_DEADLINE_POLICY.DEFAULT} tabIndex={0}>
+                  {POST_DEADLINE_POLICY.DEFAULT}
+                </S.Description>
                 <TimePickerOptionList time={time} setTime={setTime} />
                 <S.ResetButtonWrapper>
-                  <SquareButton onClick={handleResetButton} type="button" theme="blank">
+                  <SquareButton
+                    aria-label="마감시간 초기화"
+                    onClick={handleResetButton}
+                    type="button"
+                    theme="blank"
+                  >
                     초기화
                   </SquareButton>
                 </S.ResetButtonWrapper>

--- a/frontend/src/components/common/Accordion/style.ts
+++ b/frontend/src/components/common/Accordion/style.ts
@@ -23,7 +23,7 @@ export const Title = styled.div`
 `;
 
 export const Content = styled.div<{ $isOpen: boolean }>`
-  display: ${props => (props.$isOpen ? 'flex' : 'none')};
+  display: ${props => (props.$isOpen ? 'block' : 'none')};
   justify-content: space-between;
 
   border: 1px solid #f2f2f2;

--- a/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/OptionUploadImageButton/index.tsx
+++ b/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/OptionUploadImageButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import photoIcon from '@assets/photo_white.svg';
 
@@ -14,14 +14,21 @@ export default function OptionUploadImageButton({
   isImageVisible,
   ...rest
 }: OptionUploadImageButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
   const id = optionId.toString();
+
+  const handleButtonClick = () => {
+    inputRef.current && inputRef.current.click();
+  };
 
   return (
     <S.Container $isVisible={isImageVisible}>
-      <S.Label htmlFor={id} aria-label="선택지 이미지 업로드 버튼" title="이미지 업로드">
-        <S.Image src={photoIcon} alt="" />
-      </S.Label>
-      <S.FileInput id={id} type="file" accept="image/*" {...rest} />
+      <button type="button" aria-label="선택지 이미지 업로드" onClick={handleButtonClick}>
+        <S.Label htmlFor={id}>
+          <S.Image src={photoIcon} alt="" />
+        </S.Label>
+      </button>
+      <S.FileInput id={id} type="file" accept="image/*" tabIndex={-1} ref={inputRef} {...rest} />
     </S.Container>
   );
 }

--- a/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/WritingVoteOption.stories.tsx
+++ b/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/WritingVoteOption.stories.tsx
@@ -12,6 +12,7 @@ type Story = StoryObj<typeof WritingVoteOption>;
 export const IsDeletable: Story = {
   render: () => (
     <WritingVoteOption
+      ariaLabel=""
       imageUrl=""
       handleUpdateOptionChange={() => {}}
       handleDeleteOptionClick={() => {}}
@@ -28,6 +29,7 @@ export const IsDeletable: Story = {
 export const IsNotDeletable: Story = {
   render: () => (
     <WritingVoteOption
+      ariaLabel=""
       imageUrl=""
       handleUpdateOptionChange={() => {}}
       handleDeleteOptionClick={() => {}}
@@ -44,6 +46,7 @@ export const IsNotDeletable: Story = {
 export const ShowImage: Story = {
   render: () => (
     <WritingVoteOption
+      ariaLabel=""
       handleUpdateOptionChange={() => {}}
       handleDeleteOptionClick={() => {}}
       handleRemoveImageClick={() => {}}

--- a/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/index.tsx
+++ b/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/index.tsx
@@ -10,6 +10,7 @@ interface WritingVoteOptionProps {
   optionId: number;
   text: string;
   isDeletable: boolean;
+  ariaLabel: string;
   handleUpdateOptionChange: (event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
   handleDeleteOptionClick: () => void;
   handleRemoveImageClick: () => void;
@@ -23,6 +24,7 @@ export default function WritingVoteOption({
   optionId,
   text,
   isDeletable,
+  ariaLabel,
   handleUpdateOptionChange,
   handleDeleteOptionClick,
   handleRemoveImageClick,
@@ -30,7 +32,7 @@ export default function WritingVoteOption({
   imageUrl,
 }: WritingVoteOptionProps) {
   return (
-    <S.Container>
+    <S.Container aria-label={ariaLabel}>
       <S.CancelButtonWrapper>
         {isDeletable && (
           <OptionCancelButton title="선택지 삭제하기" onClick={handleDeleteOptionClick} />

--- a/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/index.tsx
+++ b/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/index.tsx
@@ -1,5 +1,7 @@
 import { ChangeEvent } from 'react';
 
+import { POST_OPTION_POLICY } from '@constants/policyMessage';
+
 import OptionCancelButton from './OptionCancelButton';
 import OptionUploadImageButton from './OptionUploadImageButton';
 import * as S from './style';
@@ -40,7 +42,7 @@ export default function WritingVoteOption({
             name="optionText"
             defaultValue={text}
             onChange={(e: ChangeEvent<HTMLTextAreaElement>) => handleUpdateOptionChange(e)}
-            placeholder="내용을 입력해주세요."
+            placeholder={POST_OPTION_POLICY.DEFAULT}
             maxLength={MAX_WRITING_LENGTH}
           />
 

--- a/frontend/src/components/optionList/WritingVoteOptionList/index.tsx
+++ b/frontend/src/components/optionList/WritingVoteOptionList/index.tsx
@@ -29,10 +29,11 @@ export default function WritingVoteOptionList({ writingOptionHook }: WritingVote
   const isDeletable = optionList.length > MINIMUM_COUNT;
 
   return (
-    <S.Container>
-      {optionList.map(optionItem => (
+    <S.Container aria-label={`${optionList.length}개의 선택지가 있습니다.`} aria-live="polite">
+      {optionList.map((optionItem, index) => (
         <WritingVoteOption
           key={optionItem.id}
+          ariaLabel={`${index + 1}번 선택지`}
           optionId={optionItem.id}
           isDeletable={isDeletable}
           text={optionItem.text}
@@ -47,7 +48,7 @@ export default function WritingVoteOptionList({ writingOptionHook }: WritingVote
       ))}
       {optionList.length < MAXIMUM_COUNT && (
         <S.AddButtonWrapper>
-          <AddButton type="button" size="md" onClick={addOption} />
+          <AddButton type="button" size="md" aria-label="선택지 추가" onClick={addOption} />
         </S.AddButtonWrapper>
       )}
     </S.Container>

--- a/frontend/src/constants/policyMessage.ts
+++ b/frontend/src/constants/policyMessage.ts
@@ -1,0 +1,39 @@
+export const NICKNAME_POLICY = {
+  LETTER_AMOUNT: '2자에서 15자 이내로 입력해주세요.',
+  NO_DUPLICATION: '중복된 닉네임은 사용할 수 없습니다.',
+  LIMIT_CHANGING: '닉네임 변경은 1개월간 1번으로 제한됩니다.',
+  LIMIT_LETTER_TYPE: '한글/영어/숫자를 사용해 닉네임을 지어주세요.',
+};
+
+export const POST_CATEGORY_POLICY = {
+  AMOUNT: '1개 ~ 3개의 카테고리를 작성해주세요.',
+};
+
+export const POST_TITLE_POLICY = {
+  DEFAULT: '내용을 입력해주세요 (100자 이내)',
+  LETTER_AMOUNT: '100자 이내로 입력해주세요.',
+};
+
+export const POST_CONTENT_POLICY = {
+  DEFAULT: '내용을 입력해주세요 (1000자 이내)',
+  LETTER_AMOUNT: '1000자 이내로 입력해주세요.',
+  PHOTO_COUNT: '1장의 사진을 업로드 할 수 있습니다.',
+  PHOTO_SHAPE: '사진은 정사각형으로 잘라져 업로드됩니다.',
+  PHOTO_CAPACITY: '용량은 5MB으로 제한됩니다.',
+};
+
+export const POST_OPTION_POLICY = {
+  DEFAULT: '내용을 입력해주세요 (50자 이내)',
+  LETTER_AMOUNT: '50자 이내로 입력해주세요.',
+  AMOUNT: '2개 ~ 5개 선택지를 작성해주세요.',
+  PHOTO_COUNT: '1장의 사진을 업로드 할 수 있습니다.',
+  PHOTO_SHAPE: '사진은 정사각형으로 잘라져 업로드됩니다.',
+  PHOTO_CAPACITY: '용량은 5MB으로 제한됩니다.',
+};
+
+export const CONTENT_PLACEHOLDER = [
+  POST_CONTENT_POLICY.DEFAULT,
+  POST_CONTENT_POLICY.PHOTO_COUNT,
+  POST_CONTENT_POLICY.PHOTO_CAPACITY,
+  POST_CONTENT_POLICY.PHOTO_SHAPE,
+].join('\n - ');

--- a/frontend/src/constants/policyMessage.ts
+++ b/frontend/src/constants/policyMessage.ts
@@ -10,7 +10,7 @@ export const POST_CATEGORY_POLICY = {
 };
 
 export const POST_TITLE_POLICY = {
-  DEFAULT: '내용을 입력해주세요 (100자 이내)',
+  DEFAULT: '제목을 입력해주세요 (100자 이내)',
   LETTER_AMOUNT: '100자 이내로 입력해주세요.',
 };
 
@@ -23,12 +23,16 @@ export const POST_CONTENT_POLICY = {
 };
 
 export const POST_OPTION_POLICY = {
-  DEFAULT: '내용을 입력해주세요 (50자 이내)',
+  DEFAULT: '선택지를 입력해주세요 (50자 이내)',
   LETTER_AMOUNT: '50자 이내로 입력해주세요.',
   AMOUNT: '2개 ~ 5개 선택지를 작성해주세요.',
   PHOTO_COUNT: '1장의 사진을 업로드 할 수 있습니다.',
   PHOTO_SHAPE: '사진은 정사각형으로 잘라져 업로드됩니다.',
   PHOTO_CAPACITY: '용량은 5MB으로 제한됩니다.',
+};
+
+export const POST_DEADLINE_POLICY = {
+  DEFAULT: '3일 이내로 마감시간을 정해주세요.',
 };
 
 export const CONTENT_PLACEHOLDER = [

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -17,6 +17,7 @@ import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
 import SquareButton from '@components/common/SquareButton';
 import Toast from '@components/common/Toast';
 
+import { NICKNAME_POLICY } from '@constants/policyMessage';
 import { NICKNAME } from '@constants/user';
 
 import DeleteMemberModal from './DeleteMemberModal';
@@ -80,16 +81,24 @@ export default function MyInfo() {
         </S.ProfileSection>
         <S.UserControlSection>
           <Accordion title="닉네임 변경">
-            <S.Input
-              value={newNickname}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => handleNicknameChange(e, NICKNAME)}
-              placeholder="새로운 닉네임을 입력해주세요"
-            />
-            <S.ButtonWrapper>
-              <SquareButton aria-label="닉네임 변경" theme="fill" onClick={handleModifyNickname}>
-                변경
-              </SquareButton>
-            </S.ButtonWrapper>
+            <S.DescribeUl>
+              <li>- {NICKNAME_POLICY.LETTER_AMOUNT}</li>
+              <li>- {NICKNAME_POLICY.LIMIT_LETTER_TYPE}</li>
+              <li>- {NICKNAME_POLICY.NO_DUPLICATION}</li>
+              <li>- {NICKNAME_POLICY.LIMIT_CHANGING}</li>
+            </S.DescribeUl>
+            <S.InputWrapper>
+              <S.Input
+                value={newNickname}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => handleNicknameChange(e, NICKNAME)}
+                placeholder="새로운 닉네임을 입력해주세요"
+              />
+              <S.ButtonWrapper>
+                <SquareButton aria-label="닉네임 변경" theme="fill" onClick={handleModifyNickname}>
+                  변경
+                </SquareButton>
+              </S.ButtonWrapper>
+            </S.InputWrapper>
           </Accordion>
           <Accordion title="회원 탈퇴">
             <S.ButtonWrapper>

--- a/frontend/src/pages/MyInfo/style.ts
+++ b/frontend/src/pages/MyInfo/style.ts
@@ -41,15 +41,29 @@ export const UserControlSection = styled.section`
   width: 90%;
 `;
 
-export const ButtonWrapper = styled.div`
-  width: 90px;
-  height: 50px;
+export const DescribeUl = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  margin: 0 0 20px 5px;
+`;
+
+export const InputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
 `;
 
 export const Input = styled.input`
   width: 80%;
   border: 1px solid #f2f2f2;
   padding: 20px;
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 90px;
+  height: 50px;
 `;
 
 export const ModalBody = styled.div`


### PR DESCRIPTION
## 🔥 연관 이슈

close: #453 
: PostForm/ReportModal/WritingVoteOptionList 웹 접근성 도입 및 정책안내문구 적용

## 📝 작업 요약
- PostForm/ReportModal/WritingVoteOptionList 웹 접근성 도입
- 정책안내문구 적용

## ⏰ 소요 시간
2시간

## 🔎 작업 상세 설명
- PostForm/ReportModal/WritingVoteOptionList 웹 접근성 도입
    : 탭 이동 확인/ 맥 보이스오버로 내용 읽히는 것 확인 
    - PostForm/WritingVoteOptionList: 타임피커는 따로 컴포넌트로 있어 처리 하지 않음
    - ReportModal: 내용의 전부인 twoButtonModal/select가 따로 컴포넌트로 있어 처리하지 않음
- 정책안내문구 적용
    - 문구 상수화
    - 각 input에 제한글자수 안내
    - 본문에만 사진 정책 안내
    - 닉네임 변경 정책 안내

## 🌟 논의 사항

크루들과 이야기 해보고 싶은 부분을 적어주세요.
