### PR TITLE
랭킹 api 연결하기

### DIFF
--- a/frontend/src/api/ranking.ts
+++ b/frontend/src/api/ranking.ts
@@ -2,12 +2,12 @@ import { PassionUser, RankingPost } from '@type/ranking';
 
 import { getFetch } from '@utils/fetch';
 
-const BASE_URL = process.env.VOTOGETHER_MOCKING_URL;
+const BASE_URL = process.env.VOTOGETHER_BASE_URL;
 
 export const getUserRanking = async (isLoggedIn: boolean) => {
   if (!isLoggedIn) return null;
 
-  return await getFetch<PassionUser>(`${BASE_URL}/members/me/ranking`);
+  return await getFetch<PassionUser>(`${BASE_URL}/members/me/ranking/passion`);
 };
 
 export const getPassionUserRanking = async () => {

--- a/frontend/src/pages/Ranking/PassionUser/index.tsx
+++ b/frontend/src/pages/Ranking/PassionUser/index.tsx
@@ -32,7 +32,15 @@ export default function PassionUserRanking() {
         ))}
       </S.Tr>
       {rankerList &&
-        rankerList.map(ranker => {
+        new Array(10).fill(0).map((_, index) => {
+          const ranker = rankerList[index] ?? {
+            ranking: '',
+            nickname: '',
+            postCount: '',
+            voteCount: '',
+            score: '',
+          };
+
           const rankIcon = rankIconUrl[ranker.ranking] && (
             <img src={rankIconUrl[ranker.ranking]} alt={ranker.ranking.toString()} />
           );


### PR DESCRIPTION
## 🔥 연관 이슈

close: #573

## 📝 작업 요약
msw였던 것을 랭킹 api로 연결하기

## ⏰ 소요 시간
1시간
다른 브랜치 작업과 동시에 작업

## 🔎 작업 상세 설명
- msw였던 것을 랭킹 api로 연결하기
- 10명 이하 데이터가 불러와지는 경우 빈 행으로 처리

## 🌟 논의 사항
없습니다!
