### PR TITLE
구글 태그 및 채널톡 버튼 추가

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -48,6 +48,16 @@
   <body>
     <div id="root"></div>
   </body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript
+    ><iframe
+      src="https://www.googletagmanager.com/ns.html?id=GTM-N7NTHNF7"
+      height="0"
+      width="0"
+      style="display: none; visibility: hidden"
+    ></iframe
+  ></noscript>
+  <!-- Channel Talk -->
   <script>
     (function () {
       var w = window;

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -48,4 +48,44 @@
   <body>
     <div id="root"></div>
   </body>
+  <script>
+    (function () {
+      var w = window;
+      if (w.ChannelIO) {
+        return w.console.error('ChannelIO script included twice.');
+      }
+      var ch = function () {
+        ch.c(arguments);
+      };
+      ch.q = [];
+      ch.c = function (args) {
+        ch.q.push(args);
+      };
+      w.ChannelIO = ch;
+      function l() {
+        if (w.ChannelIOInitialized) {
+          return;
+        }
+        w.ChannelIOInitialized = true;
+        var s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.async = true;
+        s.src = 'https://cdn.channel.io/plugin/ch-plugin-web.js';
+        var x = document.getElementsByTagName('script')[0];
+        if (x.parentNode) {
+          x.parentNode.insertBefore(s, x);
+        }
+      }
+      if (document.readyState === 'complete') {
+        l();
+      } else {
+        w.addEventListener('DOMContentLoaded', l);
+        w.addEventListener('load', l);
+      }
+    })();
+
+    ChannelIO('boot', {
+      pluginKey: '1d876858-22cd-444b-8fcd-33487aed8247',
+    });
+  </script>
 </html>


### PR DESCRIPTION
## 🔥 연관 이슈

close: #492 

## 📝 작업 요약
* 구글 태그 및 채널톡 관련 코드를 `index.html`에 추가하였습니다.

## ⏰ 소요 시간
* 2시간

## 🔎 작업 상세 설명
* 구글 애널리틱스를 사용하려면 `votogether.com` 사이트의 script에 구글 태그 관련 코드를 추가해야 했습니다.
* 채널톡 사이트에서 채널톡 버튼의 위치나 색상 등 디자인을 변경하였습니다.
![image](https://github.com/woowacourse-teams/2023-votogether/assets/81199414/db21b7ea-28ac-40da-b139-f31a6a28843e)

## 🌟 논의 사항
* 채널톡 버튼의 위치가 적절한지 궁금해요~ (데스크탑, 모바일 모두 왼쪽에 위치하도록 함)