### PR TITLE
선택지가 왼쪽으로 움직이는 버그 수정

### DIFF
--- a/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/OptionUploadImageButton/style.ts
+++ b/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/OptionUploadImageButton/style.ts
@@ -6,6 +6,7 @@ export const Container = styled.div<{ $isVisible: boolean }>`
   width: 24px;
   height: 24px;
   border-radius: 50%;
+
   visibility: ${props => props.$isVisible && 'hidden'};
 `;
 
@@ -14,6 +15,9 @@ export const Label = styled.label`
 `;
 
 export const FileInput = styled.input`
+  position: absolute;
+  left: 0;
+
   visibility: hidden;
 `;
 

--- a/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/style.ts
+++ b/frontend/src/components/optionList/WritingVoteOptionList/WritingVoteOption/style.ts
@@ -5,6 +5,8 @@ import { theme } from '@styles/theme';
 export const Container = styled.li`
   display: flex;
   gap: 10px;
+
+  position: relative;
 `;
 
 export const OptionContainer = styled.div`


### PR DESCRIPTION
## 🔥 연관 이슈

close: #622 

## 📝 작업 요약

- 선택지가 왼쪽으로 움직이지 않도록 숨겨져있는 파일 인풋을 왼쪽으로 옮겨서 에러 메세지도 왼쪽에서 나타나도록 수정

## ⏰ 소요 시간

20분

## 🔎 작업 상세 설명

### 작은 모바일

https://github.com/woowacourse-teams/2023-votogether/assets/80146176/a9e7be17-f1be-40a3-941e-8a078b12c79e

### 큰 모바일

https://github.com/woowacourse-teams/2023-votogether/assets/80146176/dcd3947c-7f15-4e8a-80e4-7e6925dfae74


### PC


https://github.com/woowacourse-teams/2023-votogether/assets/80146176/a073ea21-f2ee-43e7-ac68-5bc5ef3be82a





## 🌟 논의 사항

참고자료

에러 메세지는 스타일링이 따로 안된다고 하네요~

https://stackoverflow.com/questions/67161694/html-default-validation-messages-styling