### PR TITLE
게시글 작성 시 이미지 파일을 보낼 때 webp 로 압축하여 성능 개선

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.29.19",
+    "browser-image-compression": "^2.0.2",
     "dotenv": "^16.3.1",
     "msw": "^1.2.3",
     "react": "^18.2.0",

--- a/frontend/src/hooks/useContentImage.ts
+++ b/frontend/src/hooks/useContentImage.ts
@@ -2,6 +2,8 @@ import { ChangeEvent, useRef, useState } from 'react';
 
 import { MAX_FILE_SIZE } from '@components/PostForm/constants';
 
+import { convertImageToWebP } from '@utils/resizeImage';
+
 export const useContentImage = (imageUrl: string = '') => {
   const [contentImage, setContentImage] = useState(imageUrl);
   const contentInputRef = useRef<HTMLInputElement | null>(null);
@@ -11,12 +13,20 @@ export const useContentImage = (imageUrl: string = '') => {
     if (contentInputRef.current) contentInputRef.current.value = '';
   };
 
-  const handleUploadImage = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleUploadImage = async (event: ChangeEvent<HTMLInputElement>) => {
     const { files } = event.target;
 
     if (!files) return;
 
     const file = files[0];
+
+    const reader = new FileReader();
+
+    reader.readAsDataURL(file);
+
+    const webpFileList = await convertImageToWebP(file);
+
+    event.target.files = webpFileList;
 
     event.target.setCustomValidity('');
 
@@ -26,10 +36,6 @@ export const useContentImage = (imageUrl: string = '') => {
 
       return;
     }
-
-    const reader = new FileReader();
-
-    reader.readAsDataURL(file);
 
     reader.onloadend = () => {
       setContentImage(reader.result?.toString() ?? '');

--- a/frontend/src/hooks/useContentImage.ts
+++ b/frontend/src/hooks/useContentImage.ts
@@ -20,13 +20,15 @@ export const useContentImage = (imageUrl: string = '') => {
 
     const file = files[0];
 
-    const reader = new FileReader();
-
-    reader.readAsDataURL(file);
-
     const webpFileList = await convertImageToWebP(file);
 
     event.target.files = webpFileList;
+
+    const reader = new FileReader();
+
+    const webpFile = webpFileList[0];
+
+    reader.readAsDataURL(webpFile);
 
     event.target.setCustomValidity('');
 

--- a/frontend/src/hooks/useWritingOption.tsx
+++ b/frontend/src/hooks/useWritingOption.tsx
@@ -2,6 +2,8 @@ import React, { ChangeEvent, useState } from 'react';
 
 import { MAX_FILE_SIZE } from '@components/PostForm/constants';
 
+import { convertImageToWebP } from '@utils/resizeImage';
+
 const MAX_WRITING_LENGTH = 50;
 
 export interface WritingVoteOptionType {
@@ -78,12 +80,25 @@ export const useWritingOption = (initialOptionList: WritingVoteOptionType[] = IN
     setOptionList(updatedOptionList);
   };
 
-  const handleUploadImage = (event: React.ChangeEvent<HTMLInputElement>, optionId: number) => {
+  const handleUploadImage = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+    optionId: number
+  ) => {
     const { files } = event.target;
 
     if (!files) return;
 
     const file = files[0];
+
+    const webpFileList = await convertImageToWebP(file);
+
+    event.target.files = webpFileList;
+
+    const reader = new FileReader();
+
+    const webpFile = webpFileList[0];
+
+    reader.readAsDataURL(webpFile);
 
     event.target.setCustomValidity('');
 
@@ -93,11 +108,6 @@ export const useWritingOption = (initialOptionList: WritingVoteOptionType[] = IN
 
       return;
     }
-
-    const reader = new FileReader();
-
-    // readAsDataURL 메서드를 통해 파일을 모두 읽고 나면 reader의 loadend 이벤트에서 이미지 미리보기 결과를 확인할 수 있습니다.
-    reader.readAsDataURL(file);
 
     reader.onloadend = () => {
       const updatedOptionList = optionList.map(optionItem => {

--- a/frontend/src/utils/resizeImage.ts
+++ b/frontend/src/utils/resizeImage.ts
@@ -1,0 +1,17 @@
+import imageCompression from 'browser-image-compression';
+
+export const convertImageToWebP = async (imageFile: File) => {
+  const compressedBlob = await imageCompression(imageFile, {
+    maxWidthOrHeight: 1280,
+    initialQuality: 0.5,
+    fileType: 'image/webp',
+  });
+
+  const outputWebpFile = new File([compressedBlob], `${Date.now().toString()}.webp`);
+
+  const dataTransfer = new DataTransfer();
+
+  dataTransfer.items.add(outputWebpFile);
+
+  return dataTransfer.files;
+};


### PR DESCRIPTION
## 🔥 연관 이슈

close: #555 

## 📝 작업 요약

- 게시글 작성 시 이미지 파일을 보낼 때 webp 로 압축하여 성능 개선
- 게시글 본문 적용
- 게시글 옵션 적용

## ⏰ 소요 시간

- 2시간 (비슷한 내용의 패키지를 비교 분석하느라고 좀 늦어졌습니다)

## 🔎 작업 상세 설명

- 확장자는 webp로 바꾸고, 사이즈는 1280으로 고정시켰습니다. 

이미지 압축 패키지 비교

https://husky-dodo-c5e.notion.site/555902772db5412ba9089737c56a2302?pvs=4

## 🌟 논의 사항


