### PR TITLE
카테고리 즐겨찾기에 대한 낙관적 업데이트 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-query": "^4.29.19",
+        "browser-image-compression": "^2.0.2",
         "dotenv": "^16.3.1",
         "msw": "^1.2.3",
         "react": "^18.2.0",
@@ -9373,6 +9374,14 @@
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
     },
     "node_modules/browserify-zlib": {
       "version": "0.1.4",
@@ -22629,6 +22638,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -30123,6 +30137,14 @@
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
+    },
+    "browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "requires": {
+        "uzip": "0.20201231.0"
+      }
     },
     "browserify-zlib": {
       "version": "0.1.4",
@@ -39909,6 +39931,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
+    },
+    "uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/frontend/src/hooks/query/category/useCategoryFavoriteToggle.ts
+++ b/frontend/src/hooks/query/category/useCategoryFavoriteToggle.ts
@@ -8,15 +8,35 @@ import { QUERY_KEY } from '@constants/queryKey';
 
 export const useCategoryFavoriteToggle = () => {
   const queryClient = useQueryClient();
+  const LOGGED_IN = true;
+  const queryKey = [QUERY_KEY.CATEGORIES, LOGGED_IN];
+
   const { mutate, isLoading, isError, error } = useMutation(
     ({ id, isFavorite }: Omit<Category, 'name'>) =>
       isFavorite ? removeFavoriteCategory(id) : addFavoriteCategory(id),
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries([QUERY_KEY.CATEGORIES]);
+      onMutate: async ({ id }: Omit<Category, 'name'>) => {
+        const oldCategoryList: Category[] | undefined = queryClient.getQueryData(queryKey);
+
+        if (oldCategoryList) {
+          await queryClient.cancelQueries(queryKey);
+          const updatedCategoryList = oldCategoryList.map(item =>
+            item.id === id ? { ...item, isFavorite: !item.isFavorite } : item
+          );
+          queryClient.setQueryData(queryKey, updatedCategoryList);
+
+          return () => queryClient.setQueryData(queryKey, oldCategoryList);
+        }
       },
-      onError: error => {
+      onError: (error, _, rollback) => {
+        if (rollback) {
+          rollback();
+          return;
+        }
         window.console.log('Category favorite toggle error', error);
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries(queryKey);
       },
     }
   );


### PR DESCRIPTION
## 🔥 연관 이슈

close: #563 

## 📝 작업 요약
* 카테고리 즐겨찾기에 대한 낙관적 업데이트를 구현하였습니다.

## ⏰ 소요 시간
* 8시간 

## 🔎 작업 상세 설명
* fast 3g, slow 3g 환경에서도 UI 먼저 수정하도록 하되, 서버와의 통신에서 실패가 일어나면 이전 상태로 롤백하도록 하였습니다.

![votogether_category_optimistic](https://github.com/woowacourse-teams/2023-votogether/assets/81199414/5960042f-ad95-4246-8989-d2dc5e05d0af)

* 투표 수정에 대한 낙관적 업데이트 역시 시도했지만, 사용성 면에서 큰 의미가 없다고 판단하여 삭제하였습니다,,
(데일리에서 논의했듯, 선택지에서 `1명(100%)` 같은 정보는 서버 응답으로 제공하는 것입니다. 따라서 이런 수학적인 부분까지 낙관적 업데이트를 하고자 한다면, 이를 프론트가 미리 계산하기 위한 로직을 별도로 작성해야 합니다. 또한 `1명(100%)` 같은 정보를 제외하고, 그저 선택했는지 border 색깔만 바꿔서 보여준다면.. 결국 `1명(100%)` 정보는 나중에 볼 수 있으므로, 사용성 면에서 당황스럽고 불편할 수 있다고 생각합니다. 
이러한 이유로 투표 선택지 수정에 대한 낙관적 업데이트는 진행하지 않았습니다😂)
![image](https://github.com/woowacourse-teams/2023-votogether/assets/81199414/b651f512-7f40-4fea-8335-7ded4f309bf7)

## 🌟 논의 사항
* 데일리에서 논의함.
