### PR TITLE
랭킹 UI와 hook 연결 및 msw 도입 (+변경된 랭킹 객체 타입 적용) 

### DIFF
--- a/frontend/src/api/ranking.ts
+++ b/frontend/src/api/ranking.ts
@@ -11,9 +11,9 @@ export const getUserRanking = async (isLoggedIn: boolean) => {
 };
 
 export const getPassionUserRanking = async () => {
-  return await getFetch<PassionUser>(`${BASE_URL}/members/ranking/passion/guest`);
+  return await getFetch<PassionUser[]>(`${BASE_URL}/members/ranking/passion/guest`);
 };
 
 export const getPopularPostRanking = async () => {
-  return await getFetch<RankingPost>(`${BASE_URL}/posts/ranking/popular/guest`);
+  return await getFetch<RankingPost[]>(`${BASE_URL}/posts/ranking/popular/guest`);
 };

--- a/frontend/src/hooks/query/ranking/usePassionUserRanking.ts
+++ b/frontend/src/hooks/query/ranking/usePassionUserRanking.ts
@@ -7,7 +7,7 @@ import { getPassionUserRanking } from '@api/ranking';
 import { QUERY_KEY } from '@constants/queryKey';
 
 export const usePassionUserRanking = () => {
-  const { data, error, isLoading, isError } = useQuery<PassionUser>(
+  const { data, error, isLoading, isError } = useQuery<PassionUser[]>(
     [QUERY_KEY.PASSION_RANKING],
     getPassionUserRanking,
     {

--- a/frontend/src/hooks/query/ranking/usePopularPostRanking.ts
+++ b/frontend/src/hooks/query/ranking/usePopularPostRanking.ts
@@ -7,7 +7,7 @@ import { getPopularPostRanking } from '@api/ranking';
 import { QUERY_KEY } from '@constants/queryKey';
 
 export const usePopularPostRanking = () => {
-  const { data, error, isLoading, isError } = useQuery<RankingPost>(
+  const { data, error, isLoading, isError } = useQuery<RankingPost[]>(
     [QUERY_KEY.POPULAR_RANKING],
     getPopularPostRanking,
     {

--- a/frontend/src/hooks/query/ranking/useUserRanking.ts
+++ b/frontend/src/hooks/query/ranking/useUserRanking.ts
@@ -6,7 +6,7 @@ import { getUserRanking } from '@api/ranking';
 
 import { QUERY_KEY } from '@constants/queryKey';
 
-export const usePassionUserRanking = (isLoggedIn: boolean) => {
+export const useUserRanking = (isLoggedIn: boolean) => {
   const { data, error, isLoading, isError } = useQuery<PassionUser | null>(
     [QUERY_KEY.USER_INFO, isLoggedIn, QUERY_KEY.PASSION_RANKING],
     () => getUserRanking(isLoggedIn),

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -4,6 +4,7 @@ import { example } from './example/get';
 import { mockVoteResult } from './getVoteDetail';
 import { mockPost } from './post';
 import { mockPostList } from './postList';
+import { mockRanking } from './ranking';
 import { mockReport } from './report';
 import { mockUserInfo } from './userInfo';
 import { mockVote } from './vote';
@@ -18,4 +19,5 @@ export const handlers = [
   ...mockUserInfo,
   ...mockComment,
   ...mockReport,
+  ...mockRanking,
 ];

--- a/frontend/src/mocks/ranking.ts
+++ b/frontend/src/mocks/ranking.ts
@@ -20,7 +20,7 @@ const rankerInfo: PassionUser = {
 
 const rankerList: PassionUser[] = new Array(10)
   .fill(rankerInfo)
-  .map((ranker, index) => ({ ...ranker, rank: index + 1 }));
+  .map((ranker, index) => ({ ...ranker, ranking: index + 1 }));
 
 const rankingPostInfo: RankingPost = {
   ranking: 1,
@@ -37,14 +37,14 @@ const rankingPostList: RankingPost[] = new Array(10)
 
 export const mockRanking = [
   rest.get('/members/me/ranking', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(userRankingInfo));
+    return res(ctx.status(200), ctx.delay(500), ctx.json(userRankingInfo));
   }),
 
   rest.get('/members/ranking/passion/guest', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(rankerList));
+    return res(ctx.status(200), ctx.delay(1000), ctx.json(rankerList));
   }),
 
   rest.get('/posts/ranking/popular/guest', (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(rankingPostList));
+    return res(ctx.status(200), ctx.delay(500), ctx.json(rankingPostList));
   }),
 ];

--- a/frontend/src/mocks/ranking.ts
+++ b/frontend/src/mocks/ranking.ts
@@ -1,0 +1,50 @@
+import { rest } from 'msw';
+
+import { PassionUser, RankingPost } from '@type/ranking';
+
+const userRankingInfo: PassionUser = {
+  ranking: 1111,
+  nickname: 'wow',
+  postCount: 1,
+  voteCount: 3,
+  score: 8,
+};
+
+const rankerInfo: PassionUser = {
+  ranking: 1,
+  nickname: 'gil-dong',
+  postCount: 11,
+  voteCount: 79,
+  score: 134,
+};
+
+const rankerList: PassionUser[] = new Array(10)
+  .fill(rankerInfo)
+  .map((ranker, index) => ({ ...ranker, rank: index + 1 }));
+
+const rankingPostInfo: RankingPost = {
+  ranking: 1,
+  post: {
+    id: 29,
+    writer: 'writer',
+    title: '이것은 엄청나게 많은 투표가 이루어진 대단한 글이지요',
+    voteCount: 10,
+  },
+};
+const rankingPostList: RankingPost[] = new Array(10)
+  .fill(rankingPostInfo)
+  .map((post, index) => ({ ...post, ranking: index + 1 }));
+
+export const mockRanking = [
+  rest.get('/members/me/ranking', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(userRankingInfo));
+  }),
+
+  rest.get('/members/ranking/passion/guest', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(rankerList));
+  }),
+
+  rest.get('/posts/ranking/popular/guest', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(rankingPostList));
+  }),
+];

--- a/frontend/src/pages/Ranking/PassionUser/PassionUser.stories.tsx
+++ b/frontend/src/pages/Ranking/PassionUser/PassionUser.stories.tsx
@@ -29,7 +29,7 @@ const userRankingInfo: PassionUser = {
 
 const rankerList: PassionUser[] = new Array(10)
   .fill(rankerInfo)
-  .map((ranker, index) => ({ ...ranker, rank: index + 1 }));
+  .map((ranker, index) => ({ ...ranker, ranking: index + 1 }));
 
 export const User: Story = {
   render: () => <PassionUserRanking rankerList={rankerList} userRanking={userRankingInfo} />,

--- a/frontend/src/pages/Ranking/PassionUser/PassionUser.stories.tsx
+++ b/frontend/src/pages/Ranking/PassionUser/PassionUser.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 type Story = StoryObj<typeof PassionUserRanking>;
 
 const rankerInfo: PassionUser = {
-  rank: 1,
+  ranking: 1,
   nickname: 'gil-dong',
   postCount: 11,
   voteCount: 79,
@@ -20,7 +20,7 @@ const rankerInfo: PassionUser = {
 };
 
 const userRankingInfo: PassionUser = {
-  rank: 1111,
+  ranking: 1111,
   nickname: 'wow',
   postCount: 1,
   voteCount: 3,

--- a/frontend/src/pages/Ranking/PassionUser/PassionUser.stories.tsx
+++ b/frontend/src/pages/Ranking/PassionUser/PassionUser.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { PassionUser } from '@type/ranking';
-
 import PassionUserRanking from '.';
 
 const meta: Meta<typeof PassionUserRanking> = {
@@ -11,30 +9,10 @@ const meta: Meta<typeof PassionUserRanking> = {
 export default meta;
 type Story = StoryObj<typeof PassionUserRanking>;
 
-const rankerInfo: PassionUser = {
-  ranking: 1,
-  nickname: 'gil-dong',
-  postCount: 11,
-  voteCount: 79,
-  score: 134,
-};
-
-const userRankingInfo: PassionUser = {
-  ranking: 1111,
-  nickname: 'wow',
-  postCount: 1,
-  voteCount: 3,
-  score: 8,
-};
-
-const rankerList: PassionUser[] = new Array(10)
-  .fill(rankerInfo)
-  .map((ranker, index) => ({ ...ranker, ranking: index + 1 }));
-
 export const User: Story = {
-  render: () => <PassionUserRanking rankerList={rankerList} userRanking={userRankingInfo} />,
+  render: () => <PassionUserRanking />,
 };
 
 export const Guest: Story = {
-  render: () => <PassionUserRanking rankerList={rankerList} />,
+  render: () => <PassionUserRanking />,
 };

--- a/frontend/src/pages/Ranking/PassionUser/UserRanking/index.tsx
+++ b/frontend/src/pages/Ranking/PassionUser/UserRanking/index.tsx
@@ -1,0 +1,25 @@
+import React, { useContext } from 'react';
+
+import { AuthContext } from '@hooks/context/auth';
+import { useUserRanking } from '@hooks/query/ranking/useUserRanking';
+
+import * as S from '../style';
+
+export default function UserRanking() {
+  const { loggedInfo } = useContext(AuthContext);
+  const { isLoggedIn } = loggedInfo;
+
+  const { data: userRanking } = useUserRanking(isLoggedIn);
+
+  return (
+    userRanking && (
+      <S.Tr>
+        <S.Td>{userRanking.ranking}</S.Td>
+        <S.Td>{userRanking.nickname}</S.Td>
+        <S.Td>{userRanking.postCount}</S.Td>
+        <S.Td>{userRanking.voteCount}</S.Td>
+        <S.Td>{userRanking.score}</S.Td>
+      </S.Tr>
+    )
+  );
+}

--- a/frontend/src/pages/Ranking/PassionUser/index.tsx
+++ b/frontend/src/pages/Ranking/PassionUser/index.tsx
@@ -1,12 +1,17 @@
-import { PassionUser } from '@type/ranking';
+import { Suspense } from 'react';
+
+import { usePassionUserRanking } from '@hooks/query/ranking/usePassionUserRanking';
+
+import ErrorBoundary from '@pages/ErrorBoundary';
+
+import LoadingSpinner from '@components/common/LoadingSpinner';
 
 import firstRankIcon from '@assets/first-rank.svg';
 import secondRankIcon from '@assets/second-rank.svg';
 import thirdRankIcon from '@assets/third-rank.svg';
 
-import * as RS from '../RankingTableStyle';
-
 import * as S from './style';
+import UserRanking from './UserRanking';
 
 const columnNameList = ['등수', '닉네임', '작성글 수', '투표 수', '점수'];
 
@@ -16,21 +21,18 @@ const rankIconUrl: Record<number, string> = {
   3: thirdRankIcon,
 };
 
-interface PassionUserRankingProps {
-  rankerList: PassionUser[];
-  userRanking?: PassionUser;
-}
+export default function PassionUserRanking() {
+  const { data: rankerList } = usePassionUserRanking();
 
-export default function PassionUserRanking({ rankerList, userRanking }: PassionUserRankingProps) {
   return (
-    <RS.Background>
-      <S.Table>
-        <S.Tr>
-          {columnNameList.map(text => (
-            <S.Th key={text}>{text}</S.Th>
-          ))}
-        </S.Tr>
-        {rankerList.map(ranker => {
+    <S.Table>
+      <S.Tr>
+        {columnNameList.map(text => (
+          <S.Th key={text}>{text}</S.Th>
+        ))}
+      </S.Tr>
+      {rankerList &&
+        rankerList.map(ranker => {
           const rankIcon = rankIconUrl[ranker.ranking] && (
             <img src={rankIconUrl[ranker.ranking]} alt={ranker.ranking.toString()} />
           );
@@ -45,16 +47,17 @@ export default function PassionUserRanking({ rankerList, userRanking }: PassionU
             </S.Tr>
           );
         })}
-        {userRanking && (
-          <S.Tr>
-            <S.Td>{userRanking.ranking}</S.Td>
-            <S.Td>{userRanking.nickname}</S.Td>
-            <S.Td>{userRanking.postCount}</S.Td>
-            <S.Td>{userRanking.voteCount}</S.Td>
-            <S.Td>{userRanking.score}</S.Td>
-          </S.Tr>
-        )}
-      </S.Table>
-    </RS.Background>
+      <ErrorBoundary>
+        <Suspense
+          fallback={
+            <S.LoadingSpinnerWrapper>
+              <LoadingSpinner size="sm" />
+            </S.LoadingSpinnerWrapper>
+          }
+        >
+          <UserRanking />
+        </Suspense>
+      </ErrorBoundary>
+    </S.Table>
   );
 }

--- a/frontend/src/pages/Ranking/PassionUser/index.tsx
+++ b/frontend/src/pages/Ranking/PassionUser/index.tsx
@@ -31,13 +31,13 @@ export default function PassionUserRanking({ rankerList, userRanking }: PassionU
           ))}
         </S.Tr>
         {rankerList.map(ranker => {
-          const rankIcon = rankIconUrl[ranker.rank] && (
-            <img src={rankIconUrl[ranker.rank]} alt={ranker.rank.toString()} />
+          const rankIcon = rankIconUrl[ranker.ranking] && (
+            <img src={rankIconUrl[ranker.ranking]} alt={ranker.ranking.toString()} />
           );
 
           return (
-            <S.Tr key={ranker.rank}>
-              <S.RankingTd>{rankIcon ?? ranker.rank}</S.RankingTd>
+            <S.Tr key={ranker.ranking}>
+              <S.RankingTd>{rankIcon ?? ranker.ranking}</S.RankingTd>
               <S.Td>{ranker.nickname}</S.Td>
               <S.Td>{ranker.postCount}</S.Td>
               <S.Td>{ranker.voteCount}</S.Td>
@@ -47,7 +47,7 @@ export default function PassionUserRanking({ rankerList, userRanking }: PassionU
         })}
         {userRanking && (
           <S.Tr>
-            <S.Td>{userRanking.rank}</S.Td>
+            <S.Td>{userRanking.ranking}</S.Td>
             <S.Td>{userRanking.nickname}</S.Td>
             <S.Td>{userRanking.postCount}</S.Td>
             <S.Td>{userRanking.voteCount}</S.Td>

--- a/frontend/src/pages/Ranking/PassionUser/style.ts
+++ b/frontend/src/pages/Ranking/PassionUser/style.ts
@@ -39,3 +39,12 @@ export const RankingTd = styled.td`
 export const Td = styled.td`
   padding: 10px 0;
 `;
+
+export const LoadingSpinnerWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  height: 50px;
+  padding: 0;
+`;

--- a/frontend/src/pages/Ranking/PopularPost/PopularPost.stories.tsx
+++ b/frontend/src/pages/Ranking/PopularPost/PopularPost.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { RankingPost } from '@type/ranking';
-
 import PopularPost from '.';
 
 const meta: Meta<typeof PopularPost> = {
@@ -11,19 +9,6 @@ const meta: Meta<typeof PopularPost> = {
 export default meta;
 type Story = StoryObj<typeof PopularPost>;
 
-const rankingPostInfo: RankingPost = {
-  ranking: 1,
-  post: {
-    id: 29,
-    writer: 'writer',
-    title: '이것은 엄청나게 많은 투표가 이루어진 대단한 글이지요',
-    voteCount: 10,
-  },
-};
-const rankingPostList: RankingPost[] = new Array(10)
-  .fill(rankingPostInfo)
-  .map((post, index) => ({ ...post, ranking: index + 1 }));
-
 export const Default: Story = {
-  render: () => <PopularPost rankingPostList={rankingPostList} />,
+  render: () => <PopularPost />,
 };

--- a/frontend/src/pages/Ranking/PopularPost/PopularPost.stories.tsx
+++ b/frontend/src/pages/Ranking/PopularPost/PopularPost.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 type Story = StoryObj<typeof PopularPost>;
 
 const rankingPostInfo: RankingPost = {
-  rank: 1,
+  ranking: 1,
   post: {
     id: 29,
     writer: 'writer',

--- a/frontend/src/pages/Ranking/PopularPost/index.tsx
+++ b/frontend/src/pages/Ranking/PopularPost/index.tsx
@@ -1,14 +1,12 @@
 import { Link } from 'react-router-dom';
 
-import { RankingPost } from '@type/ranking';
+import { usePopularPostRanking } from '@hooks/query/ranking/usePopularPostRanking';
 
 import { PATH } from '@constants/path';
 
 import firstRankIcon from '@assets/first-rank.svg';
 import secondRankIcon from '@assets/second-rank.svg';
 import thirdRankIcon from '@assets/third-rank.svg';
-
-import * as RS from '../RankingTableStyle';
 
 import * as S from './style';
 
@@ -20,20 +18,18 @@ const rankIconUrl: Record<number, string> = {
 
 const columnNameList = ['등수', '닉네임', '글 제목', '투표 수'];
 
-interface PopularPostProps {
-  rankingPostList: RankingPost[];
-}
+export default function PopularPost() {
+  const { data: rankingPostList } = usePopularPostRanking();
 
-export default function PopularPost({ rankingPostList }: PopularPostProps) {
   return (
-    <RS.Background>
-      <S.Table>
-        <S.Tr>
-          {columnNameList.map(text => (
-            <S.Th key={text}>{text}</S.Th>
-          ))}
-        </S.Tr>
-        {rankingPostList.map(rankingPost => {
+    <S.Table>
+      <S.Tr>
+        {columnNameList.map(text => (
+          <S.Th key={text}>{text}</S.Th>
+        ))}
+      </S.Tr>
+      {rankingPostList &&
+        rankingPostList.map(rankingPost => {
           const rankIcon = rankIconUrl[rankingPost.ranking] && (
             <img src={rankIconUrl[rankingPost.ranking]} alt={rankingPost.ranking.toString()} />
           );
@@ -49,7 +45,6 @@ export default function PopularPost({ rankingPostList }: PopularPostProps) {
             </S.Tr>
           );
         })}
-      </S.Table>
-    </RS.Background>
+    </S.Table>
   );
 }

--- a/frontend/src/pages/Ranking/PopularPost/index.tsx
+++ b/frontend/src/pages/Ranking/PopularPost/index.tsx
@@ -34,13 +34,13 @@ export default function PopularPost({ rankingPostList }: PopularPostProps) {
           ))}
         </S.Tr>
         {rankingPostList.map(rankingPost => {
-          const rankIcon = rankIconUrl[rankingPost.rank] && (
-            <img src={rankIconUrl[rankingPost.rank]} alt={rankingPost.rank.toString()} />
+          const rankIcon = rankIconUrl[rankingPost.ranking] && (
+            <img src={rankIconUrl[rankingPost.ranking]} alt={rankingPost.ranking.toString()} />
           );
 
           return (
-            <S.Tr key={rankingPost.rank}>
-              <S.RankingTd>{rankIcon ?? rankingPost.rank}</S.RankingTd>
+            <S.Tr key={rankingPost.ranking}>
+              <S.RankingTd>{rankIcon ?? rankingPost.ranking}</S.RankingTd>
               <S.Td>{rankingPost.post.writer}</S.Td>
               <S.Td>
                 <Link to={`${PATH.POST}/${rankingPost.post.id}`}>{rankingPost.post.title}</Link>

--- a/frontend/src/pages/Ranking/RankingTableStyle.ts
+++ b/frontend/src/pages/Ranking/RankingTableStyle.ts
@@ -3,7 +3,12 @@ import { styled } from 'styled-components';
 import { theme } from '@styles/theme';
 
 export const Background = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   height: fit-content;
+  min-height: 500px;
   border-radius: 4px;
 
   background-color: var(--gray);

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -14,7 +14,7 @@ import PopularPost from './PopularPost';
 import * as S from './style';
 
 const rankerInfo: PassionUser = {
-  rank: 1,
+  ranking: 1,
   nickname: 'gil-dong',
   postCount: 11,
   voteCount: 79,
@@ -22,7 +22,7 @@ const rankerInfo: PassionUser = {
 };
 
 const userRankingInfo: PassionUser = {
-  rank: 1111,
+  ranking: 1111,
   nickname: 'wow',
   postCount: 1,
   voteCount: 3,
@@ -34,7 +34,7 @@ const rankerList: PassionUser[] = new Array(10)
   .map((ranker, index) => ({ ...ranker, rank: index + 1 }));
 
 const rankingPostInfo: RankingPost = {
-  rank: 1,
+  ranking: 1,
   post: {
     id: 29,
     writer: 'writer',

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -31,7 +31,7 @@ const userRankingInfo: PassionUser = {
 
 const rankerList: PassionUser[] = new Array(10)
   .fill(rankerInfo)
-  .map((ranker, index) => ({ ...ranker, rank: index + 1 }));
+  .map((ranker, index) => ({ ...ranker, ranking: index + 1 }));
 
 const rankingPostInfo: RankingPost = {
   ranking: 1,

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -1,50 +1,20 @@
+import { Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-import { PassionUser, RankingPost } from '@type/ranking';
 
 import { useToggleSwitch } from '@hooks/useToggleSwitch';
 
+import ErrorBoundary from '@pages/ErrorBoundary';
+
 import IconButton from '@components/common/IconButton';
 import Layout from '@components/common/Layout';
+import LoadingSpinner from '@components/common/LoadingSpinner';
 import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
 import ToggleSwitch from '@components/common/ToggleSwitch';
 
 import PassionUserRanking from './PassionUser';
 import PopularPost from './PopularPost';
+import * as RS from './RankingTableStyle';
 import * as S from './style';
-
-const rankerInfo: PassionUser = {
-  ranking: 1,
-  nickname: 'gil-dong',
-  postCount: 11,
-  voteCount: 79,
-  score: 134,
-};
-
-const userRankingInfo: PassionUser = {
-  ranking: 1111,
-  nickname: 'wow',
-  postCount: 1,
-  voteCount: 3,
-  score: 8,
-};
-
-const rankerList: PassionUser[] = new Array(10)
-  .fill(rankerInfo)
-  .map((ranker, index) => ({ ...ranker, ranking: index + 1 }));
-
-const rankingPostInfo: RankingPost = {
-  ranking: 1,
-  post: {
-    id: 29,
-    writer: 'writer',
-    title: '이것은 엄청나게 많은 투표가 이루어진 대단한 글이지요',
-    voteCount: 10,
-  },
-};
-const rankingPostList: RankingPost[] = new Array(10)
-  .fill(rankingPostInfo)
-  .map((post, index) => ({ ...post, ranking: index + 1 }));
 
 export default function Ranking() {
   const navigate = useNavigate();
@@ -72,9 +42,23 @@ export default function Ranking() {
             secondButton={secondButton}
           />
           {selectedButton === '열정 유저' && (
-            <PassionUserRanking rankerList={rankerList} userRanking={userRankingInfo} />
+            <RS.Background>
+              <ErrorBoundary>
+                <Suspense fallback={<LoadingSpinner size="md" />}>
+                  <PassionUserRanking />
+                </Suspense>
+              </ErrorBoundary>
+            </RS.Background>
           )}
-          {selectedButton === '인기글 유저' && <PopularPost rankingPostList={rankingPostList} />}
+          {selectedButton === '인기글 유저' && (
+            <RS.Background>
+              <ErrorBoundary>
+                <Suspense fallback={<LoadingSpinner size="md" />}>
+                  <PopularPost />
+                </Suspense>
+              </ErrorBoundary>
+            </RS.Background>
+          )}
         </S.ContentContainer>
       </S.Container>
     </Layout>

--- a/frontend/src/types/ranking.ts
+++ b/frontend/src/types/ranking.ts
@@ -1,5 +1,5 @@
 export interface PassionUser {
-  rank: number;
+  ranking: number;
   nickname: string;
   postCount: number;
   voteCount: number;
@@ -7,7 +7,7 @@ export interface PassionUser {
 }
 
 export interface RankingPost {
-  rank: number;
+  ranking: number;
   post: {
     id: number;
     writer: string;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #521

## 📝 작업 요약
 - [x] 랭킹 UI와 hook 연결
 - [x] msw 도입
 - [x] (+변경된 랭킹 객체 타입 적용)
- [x]  서스펜스, 에러바운더리 도입
 - [x] 랭킹 유저/게시글이 없는 경우 UI

## ⏰ 소요 시간
1시간
: 연결할게 많을 줄 알았는데 기존 코드를 따라했더니 얼마 안걸리네요.

## 🔎 작업 상세 설명
- 기존 방식대로 서스펜스, 에러바운더리 적용했습니다.
- 이전 pr에서는 랭킹 페이지에서 api를 불러오는 것으로 생각했는데 막상 서스펜트, 에러바운더리를 적용하려고 하니까 불필요하게 내려받는 과정이 생기는 것 같아 랭킹 테이블(열정유저, 인기글)에서 바로 api를 받는 것으로 수정했습니다.
- 열정유저 테이블에서 사용자 랭킹은 따로 분리하여 서스펜스와 에러바운더리를 적용했습니다. 때문에 아래와 같이 처리됩니다. 이는 서스펜스도 동일합니다. 열정유저와 사용자 랭킹을 아예 분리하는 것도 고려하였으나 현재 css 코드로는 테이블의 12번째 행에 사용자랭킹 UI처리가 되어있어 처리하기 어려운 부분도 있고, 열정 랭킹 내에 사용자 (열정) 랭킹이 포함된다고 생각이 들어 아래처럼 처리했습니다. 의견 있으시면 말씀주세요!
    1. 열정유저 api는 성공하고 사용자 랭킹 api는 실패한다 > 사용자 랭킹 부분만 에러 바운더리 적용 
    2. 열정유저 api는 실패하고 사용자 랭킹 api는 성공한다 > 열정유저 랭킹 테이블 전체가 에러 바운더리 적용
- 기존 코드에 허점이 있었습니다..
    - 사용자랭킹 쿼리훅 이름이 수정되지 않아 열정랭킹 쿼리훅과 동일했습니다 > 수정완료
    - 열정유저 랭킹, 인기글 랭킹 type이 배열로 되어있지 않았습니다 > 수정완료
- 현재 msw 적용 완료입니다.

https://github.com/woowacourse-teams/2023-votogether/assets/113416448/9eb88a04-b977-4ef9-aa0b-4d9f584e7350

https://github.com/woowacourse-teams/2023-votogether/assets/113416448/2d6695b8-e0c7-423e-aa03-1fbd886e6adc



