### PR TITLE
배너에서 이벤트 링크로 가능 문구 수정  

### DIFF
--- a/frontend/src/components/common/Banner/index.tsx
+++ b/frontend/src/components/common/Banner/index.tsx
@@ -17,7 +17,7 @@ export default function Banner({ title, content, handleClose, path }: BannerProp
         <S.Description aria-label="배너 내용">{content}</S.Description>
       </S.Content>
       <S.MovePageLink to={path} aria-label="세부 페이지로 이동">
-        자세히
+        보러가기
       </S.MovePageLink>
     </S.Wrapper>
   );


### PR DESCRIPTION
## 🔥 연관 이슈

close: #643 

## 📝 작업 요약

- 배너로 가는 링크의 문구를 "자세히" 에서 "보러가기"로 수정

## ⏰ 소요 시간

5분

## 🔎 작업 상세 설명

<img width="1237" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/041fe2db-a7cd-4485-af2e-c5817b842248">

