### PR TITLE
회원의 닉네임을 일정주기를 통해 변경할 수 있도록 구현

### DIFF
--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -82,17 +82,20 @@ public class Member extends BaseEntity {
 
     public void changeNicknameByCycle(final String nickname, final Long days) {
         if (nickname.startsWith(INITIAL_NICKNAME_PREFIX)) {
-            throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LETTER);
+            throw new BadRequestException(MemberExceptionType.NOT_ALLOWED_INITIAL_NICKNAME_PREFIX);
         }
-        if (isNotPassedChangingCycle(days)) {
+        if (isNotPassedChangingCycle(days) && isNotInitialNickname()) {
             throw new BadRequestException(MemberExceptionType.NOT_PASSED_NICKNAME_CHANGING_CYCLE);
         }
         this.nickname = new Nickname(nickname);
     }
 
     private boolean isNotPassedChangingCycle(final Long days) {
-        return (this.nickname.nonStartsWith(INITIAL_NICKNAME_PREFIX)) &&
-                (this.getUpdatedAt().isAfter(LocalDateTime.now().minusDays(days)));
+        return this.getUpdatedAt().isAfter(LocalDateTime.now().minusDays(days));
+    }
+
+    private boolean isNotInitialNickname() {
+        return this.nickname.nonStartsWith(INITIAL_NICKNAME_PREFIX);
     }
 
     public void changeNicknameByReport() {

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -5,6 +5,8 @@ import com.votogether.domain.common.BaseEntity;
 import com.votogether.domain.member.entity.vo.Gender;
 import com.votogether.domain.member.entity.vo.Nickname;
 import com.votogether.domain.member.entity.vo.SocialType;
+import com.votogether.domain.member.exception.MemberExceptionType;
+import com.votogether.global.exception.BadRequestException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -15,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -78,7 +81,15 @@ public class Member extends BaseEntity {
     }
 
     public void changeNickname(final String nickname) {
+        if (isNotPassedChangingCycle()) {
+            throw new BadRequestException(MemberExceptionType.NOT_PASSED_NICKNAME_CHANGING_CYCLE);
+        }
         this.nickname = new Nickname(nickname);
+    }
+
+    private boolean isNotPassedChangingCycle() {
+        return (!this.getCreatedAt().equals(this.getUpdatedAt())) &&
+                (this.getUpdatedAt().isAfter(LocalDateTime.now().minusDays(14L)));
     }
 
     public void changeNicknameByReport() {

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -80,16 +80,18 @@ public class Member extends BaseEntity {
                 .build();
     }
 
-    public void changeNickname(final String nickname) {
-        if (isNotPassedChangingCycle()) {
+    public void changeNicknameByCycle(final String nickname, final Long days) {
+        if (isNotPassedChangingCycle(days)) {
             throw new BadRequestException(MemberExceptionType.NOT_PASSED_NICKNAME_CHANGING_CYCLE);
         }
         this.nickname = new Nickname(nickname);
     }
 
-    private boolean isNotPassedChangingCycle() {
+    private boolean isNotPassedChangingCycle(final Long days) {
+        System.out.println("this.getCreatedAt() = " + this.getCreatedAt());
+        System.out.println("this.getUpdatedAt() = " + this.getUpdatedAt());
         return (!this.getCreatedAt().equals(this.getUpdatedAt())) &&
-                (this.getUpdatedAt().isAfter(LocalDateTime.now().minusDays(14L)));
+                (this.getUpdatedAt().isAfter(LocalDateTime.now().minusDays(days)));
     }
 
     public void changeNicknameByReport() {

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -81,6 +81,9 @@ public class Member extends BaseEntity {
     }
 
     public void changeNicknameByCycle(final String nickname, final Long days) {
+        if (nickname.startsWith(INITIAL_NICKNAME_PREFIX)) {
+            throw new BadRequestException(MemberExceptionType.INVALID_NICKNAME_LETTER);
+        }
         if (isNotPassedChangingCycle(days)) {
             throw new BadRequestException(MemberExceptionType.NOT_PASSED_NICKNAME_CHANGING_CYCLE);
         }
@@ -88,7 +91,7 @@ public class Member extends BaseEntity {
     }
 
     private boolean isNotPassedChangingCycle(final Long days) {
-        return (!this.getCreatedAt().equals(this.getUpdatedAt())) &&
+        return (this.nickname.nonStartsWith(INITIAL_NICKNAME_PREFIX)) &&
                 (this.getUpdatedAt().isAfter(LocalDateTime.now().minusDays(days)));
     }
 

--- a/backend/src/main/java/com/votogether/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/Member.java
@@ -88,8 +88,6 @@ public class Member extends BaseEntity {
     }
 
     private boolean isNotPassedChangingCycle(final Long days) {
-        System.out.println("this.getCreatedAt() = " + this.getCreatedAt());
-        System.out.println("this.getUpdatedAt() = " + this.getUpdatedAt());
         return (!this.getCreatedAt().equals(this.getUpdatedAt())) &&
                 (this.getUpdatedAt().isAfter(LocalDateTime.now().minusDays(days)));
     }

--- a/backend/src/main/java/com/votogether/domain/member/entity/vo/Nickname.java
+++ b/backend/src/main/java/com/votogether/domain/member/entity/vo/Nickname.java
@@ -34,4 +34,8 @@ public class Nickname {
         }
     }
 
+    public boolean nonStartsWith(final String prefix) {
+        return !this.value.startsWith(prefix);
+    }
+
 }

--- a/backend/src/main/java/com/votogether/domain/member/exception/MemberExceptionType.java
+++ b/backend/src/main/java/com/votogether/domain/member/exception/MemberExceptionType.java
@@ -14,6 +14,7 @@ public enum MemberExceptionType implements ExceptionType {
     ALREADY_ASSIGNED_GENDER(805, "이미 성별이 할당되어 있습니다."),
     ALREADY_ASSIGNED_BIRTH_YEAR(806, "이미 출생년도가 할당되어 있습니다."),
     NOT_PASSED_NICKNAME_CHANGING_CYCLE(807, "최소 닉네임 변경주기가 지나지 않았습니다."),
+    NOT_ALLOWED_INITIAL_NICKNAME_PREFIX(808, "초기 닉네임에 포함된 접두어로 닉네임을 변경할 수 없습니다."),
     ;
 
     private final int code;

--- a/backend/src/main/java/com/votogether/domain/member/exception/MemberExceptionType.java
+++ b/backend/src/main/java/com/votogether/domain/member/exception/MemberExceptionType.java
@@ -13,6 +13,7 @@ public enum MemberExceptionType implements ExceptionType {
     INVALID_AGE(804, "존재할 수 없는 연령입니다."),
     ALREADY_ASSIGNED_GENDER(805, "이미 성별이 할당되어 있습니다."),
     ALREADY_ASSIGNED_BIRTH_YEAR(806, "이미 출생년도가 할당되어 있습니다."),
+    NOT_PASSED_NICKNAME_CHANGING_CYCLE(807, "최소 닉네임 변경주기가 지나지 않았습니다."),
     ;
 
     private final int code;

--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -29,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class MemberService {
 
+    private static final Long NICKNAME_CHANGING_CYCLE = 14L;
+
     private final MemberRepository memberRepository;
     private final MemberCategoryRepository memberCategoryRepository;
     private final PostRepository postRepository;
@@ -68,7 +70,7 @@ public class MemberService {
     @Transactional
     public void changeNickname(final Member member, final String nickname) {
         validateExistentNickname(nickname);
-        member.changeNickname(nickname);
+        member.changeNicknameByCycle(nickname, NICKNAME_CHANGING_CYCLE);
     }
 
     private void validateExistentNickname(final String nickname) {

--- a/backend/src/test/java/com/votogether/domain/member/entity/MemberTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/entity/MemberTest.java
@@ -3,15 +3,14 @@ package com.votogether.domain.member.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.votogether.domain.common.BaseEntity;
 import com.votogether.domain.member.entity.vo.Gender;
 import com.votogether.domain.member.entity.vo.SocialType;
 import com.votogether.global.exception.BadRequestException;
-import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class MemberTest {
 
@@ -21,7 +20,7 @@ class MemberTest {
 
         @Test
         @DisplayName("15일전에 변경된 닉네임은 14일 주기로 변경할 때 성공적으로 변경된다.")
-        void success() throws Exception {
+        void success() {
             // given
             Member member = Member.builder()
                     .nickname("저문")
@@ -31,14 +30,9 @@ class MemberTest {
                     .socialType(SocialType.KAKAO)
                     .build();
 
-            Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
-            Field updatedAtField = BaseEntity.class.getDeclaredField("updatedAt");
-            createdAtField.setAccessible(true);
-            updatedAtField.setAccessible(true);
-
             LocalDateTime now = LocalDateTime.now().minusDays(15L);
-            createdAtField.set(member, now);
-            updatedAtField.set(member, now);
+            ReflectionTestUtils.setField(member, "createdAt", now);
+            ReflectionTestUtils.setField(member, "updatedAt", now);
 
             // when
             member.changeNicknameByCycle("저라니", 14L);
@@ -49,7 +43,7 @@ class MemberTest {
 
         @Test
         @DisplayName("13일 전에 변경된 닉네임은 14일 주기로 변경하더라도 한번도 닉네임을 변경하지 않았다면 성공적으로 변경된다.")
-        void successFirstChange() throws Exception {
+        void successFirstChange() {
             // given
             Member member = Member.builder()
                     .nickname("저문")
@@ -59,14 +53,9 @@ class MemberTest {
                     .socialType(SocialType.KAKAO)
                     .build();
 
-            Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
-            Field updatedAtField = BaseEntity.class.getDeclaredField("updatedAt");
-            createdAtField.setAccessible(true);
-            updatedAtField.setAccessible(true);
-
             LocalDateTime now = LocalDateTime.now().minusDays(13L);
-            createdAtField.set(member, now);
-            updatedAtField.set(member, now);
+            ReflectionTestUtils.setField(member, "createdAt", now);
+            ReflectionTestUtils.setField(member, "updatedAt", now);
 
             // when
             member.changeNicknameByCycle("저라니", 14L);
@@ -77,7 +66,7 @@ class MemberTest {
 
         @Test
         @DisplayName("13일 전에 변경된 닉네임은 14일 주기로 변경할 때 변경에 실패한다.")
-        void fail() throws Exception {
+        void fail() {
             // given
             Member member = Member.builder()
                     .nickname("저문")
@@ -87,15 +76,10 @@ class MemberTest {
                     .socialType(SocialType.KAKAO)
                     .build();
 
-            Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
-            Field updatedAtField = BaseEntity.class.getDeclaredField("updatedAt");
-            createdAtField.setAccessible(true);
-            updatedAtField.setAccessible(true);
-
             LocalDateTime createdTime = LocalDateTime.now().minusDays(20L);
             LocalDateTime updatedTime = LocalDateTime.now().minusDays(13L);
-            createdAtField.set(member, createdTime);
-            updatedAtField.set(member, updatedTime);
+            ReflectionTestUtils.setField(member, "createdAt", createdTime);
+            ReflectionTestUtils.setField(member, "updatedAt", updatedTime);
 
             // when, then
             assertThatThrownBy(() -> member.changeNicknameByCycle("저라니", 14L))

--- a/backend/src/test/java/com/votogether/domain/member/entity/MemberTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/entity/MemberTest.java
@@ -1,0 +1,108 @@
+package com.votogether.domain.member.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.votogether.domain.common.BaseEntity;
+import com.votogether.domain.member.entity.vo.Gender;
+import com.votogether.domain.member.entity.vo.SocialType;
+import com.votogether.global.exception.BadRequestException;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Nested
+    @DisplayName("닉네임을 주기에 따라 변경하는 경우")
+    class ChangeNicknameByCycle {
+
+        @Test
+        @DisplayName("15일전에 변경된 닉네임은 14일 주기로 변경할 때 성공적으로 변경된다.")
+        void success() throws Exception {
+            // given
+            Member member = Member.builder()
+                    .nickname("저문")
+                    .gender(Gender.MALE)
+                    .birthYear(1966)
+                    .socialId("abc123")
+                    .socialType(SocialType.KAKAO)
+                    .build();
+
+            Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
+            Field updatedAtField = BaseEntity.class.getDeclaredField("updatedAt");
+            createdAtField.setAccessible(true);
+            updatedAtField.setAccessible(true);
+
+            LocalDateTime now = LocalDateTime.now().minusDays(15L);
+            createdAtField.set(member, now);
+            updatedAtField.set(member, now);
+
+            // when
+            member.changeNicknameByCycle("저라니", 14L);
+
+            // then
+            assertThat(member.getNickname()).isEqualTo("저라니");
+        }
+
+        @Test
+        @DisplayName("13일 전에 변경된 닉네임은 14일 주기로 변경하더라도 한번도 닉네임을 변경하지 않았다면 성공적으로 변경된다.")
+        void successFirstChange() throws Exception {
+            // given
+            Member member = Member.builder()
+                    .nickname("저문")
+                    .gender(Gender.MALE)
+                    .birthYear(1966)
+                    .socialId("abc123")
+                    .socialType(SocialType.KAKAO)
+                    .build();
+
+            Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
+            Field updatedAtField = BaseEntity.class.getDeclaredField("updatedAt");
+            createdAtField.setAccessible(true);
+            updatedAtField.setAccessible(true);
+
+            LocalDateTime now = LocalDateTime.now().minusDays(13L);
+            createdAtField.set(member, now);
+            updatedAtField.set(member, now);
+
+            // when
+            member.changeNicknameByCycle("저라니", 14L);
+
+            // then
+            assertThat(member.getNickname()).isEqualTo("저라니");
+        }
+
+        @Test
+        @DisplayName("13일 전에 변경된 닉네임은 14일 주기로 변경할 때 변경에 실패한다.")
+        void fail() throws Exception {
+            // given
+            Member member = Member.builder()
+                    .nickname("저문")
+                    .gender(Gender.MALE)
+                    .birthYear(1966)
+                    .socialId("abc123")
+                    .socialType(SocialType.KAKAO)
+                    .build();
+
+            Field createdAtField = BaseEntity.class.getDeclaredField("createdAt");
+            Field updatedAtField = BaseEntity.class.getDeclaredField("updatedAt");
+            createdAtField.setAccessible(true);
+            updatedAtField.setAccessible(true);
+
+            LocalDateTime createdTime = LocalDateTime.now().minusDays(20L);
+            LocalDateTime updatedTime = LocalDateTime.now().minusDays(13L);
+            createdAtField.set(member, createdTime);
+            updatedAtField.set(member, updatedTime);
+
+            // when, then
+            assertThatThrownBy(() -> member.changeNicknameByCycle("저라니", 14L))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("최소 닉네임 변경주기가 지나지 않았습니다.");
+        }
+
+    }
+
+}

--- a/backend/src/test/java/com/votogether/domain/member/entity/MemberTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/entity/MemberTest.java
@@ -87,6 +87,29 @@ class MemberTest {
                     .hasMessage("최소 닉네임 변경주기가 지나지 않았습니다.");
         }
 
+        @Test
+        @DisplayName("초기 닉네임의 접두사가 포함되어 있으면 예외가 발생한다.")
+        void notAllowedChangeToInitialNicknamePrefix() {
+            // given
+            Member member = Member.builder()
+                    .nickname("저문")
+                    .gender(Gender.MALE)
+                    .birthYear(1966)
+                    .socialId("abc123")
+                    .socialType(SocialType.KAKAO)
+                    .build();
+
+            LocalDateTime createdTime = LocalDateTime.now().minusDays(20L);
+            LocalDateTime updatedTime = LocalDateTime.now().minusDays(7L);
+            ReflectionTestUtils.setField(member, "createdAt", createdTime);
+            ReflectionTestUtils.setField(member, "updatedAt", updatedTime);
+
+            // when, then
+            assertThatThrownBy(() -> member.changeNicknameByCycle("익명의손님저라니", 14L))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("초기 닉네임에 포함된 접두어로 닉네임을 변경할 수 없습니다.");
+        }
+
     }
 
 }

--- a/backend/src/test/java/com/votogether/domain/member/entity/MemberTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/entity/MemberTest.java
@@ -32,7 +32,7 @@ class MemberTest {
 
             LocalDateTime now = LocalDateTime.now().minusDays(15L);
             ReflectionTestUtils.setField(member, "createdAt", now);
-            ReflectionTestUtils.setField(member, "updatedAt", now);
+            ReflectionTestUtils.setField(member, "updatedAt", now.plusHours(1L));
 
             // when
             member.changeNicknameByCycle("저라니", 14L);
@@ -46,7 +46,7 @@ class MemberTest {
         void successFirstChange() {
             // given
             Member member = Member.builder()
-                    .nickname("저문")
+                    .nickname("익명의손님fFp4vAgX2d")
                     .gender(Gender.MALE)
                     .birthYear(1966)
                     .socialId("abc123")
@@ -55,7 +55,7 @@ class MemberTest {
 
             LocalDateTime now = LocalDateTime.now().minusDays(13L);
             ReflectionTestUtils.setField(member, "createdAt", now);
-            ReflectionTestUtils.setField(member, "updatedAt", now);
+            ReflectionTestUtils.setField(member, "updatedAt", now.plusHours(1L));
 
             // when
             member.changeNicknameByCycle("저라니", 14L);

--- a/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
@@ -87,14 +87,21 @@ class MemberServiceTest {
         @DisplayName("한번도 변경되지 않았다면 닉네임 변경 주기에 상관없이 닉네임을 변경한다.")
         void changeNickname() {
             // given
+            Member member = Member.builder()
+                    .nickname("익명의손님fFp4vAgX2d")
+                    .gender(Gender.MALE)
+                    .birthYear(1966)
+                    .socialId("abc123")
+                    .socialType(SocialType.KAKAO)
+                    .build();
             String newNickname = "jeomxon";
-            Member member = memberRepository.save(MemberFixtures.FEMALE_30.get());
+            Member savedMember = memberRepository.save(member);
 
             // when
-            memberService.changeNickname(member, newNickname);
+            memberService.changeNickname(savedMember, newNickname);
 
             // then
-            assertThat(member.getNickname()).isEqualTo(newNickname);
+            assertThat(savedMember.getNickname()).isEqualTo(newNickname);
         }
 
         @ParameterizedTest
@@ -140,12 +147,19 @@ class MemberServiceTest {
         @DisplayName("최초 닉네임을 변경한 후 닉네임 변경 주기가 지나지 않았다면 예외가 발생한다.")
         void changeNicknameThrowsExceptionNotPassedChangingCycle() {
             // given
-            Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+            Member member = Member.builder()
+                    .nickname("익명의손님fFp4vAgX2d")
+                    .gender(Gender.MALE)
+                    .birthYear(1966)
+                    .socialId("abc123")
+                    .socialType(SocialType.KAKAO)
+                    .build();
+            Member savedMember = memberRepository.save(member);
 
-            memberService.changeNickname(member, "저문");
+            memberService.changeNickname(savedMember, "저문");
 
             // when, then
-            assertThatThrownBy(() -> memberService.changeNickname(member, "저라니"))
+            assertThatThrownBy(() -> memberService.changeNickname(savedMember, "저라니"))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("최소 닉네임 변경주기가 지나지 않았습니다.");
         }

--- a/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
@@ -84,7 +84,7 @@ class MemberServiceTest {
     class ChangeNickname {
 
         @Test
-        @DisplayName("주어질 때 정상적으로 닉네임을 변경한다.")
+        @DisplayName("한번도 변경되지 않았다면 닉네임 변경 주기에 상관없이 닉네임을 변경한다.")
         void changeNickname() {
             // given
             String newNickname = "jeomxon";
@@ -134,6 +134,20 @@ class MemberServiceTest {
             assertThatThrownBy(() -> memberService.changeNickname(member1, member2.getNickname()))
                     .isInstanceOf(BadRequestException.class)
                     .hasMessage("이미 중복된 닉네임이 존재합니다.");
+        }
+
+        @Test
+        @DisplayName("최초 닉네임을 변경한 후 닉네임 변경 주기가 지나지 않았다면 예외가 발생한다.")
+        void changeNicknameThrowsExceptionNotPassedChangingCycle() {
+            // given
+            Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+
+            memberService.changeNickname(member, "저문");
+
+            // when, then
+            assertThatThrownBy(() -> memberService.changeNickname(member, "저라니"))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("최소 닉네임 변경주기가 지나지 않았습니다.");
         }
 
     }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #491 

## 📝 작업 요약

초기에 랜덤닉네임이 지정된 후에 1회는 자유롭게 변경이 가능합니다.
1회 변경 후에는 최소 14일이 지나야 닉네임을 변경할 수 있도록 로직을 추가하겠습니다.

## ⏰ 소요 시간

1시간 

## 🔎 작업 상세 설명

없음.

## 🌟 논의 사항

없음.
