### PR TITLE
닉네임 정책 사용자에게 14일마다 가능하다고 안내 메세지 변경

### DIFF
--- a/frontend/src/constants/policyMessage.ts
+++ b/frontend/src/constants/policyMessage.ts
@@ -1,8 +1,9 @@
 export const NICKNAME_POLICY = {
   LETTER_AMOUNT: '2자에서 15자 이내로 입력해주세요.',
   NO_DUPLICATION: '중복된 닉네임은 사용할 수 없습니다.',
-  LIMIT_CHANGING: '닉네임 변경은 1개월간 1번으로 제한됩니다.',
+  LIMIT_CHANGING: '닉네임 변경은 14일간 1회로 제한됩니다.',
   LIMIT_LETTER_TYPE: '한글/영어/숫자를 사용해 닉네임을 지어주세요.',
+  LIMIT_KOREAN: '한글은 완전한 단어만 가능합니다.',
 };
 
 export const POST_CATEGORY_POLICY = {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,7 +10,7 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 if (
-  (navigator.appName === 'Netscape' && navigator.userAgent.search('Trident') !== -1) ||
+  navigator.userAgent.search('Trident') !== -1 ||
   navigator.userAgent.toLowerCase().indexOf('msie') !== -1
 ) {
   alert('이 브라우저는 지원 중단 되었습니다. 최적의 환경을 위해 브라우저를 업데이트 하세요.');

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -106,7 +106,9 @@ export default function MyInfo() {
             <S.DescribeUl>
               <li>- {NICKNAME_POLICY.LETTER_AMOUNT}</li>
               <li>- {NICKNAME_POLICY.LIMIT_LETTER_TYPE}</li>
+              <li>- {NICKNAME_POLICY.LIMIT_CHANGING}</li>
               <li>- {NICKNAME_POLICY.NO_DUPLICATION}</li>
+              <li>- {NICKNAME_POLICY.LIMIT_KOREAN}</li>
             </S.DescribeUl>
             <S.InputWrapper>
               <S.Input


### PR DESCRIPTION
## 🔥 연관 이슈

close: #528 

## 📝 작업 요약

- 닉네임 정책 사용자에게 14일마다 가능하다고 안내 메세지 변경
- 닉네임 정책 온전한 한글만 닉네임 변경이 가능하다고 메세지 추가
- 권장되지 않는 코드 삭제 ( #484 )

## ⏰ 소요 시간

10분

<img width="660" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/5365e82e-07ec-4f8b-9cd4-9dac8810c184">

