### PR TITLE
네이버 소유권 확인용 meta 설정

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -43,6 +43,7 @@
     <meta property="og:site_name" content="VoTogether" />
     <meta property="og:locale" content="ko_KR" />
 
+    <meta name="naver-site-verification" content="8e4ae2052ca3d96eb412d12c2662dafba2f66883" />
     <title>VoTogether</title>
   </head>
   <body>


### PR DESCRIPTION
## 🔥 연관 이슈

close: #552 

## 📝 작업 요약

- 네이버에서 소유 확인을 할 때 필요한 head의 meta 등록

## ⏰ 소요 시간

10분

## 🔎 작업 상세 설명

### 네이버

<img width="1197" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/d1134a1c-a981-4561-9dff-de2aad5d3aa9">

### 구글

구글은 몇시간 기다려야 진행 가능할 것 같아요

<img width="910" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/07e7c5d2-15e1-44d8-8e71-3fade0c6313f">


## 논의 사항

1. SEO 설정했던 방법은 팀 블로그에 글 작성 후 공유하겠습니다
2. 해당 meta가 main으로 머지가 되어서 운영서버에서 meta가 있는지 네이버 측에서 확인을 한 후에 진행을 할 수 있습니다~
