### PR TITLE
게시글 리스트에서 CSS 다르게 보이는 문제 해결

### DIFF
--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
 
 import { AuthContext } from '@hooks/context/auth';
 import { PostOptionContext } from '@hooks/context/postOption';
@@ -92,7 +91,7 @@ export default function PostList() {
           />
         </S.SelectWrapper>
       </S.SelectContainer>
-      <Link aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE}></Link>
+      <S.HiddenLink aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE} />
       <S.PostListContainer>
         {isPostListEmpty && (
           <EmptyPostList status={selectedStatusOption} keyword={postOptionalOption.keyword} />
@@ -107,10 +106,17 @@ export default function PostList() {
                   </div>
                 );
               }
+
               return <Post key={post.postId} isPreview={true} postInfo={post} />;
             })}
-            <button onClick={focusTopContent} aria-label="스크롤 맨 위로가기"></button>
-            <Link aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE}></Link>
+            <S.HiddenButton
+              onClick={focusTopContent}
+              aria-label="스크롤 맨 위로가기"
+            ></S.HiddenButton>
+            <S.HiddenLink
+              aria-label="게시글 작성 페이지로 이동"
+              to={PATH.POST_WRITE}
+            ></S.HiddenLink>
           </React.Fragment>
         ))}
         {isFetchingNextPage && <Skeleton isLarge={false} />}

--- a/frontend/src/components/post/PostList/style.ts
+++ b/frontend/src/components/post/PostList/style.ts
@@ -30,6 +30,11 @@ export const PostListContainer = styled.ul`
 
   padding: 30px 20px;
 
+  > div > li {
+    padding-bottom: 30px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
   > li {
     padding-bottom: 30px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);

--- a/frontend/src/components/post/PostList/style.ts
+++ b/frontend/src/components/post/PostList/style.ts
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 import { styled } from 'styled-components';
 
 import { theme } from '@styles/theme';
@@ -45,4 +47,12 @@ export const SelectWrapper = styled.div`
   &:last-child {
     right: 20px;
   }
+`;
+
+export const HiddenButton = styled.button`
+  position: absolute;
+`;
+
+export const HiddenLink = styled(Link)`
+  position: absolute;
 `;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #639 
close: #640 

## 📝 작업 요약

- [무한스크롤 시 10번째 게시글 공백이 다른 문제 수정](https://github.com/woowacourse-teams/2023-votogether/commit/28b9061f0e44c993e7dd798617a8511d6a87d035)
- [무한 스크롤 시 일부 게시글의 border이 없던 문제 해결](https://github.com/woowacourse-teams/2023-votogether/commit/9347ecd8347dca3ae933c59fcce7f932cfb805fd)



## ⏰ 소요 시간

30분

## 🔎 작업 상세 설명

CSS 속성을 통해 해당 문제들을 해결했습니다
