### PR TITLE
컴포넌트 사용성 개선 및 라우팅 제한 추가, github action worflow 오류 해결 등 버그 5건 수정 

### DIFF
--- a/.github/workflows/backend-pr-comment.yml
+++ b/.github/workflows/backend-pr-comment.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification When Review Completed
-        if: contains(github.event.comment.body, 'review-complete') # check the comment if it contains the keywords
+        if: contains(github.event.comment.body, 'be-리뷰완') # check the comment if it contains the keywords
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_BE_CHANNEL }} # Slack 채널 ID
@@ -35,7 +35,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }} # Slack 토큰
 
       - name: Send Slack notification When Re-review Requested
-        if: contains(github.event.comment.body, 'review-request')
+        if: contains(github.event.comment.body, 'be-리뷰요청')
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_BE_CHANNEL }}

--- a/.github/workflows/backend-pr-deadline-slack-bot.yml
+++ b/.github/workflows/backend-pr-deadline-slack-bot.yml
@@ -7,7 +7,6 @@ on:
     branches: ['dev']
     paths:
       - 'backend/**'
-      - '.github/**'
 
 jobs:
   pull_request_open:

--- a/.github/workflows/backend-pr-deadline-slack-bot.yml
+++ b/.github/workflows/backend-pr-deadline-slack-bot.yml
@@ -9,10 +9,6 @@ on:
       - 'backend/**'
       - '.github/**'
 
-defaults:
-  run:
-    working-directory: backend
-
 jobs:
   pull_request_open:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-pr-deadline-slack-bot.yml
+++ b/.github/workflows/backend-pr-deadline-slack-bot.yml
@@ -7,6 +7,7 @@ on:
     branches: ['dev']
     paths:
       - 'backend/**'
+      - '.github/**'
 
 defaults:
   run:

--- a/.github/workflows/frontend-pr-comment.yml
+++ b/.github/workflows/frontend-pr-comment.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification When Review Completed
-        if: contains(github.event.comment.body, 'review-complete') # check the comment if it contains the keywords
+        if: contains(github.event.comment.body, 'fe-리뷰완') # check the comment if it contains the keywords
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_FE_CHANNEL }} # Slack 채널 ID
@@ -35,7 +35,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }} # Slack 토큰
 
       - name: Send Slack notification When Re-review Requested
-        if: contains(github.event.comment.body, 'review-request') # check the comment if it contains the keywords
+        if: contains(github.event.comment.body, 'fe-리뷰요청') # check the comment if it contains the keywords
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: ${{ secrets.SLACK_FE_CHANNEL }} # Slack 채널 ID

--- a/.github/workflows/frontend-pr-deadline-slack-bot.yml
+++ b/.github/workflows/frontend-pr-deadline-slack-bot.yml
@@ -9,10 +9,6 @@ on:
       - 'frontend/**'
       - '.github/**'
 
-defaults:
-  run:
-    working-directory: frontend
-
 jobs:
   pull_request_open:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-pr-deadline-slack-bot.yml
+++ b/.github/workflows/frontend-pr-deadline-slack-bot.yml
@@ -7,6 +7,7 @@ on:
     branches: ['dev']
     paths:
       - 'frontend/**'
+      - '.github/**'
 
 defaults:
   run:

--- a/.github/workflows/frontend-pr-deadline-slack-bot.yml
+++ b/.github/workflows/frontend-pr-deadline-slack-bot.yml
@@ -7,7 +7,6 @@ on:
     branches: ['dev']
     paths:
       - 'frontend/**'
-      - '.github/**'
 
 jobs:
   pull_request_open:

--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -1,4 +1,4 @@
-name: Storybook-Deploy
+name: Deploy
 
 on:
   pull_request:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,8 +8,9 @@ import PostOptionProvider from '@hooks/context/postOption';
 
 import router from '@routes/router';
 
-import ChannelTalk from '@pages/ChannelTalk';
 import ErrorBoundaryForTopClass from '@pages/ErrorBoundaryForTopClass';
+
+import ChannelTalk from '@components/ChannelTalk';
 
 import { GlobalStyle } from '@styles/globalStyle';
 import { theme } from '@styles/theme';

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -27,7 +27,7 @@ import {
   POST_DEADLINE_POLICY,
   POST_TITLE_POLICY,
 } from '@constants/policyMessage';
-import { CATEGORY_COUNT_LIMIT, IMAGE_BASE_URL, POST_CONTENT, POST_TITLE } from '@constants/post';
+import { CATEGORY_COUNT_LIMIT, POST_CONTENT, POST_TITLE } from '@constants/post';
 
 import { calculateDeadlineTime } from '@utils/post/calculateDeadlineTime';
 import { checkWriter } from '@utils/post/checkWriter';

--- a/frontend/src/components/common/Toast/style.ts
+++ b/frontend/src/components/common/Toast/style.ts
@@ -18,18 +18,9 @@ export const fadeInOutAnimation = keyframes`
 `;
 
 export const Wrapper = styled.div<{ $position: 'top' | 'bottom' }>`
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: ${props => POSITION[props.$position]};
-  align-items: end;
-  justify-items: center;
-
-  width: 100vw;
-  height: 100vh;
-
   position: fixed;
-  top: 0;
-  left: 0;
+
+  top: ${props => POSITION[props.$position]};
 `;
 
 export const Content = styled.div<{ $size: Size | 'free' }>`
@@ -49,5 +40,5 @@ export const Content = styled.div<{ $size: Size | 'free' }>`
 
   animation: ${fadeInOutAnimation} ${TOAST_TIME}s linear infinite;
 
-  z-index: ${theme.zIndex.modal};
+  z-index: ${theme.zIndex.select};
 `;

--- a/frontend/src/components/common/Toast/style.ts
+++ b/frontend/src/components/common/Toast/style.ts
@@ -40,5 +40,5 @@ export const Content = styled.div<{ $size: Size | 'free' }>`
 
   animation: ${fadeInOutAnimation} ${TOAST_TIME}s linear infinite;
 
-  z-index: ${theme.zIndex.select};
+  z-index: ${theme.zIndex.modal};
 `;

--- a/frontend/src/components/post/PostListPage/style.ts
+++ b/frontend/src/components/post/PostListPage/style.ts
@@ -40,9 +40,11 @@ export const ButtonContainer = styled.div`
   align-items: end;
   gap: 20px;
 
+  width: 62px;
   padding-right: 10px;
 
-  position: sticky;
+  position: fixed;
+  left: 90%;
   bottom: 24px;
 `;
 

--- a/frontend/src/hooks/query/user/useUpdateUserInfo.ts
+++ b/frontend/src/hooks/query/user/useUpdateUserInfo.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { UpdateUserInfoRequest } from '@type/user';
+
+import { updateUserInfo } from '@api/userInfo';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useUpdateUserInfo = () => {
+  const queryClient = useQueryClient();
+
+  const LOGGED_IN = true;
+  const { mutate, isLoading, isSuccess, isError, error } = useMutation({
+    mutationFn: async (userInfo: UpdateUserInfoRequest) => await updateUserInfo(userInfo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER_INFO, LOGGED_IN] });
+    },
+    onError: () => {
+      window.console.error('개인 정보 등록에 실패했습니다.');
+    },
+  });
+
+  return { mutate, isLoading, isSuccess, isError, error };
+};

--- a/frontend/src/pages/VoteStatisticsPage/index.tsx
+++ b/frontend/src/pages/VoteStatisticsPage/index.tsx
@@ -37,17 +37,13 @@ export default function VoteStatisticsPage() {
     isLoading: isVoteResultLoading,
   } = useFetch(() => getPostStatistics(postId));
 
-  const movePostDetailPage = () => {
-    navigate(`${PATH.POST}/${postId}`);
-  };
-
   if (postDetail && !checkWriter(postDetail.writer.id)) return <Navigate to={PATH.HOME} />;
 
   return (
     <Layout isSidebarVisible={true}>
       <S.HeaderWrapper>
         <NarrowTemplateHeader>
-          <IconButton category="back" onClick={movePostDetailPage} />
+          <IconButton category="back" onClick={() => navigate(-1)} />
         </NarrowTemplateHeader>
       </S.HeaderWrapper>
       <S.Container>

--- a/frontend/src/pages/post/PostDetail/InnerHeaderPart/index.tsx
+++ b/frontend/src/pages/post/PostDetail/InnerHeaderPart/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { PostAction, PostMenuItem } from '@type/menu';
 
@@ -39,7 +40,9 @@ export default function InnerHeaderPart({
   isClosed,
   handleEvent: { movePage, controlPost },
 }: PostDetailPageChildProps) {
-  const { moveWritePostPage, moveVoteStatisticsPage, movePostListPage } = movePage;
+  const navigate = useNavigate();
+
+  const { moveWritePostPage, moveVoteStatisticsPage } = movePage;
   const { setEarlyClosePost, deletePost, reportPost, reportNickname } = controlPost;
   const { isOpen, toggleComponent, closeComponent } = useToggle();
   const [action, setAction] = useState<PostAction | null>(null);
@@ -55,7 +58,12 @@ export default function InnerHeaderPart({
 
   return (
     <>
-      <IconButton category="back" onClick={movePostListPage} />
+      <IconButton
+        category="back"
+        onClick={() => {
+          navigate(-1);
+        }}
+      />
       <S.HeaderWrapper>
         {!isWriter ? (
           <>

--- a/frontend/src/pages/user/RegisterPersonalInfo/index.tsx
+++ b/frontend/src/pages/user/RegisterPersonalInfo/index.tsx
@@ -5,8 +5,8 @@ import { useUpdateUserInfo } from '@hooks/query/user/useUpdateUserInfo';
 import { useToast } from '@hooks/useToast';
 
 import Accordion from '@components/common/Accordion';
-import IconButton from '@components/common/IconButton';
 import Layout from '@components/common/Layout';
+import LogoButton from '@components/common/LogoButton';
 import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
 import SquareButton from '@components/common/SquareButton';
 import Toast from '@components/common/Toast';
@@ -95,7 +95,11 @@ export default function RegisterPersonalInfo() {
       <S.Wrapper>
         <S.HeaderWrapper>
           <NarrowTemplateHeader>
-            <IconButton category="back" />
+            <LogoButton
+              content="icon"
+              style={{ width: '33px', height: '33px' }}
+              onClick={() => navigate('/')}
+            />
           </NarrowTemplateHeader>
         </S.HeaderWrapper>
         <S.Title>개인 정보 등록</S.Title>


### PR DESCRIPTION
## 🔥 연관 이슈

close: #474 
close: #476 
close: #477 
close: #478 
close: #518

## 📝 작업 요약
* Toast 컴포넌트가 열리면 Toast 외부 화면을 눌러도 상호작용 되도록 style 수정함.
* 헤더의 뒤로가기 버튼누르면 홈이 아닌 바로 이전 url로 이동하도록 함
* 개인정보 최초 등록 후 다시 등록 페이지로 갈 수 없도록 라우팅 제한함
* UpButton, AddButton style 수정함

## ⏰ 소요 시간
* 5시간

## 🌟 논의 사항
* 사이드바에서 토스트 잘려서 보이는거 해결하고 싶은데 왜 해결이 안될까요... z-index 쓰면 해결될 줄 알았는데 실패.. ㅜㅜ  (#475)
