### PR TITLE
게시글 작성 시 이미지 복사 붙혀넣기로 이미지 첨부 가능하도록 구현

### DIFF
--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -67,6 +67,8 @@ export default function PostForm({ data, mutate }: PostFormProps) {
   const contentImageHook = useContentImage(
     serverImageUrl && convertImageUrlToServerUrl(serverImageUrl)
   );
+  const { handlePasteImage } = contentImageHook;
+
   const writingOptionHook = useWritingOption(
     serverVoteInfo?.options.map(option => ({
       ...option,
@@ -233,6 +235,7 @@ export default function PostForm({ data, mutate }: PostFormProps) {
               placeholder={CONTENT_PLACEHOLDER}
               maxLength={POST_CONTENT.MAX_LENGTH}
               minLength={POST_CONTENT.MIN_LENGTH}
+              onPaste={handlePasteImage}
               required
             />
             <S.ContentLinkButtonWrapper>

--- a/frontend/src/hooks/useContentImage.ts
+++ b/frontend/src/hooks/useContentImage.ts
@@ -6,7 +6,7 @@ export const useContentImage = (imageUrl: string = '') => {
   const [contentImage, setContentImage] = useState(imageUrl);
   const contentInputRef = useRef<HTMLInputElement | null>(null);
 
-  const handlePasteImage = async (event: ClipboardEvent<HTMLTextAreaElement>) => {
+  const handlePasteImage = (event: ClipboardEvent<HTMLTextAreaElement>) => {
     const file = event.clipboardData.files[0];
 
     if (file.type.slice(0, 5) === 'image') {
@@ -15,7 +15,7 @@ export const useContentImage = (imageUrl: string = '') => {
       uploadImage({
         imageFile: file,
         inputElement: contentInputRef.current,
-        setPreviewUrlFunc: setContentImage,
+        setPreviewImageUrl: setContentImage,
       });
     }
   };
@@ -35,7 +35,7 @@ export const useContentImage = (imageUrl: string = '') => {
     uploadImage({
       imageFile: file,
       inputElement: contentInputRef.current,
-      setPreviewUrlFunc: setContentImage,
+      setPreviewImageUrl: setContentImage,
     });
   };
 

--- a/frontend/src/hooks/useWritingOption.tsx
+++ b/frontend/src/hooks/useWritingOption.tsx
@@ -103,7 +103,7 @@ export const useWritingOption = (initialOptionList: WritingVoteOptionType[] = IN
     uploadImage({
       imageFile: file,
       inputElement: event.target,
-      setPreviewUrlFunc: setPreviewImageUrl(optionId),
+      setPreviewImageUrl: setPreviewImageUrl(optionId),
     });
   };
 

--- a/frontend/src/hooks/useWritingOption.tsx
+++ b/frontend/src/hooks/useWritingOption.tsx
@@ -1,8 +1,6 @@
 import React, { ChangeEvent, useState } from 'react';
 
-import { MAX_FILE_SIZE } from '@components/PostForm/constants';
-
-import { convertImageToWebP } from '@utils/resizeImage';
+import { uploadImage } from '@utils/post/uploadImage';
 
 const MAX_WRITING_LENGTH = 50;
 
@@ -80,6 +78,18 @@ export const useWritingOption = (initialOptionList: WritingVoteOptionType[] = IN
     setOptionList(updatedOptionList);
   };
 
+  const setPreviewImageUrl = (optionId: number) => (imageUrl: string) => {
+    const updatedOptionList = optionList.map(optionItem => {
+      if (optionItem.id === optionId) {
+        return { ...optionItem, imageUrl };
+      }
+
+      return optionItem;
+    });
+
+    setOptionList(updatedOptionList);
+  };
+
   const handleUploadImage = async (
     event: React.ChangeEvent<HTMLInputElement>,
     optionId: number
@@ -90,36 +100,11 @@ export const useWritingOption = (initialOptionList: WritingVoteOptionType[] = IN
 
     const file = files[0];
 
-    const webpFileList = await convertImageToWebP(file);
-
-    event.target.files = webpFileList;
-
-    const reader = new FileReader();
-
-    const webpFile = webpFileList[0];
-
-    reader.readAsDataURL(webpFile);
-
-    event.target.setCustomValidity('');
-
-    if (file.size > MAX_FILE_SIZE) {
-      event.target.setCustomValidity('사진의 용량은 1.5MB 이하만 가능합니다.');
-      event.target.reportValidity();
-
-      return;
-    }
-
-    reader.onloadend = () => {
-      const updatedOptionList = optionList.map(optionItem => {
-        if (optionItem.id === optionId) {
-          return { ...optionItem, imageUrl: reader.result?.toString() ?? '' };
-        }
-
-        return optionItem;
-      });
-
-      setOptionList(updatedOptionList);
-    };
+    uploadImage({
+      imageFile: file,
+      inputElement: event.target,
+      setPreviewUrlFunc: setPreviewImageUrl(optionId),
+    });
   };
 
   return { optionList, addOption, writingOption, deleteOption, removeImage, handleUploadImage };

--- a/frontend/src/utils/post/uploadImage.ts
+++ b/frontend/src/utils/post/uploadImage.ts
@@ -5,11 +5,11 @@ import { convertImageToWebP } from '@utils/resizeImage';
 export const uploadImage = async ({
   imageFile,
   inputElement,
-  setPreviewUrlFunc,
+  setPreviewImageUrl,
 }: {
   imageFile: File;
   inputElement: HTMLInputElement | null;
-  setPreviewUrlFunc: (previewUrl: string) => void;
+  setPreviewImageUrl: (previewUrl: string) => void;
 }) => {
   if (!inputElement) return;
 
@@ -33,6 +33,6 @@ export const uploadImage = async ({
   }
 
   reader.onloadend = () => {
-    setPreviewUrlFunc(reader.result?.toString() ?? '');
+    setPreviewImageUrl(reader.result?.toString() ?? '');
   };
 };

--- a/frontend/src/utils/post/uploadImage.ts
+++ b/frontend/src/utils/post/uploadImage.ts
@@ -1,0 +1,38 @@
+import { MAX_FILE_SIZE } from '@constants/post';
+
+import { convertImageToWebP } from '@utils/resizeImage';
+
+export const uploadImage = async ({
+  imageFile,
+  inputElement,
+  setPreviewUrlFunc,
+}: {
+  imageFile: File;
+  inputElement: HTMLInputElement | null;
+  setPreviewUrlFunc: (previewUrl: string) => void;
+}) => {
+  if (!inputElement) return;
+
+  const webpFileList = await convertImageToWebP(imageFile);
+
+  inputElement.files = webpFileList;
+
+  const reader = new FileReader();
+
+  const webpFile = webpFileList[0];
+
+  reader.readAsDataURL(webpFile);
+
+  inputElement.setCustomValidity('');
+
+  if (imageFile.size > MAX_FILE_SIZE) {
+    inputElement.setCustomValidity('사진의 용량은 1.5MB 이하만 가능합니다.');
+    inputElement.reportValidity();
+
+    return;
+  }
+
+  reader.onloadend = () => {
+    setPreviewUrlFunc(reader.result?.toString() ?? '');
+  };
+};


### PR DESCRIPTION
## 🔥 연관 이슈

close: #602 

## 📝 작업 요약

- 본문 이미지 복사 붙혀넣기로 동작되도록 구현
- 중복되는 코드 분리 후 useContentImage, useWritingOption에서 import하여 사용

## ⏰ 소요 시간

40분

## 🔎 작업 상세 설명

- onPaste 이벤트에서 file의 타입이 image라면 이미지 파일을 붙혀넣기한 것으로 판단하고 업로드 input에 파일을 넣어주도록 구현
- 선택지와 본문에서 이미지 업로드 하는 코드가 중복된다고 생각하여 분리하였음
- 붙혀넣기 기능은 선택지는 미적용, 본문만 적용하였습니다. 그 이유는 useWritingOption에서 업로드 버튼의 ref가 필요한데 수아의 PR이 머지된 후 진행하는 것이 깔끔하다고 생각했습니다


### 적용된 동영상

https://github.com/woowacourse-teams/2023-votogether/assets/80146176/00b41419-e3cd-4f68-a140-62e06268126b





## 🌟 논의 사항

크루들과 이야기 해보고 싶은 부분을 적어주세요.
