### PR TITLE
cookie의 path를 /auth에서 /로 변경 및 RefreshToken TTL설정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/votogether/domain/auth/controller/AuthController.java
@@ -75,7 +75,7 @@ public class AuthController implements AuthControllerDocs {
         final ResponseCookie responseCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
                 .secure(true)
-                .path("/auth")
+                .path("/")
                 .maxAge(1209600)
                 .sameSite(SameSite.NONE.attributeValue())
                 .build();
@@ -94,7 +94,7 @@ public class AuthController implements AuthControllerDocs {
         final ResponseCookie responseCookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
                 .secure(true)
-                .path("/auth")
+                .path("/")
                 .maxAge(0)
                 .sameSite(SameSite.NONE.attributeValue())
                 .build();

--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import com.votogether.global.exception.BadRequestException;
 import com.votogether.global.jwt.TokenPayload;
 import com.votogether.global.jwt.TokenProcessor;
 import com.votogether.global.jwt.exception.JsonException;
+import java.time.Duration;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -58,7 +59,7 @@ public class AuthService {
 
         final String newAccessToken = tokenProcessor.generateAccessToken(accessTokenPayload.memberId());
         final String newRefreshToken = tokenProcessor.generateRefreshToken(accessTokenPayload.memberId());
-        redisTemplate.opsForValue().set(newRefreshToken, accessTokenPayload.memberId());
+        redisTemplate.opsForValue().set(newRefreshToken, accessTokenPayload.memberId(), Duration.ofDays(14L));
         return new ReissuedTokenDto(newAccessToken, newRefreshToken);
     }
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #608 

## 📝 작업 요약

- cookie에 path를 `/auth`에서 `/`로 변경했습니다.
- 레디스에서 RefreshToken의 TTL을 14일로 설정했습니다.

## ⏰ 소요 시간

1분

## 🔎 작업 상세 설명

`/auth`로 경로를 설정하게 되면 새로고침 시 쿠키가 삭제됩니다.
다른 경로에서 한번 받아오는 것은 되지만 그 이후에는 새로고침을 하면서 경로가 다르다고 판단하여 삭제하는 것 같아요.
`/`로 설정해야 새로고침을 해도 쿠키가 남아있습니다.

## 🌟 논의 사항

없음.
