### PR TITLE
[BUG] 모바일/데스크탑에서 사진을 2번씩 눌러야 이미지 첨부가 돼요

### DIFF
--- a/frontend/src/components/PostForm/ContentImageSection/index.tsx
+++ b/frontend/src/components/PostForm/ContentImageSection/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, MutableRefObject } from 'react';
+import { ChangeEvent, MouseEvent, MutableRefObject } from 'react';
 
 import { Size } from '@type/style';
 
@@ -18,7 +18,8 @@ interface ContentImageSectionProps {
 export default function ContentImageSection({ contentImageHook, size }: ContentImageSectionProps) {
   const { contentImage, contentInputRef, removeImage, handleUploadImage } = contentImageHook;
 
-  const handleButtonClick = () => {
+  const handleButtonClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     contentInputRef.current && contentInputRef.current.click();
   };
 

--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -50,7 +50,7 @@ export default function Post({ postInfo, isPreview }: PostProps) {
 
   const handleVoteClick = (newOptionId: number) => {
     if (!loggedInfo.isLoggedIn) {
-      openToast('투표를 하려면 로그인 후에 이용하실 수 있습니다.');
+      openToast('투표는 로그인 후에 이용하실 수 있습니다.');
       return;
     }
 

--- a/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/OptionUploadImageButton/index.tsx
+++ b/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/OptionUploadImageButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { MouseEvent, useRef } from 'react';
 
 import photoIcon from '@assets/photo_white.svg';
 
@@ -17,7 +17,8 @@ export default function OptionUploadImageButton({
   const inputRef = useRef<HTMLInputElement>(null);
   const id = optionId.toString();
 
-  const handleButtonClick = () => {
+  const handleButtonClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     inputRef.current && inputRef.current.click();
   };
 

--- a/frontend/src/pages/Error/index.tsx
+++ b/frontend/src/pages/Error/index.tsx
@@ -14,7 +14,7 @@ export default function Error({ message }: { message?: string }) {
       <S.Wrapper>
         <S.Description>{message ? message : '요청 중 오류가 발생했습니다.'}</S.Description>
         <LogoButton content="icon" style={{ width: '100px', height: '100px' }} />
-        <S.Text>오류가 지속되는 경우 votogether@gmail.com 로 문의해주세요.</S.Text>
+        <S.Text>오류가 지속되는 경우 votogether2023@gmail.com 로 문의해주세요.</S.Text>
         <S.ButtonWrapper>
           <SquareButton
             theme="fill"

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -107,7 +107,6 @@ export default function MyInfo() {
               <li>- {NICKNAME_POLICY.LETTER_AMOUNT}</li>
               <li>- {NICKNAME_POLICY.LIMIT_LETTER_TYPE}</li>
               <li>- {NICKNAME_POLICY.NO_DUPLICATION}</li>
-              <li>- {NICKNAME_POLICY.LIMIT_CHANGING}</li>
             </S.DescribeUl>
             <S.InputWrapper>
               <S.Input


### PR DESCRIPTION
- 기본 이벤트로 인한 호출 오류

## 🔥 연관 이슈

close: #468
close: #467


## 📝 작업 요약
모바일/데스크탑에서 사진 업로드 버튼 클릭시 2번씩 파일 창이 뜨는 오류 수정 
사용자에게 보여지는 메세지 수정

## ⏰ 소요 시간
5분

## 🔎 작업 상세 설명
- 웹접근성 도입으로 button을 이용하여 file 업로드 창을 띄우도록 수정됨
- 이 과정에서 button이벤트와 중복되어 문제 발생
- button의 이벤트를 ```e.preventDefault();```로 막아 해결
- 닉네임 변경 주기 제한 안내 삭제
- 잘못된 보투게터 이메일 수정

## 🌟 논의 사항
