### PR TITLE
앱 설치를 지원하지 않는 브라우저에서 안 나오는 것 수정 및 7일마다 물어보도록 수정하기 

### DIFF
--- a/frontend/src/components/common/AppInstallPrompt/index.tsx
+++ b/frontend/src/components/common/AppInstallPrompt/index.tsx
@@ -1,5 +1,7 @@
 import { Fragment, useEffect, useState } from 'react';
 
+import { getCookieToken, setCookie } from '@utils/cookie';
+
 import { BeforeInstallPromptEvent } from '../../../../window';
 
 import MobileInstallPrompt from './MobileInstallPrompt';
@@ -12,7 +14,7 @@ const defaultBeforeInstallPromptEvent: BeforeInstallPromptEvent = {
 };
 
 const isIOSPromptActive = () => {
-  const isActive = JSON.parse(localStorage.getItem('iosInstalled') || 'true');
+  const isActive = JSON.parse(getCookieToken().isAppInstallVisible || 'true');
 
   if (isActive) {
     return defaultBeforeInstallPromptEvent;
@@ -38,12 +40,16 @@ export default function AppInstallPrompt() {
   };
 
   const handleCancelClick = () => {
-    localStorage.setItem('iosInstalled', 'false');
+    setCookie({ key: 'isAppInstallVisible', value: 'false', maxAge: 7 * 24 * 60 * 60 });
     setDeferredPrompt(null);
   };
 
   const handleBeforeInstallPrompt = (event: BeforeInstallPromptEvent) => {
     event.preventDefault();
+    const isVisible = JSON.parse(getCookieToken().isAppInstallVisible || 'true');
+
+    if (!isVisible) return;
+
     setDeferredPrompt(event);
   };
 

--- a/frontend/src/utils/cookie/index.ts
+++ b/frontend/src/utils/cookie/index.ts
@@ -1,8 +1,22 @@
-type CookieKey = 'accessToken' | 'refreshToken' | 'hasEssentialInfo';
+type CookieKey = 'accessToken' | 'refreshToken' | 'hasEssentialInfo' | 'isAppInstallVisible';
 
 export const setCookieToken = (key: CookieKey, token: string | boolean) => {
   //secure 속성은 현재 dev에서는 http로 진행중이기 때문에 사용할 수 없음
   document.cookie = `${encodeURIComponent(key)}=${encodeURIComponent(token)}; path=/`;
+};
+
+export const setCookie = ({
+  key,
+  value,
+  maxAge,
+}: {
+  key: string;
+  value: string;
+  maxAge: number;
+}) => {
+  document.cookie = `${encodeURIComponent(key)}=${encodeURIComponent(
+    value
+  )}; max-age=${maxAge}; path=/`;
 };
 
 // token형식 = "key=value; key=value; key=value"

--- a/frontend/window.d.ts
+++ b/frontend/window.d.ts
@@ -1,9 +1,10 @@
-export interface BeforeInstallPromptEvent extends Event {
+export interface BeforeInstallPromptEvent {
   readonly platforms: string[];
   readonly userChoice: Promise<{
     outcome: 'accepted' | 'dismissed';
     platform: string;
   }>;
+  preventDefault(): void;
   prompt(): Promise<void>;
 }
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #520 

## 📝 작업 요약
- 앱 설치를 지원하지 않는 ios에서 직접 설치할 수 있다고 보여주는 설치창 보이도록 수정
- 닫기를 눌렀을 때 매번 홈 화면에서 계속해서 설치 권유 창이 나오는 것을 7일에 한번씩 보여주도록 수정

## ⏰ 소요 시간

30분

## 🔎 작업 상세 설명


### ios의 경우

- 사용자 화면에 보여줘야할지 담고있는 쿠키의 정보가 false라면 null값을 주어 보여주지 않음
- 사용자 화면에 보여줘야할지 담고있는 쿠키의 정보가 undefined라면 || 'true'의 로직으로 isActive가 활성화되어 사용자에게 보여줌

```tsx
const isIOSPromptActive = () => {
  const isActive = JSON.parse(getCookieToken().isAppInstallVisible || 'true');

  if (isActive) {
    return defaultBeforeInstallPromptEvent;
  }

  return null;
};
```

### 안드로이드의 경우

-  BeforeInstallPromptEvent를 지원하는 브라우저라면 자동으로 이벤트가 발생되는데 사용자가 닫기 버튼을 눌렀던 사람이라면 이벤트의 동작을 막고, 쿠키에 저장되어 있는 값이 없다면 이벤트를 발생시켰습니다.

```tsx
  const handleBeforeInstallPrompt = (event: BeforeInstallPromptEvent) => {
    event.preventDefault();
    const isVisible = JSON.parse(getCookieToken().isAppInstallVisible || 'true');

    if (!isVisible) return;

    setDeferredPrompt(event);
  };
```





## 🌟 논의 사항

현재 리프래시 토큰에서 setCookieToken 유효 기간이 설정 가능한 함수가 사용되고 있는데, 현재 브랜치에서는 적용되지 않은 상태라 임시로 사용할 setCookie를 사용하여 코드 충돌을 최소화했습니다 나중에 변경하려구요😀