### PR TITLE
[BUG] 게시글 이미지 저장이 되지 않는 문제

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/controller/PostGuestController.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostGuestController.java
@@ -1,5 +1,6 @@
 package com.votogether.domain.post.controller;
 
+import com.votogether.domain.post.dto.response.post.PostRankingResponse;
 import com.votogether.domain.post.dto.response.post.PostResponse;
 import com.votogether.domain.post.entity.vo.PostClosingType;
 import com.votogether.domain.post.entity.vo.PostSortType;
@@ -51,6 +52,12 @@ public class PostGuestController implements PostGuestControllerDocs {
             @RequestParam final PostSortType postSortType
     ) {
         final List<PostResponse> responses = postGuestService.searchPosts(keyword, page, postClosingType, postSortType);
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("ranking/popular/guest")
+    public ResponseEntity<List<PostRankingResponse>> getRanking() {
+        final List<PostRankingResponse> responses = postGuestService.getRanking();
         return ResponseEntity.ok(responses);
     }
 

--- a/backend/src/main/java/com/votogether/domain/post/controller/PostGuestControllerDocs.java
+++ b/backend/src/main/java/com/votogether/domain/post/controller/PostGuestControllerDocs.java
@@ -1,5 +1,6 @@
 package com.votogether.domain.post.controller;
 
+import com.votogether.domain.post.dto.response.post.PostRankingResponse;
 import com.votogether.domain.post.dto.response.post.PostResponse;
 import com.votogether.domain.post.entity.vo.PostClosingType;
 import com.votogether.domain.post.entity.vo.PostSortType;
@@ -84,5 +85,9 @@ public interface PostGuestControllerDocs {
             @Parameter(description = "게시글 마감 여부", example = "ALL") final PostClosingType postClosingType,
             @Parameter(description = "게시글 정렬 기준", example = "HOT") final PostSortType postSortType
     );
+
+    @Operation(summary = "인기 게시글 랭킹 조회", description = "인기 게시글 랭킹을 조회한다.")
+    @ApiResponse(responseCode = "200", description = "인기 게시글 랭킹 조회 성공")
+    ResponseEntity<List<PostRankingResponse>> getRanking();
 
 }

--- a/backend/src/main/java/com/votogether/domain/post/dto/request/post/PostOptionCreateRequest.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/request/post/PostOptionCreateRequest.java
@@ -21,6 +21,6 @@ public class PostOptionCreateRequest {
     private String content;
 
     @Schema(description = "게시글 옵션 이미지 파일", example = "votogether.png")
-    private MultipartFile optionImage;
+    private MultipartFile imageFile;
 
 }

--- a/backend/src/main/java/com/votogether/domain/post/dto/response/post/PostOptionVoteResultResponse.java
+++ b/backend/src/main/java/com/votogether/domain/post/dto/response/post/PostOptionVoteResultResponse.java
@@ -66,7 +66,8 @@ public record PostOptionVoteResultResponse(
         if (voteCount == HIDDEN_COUNT || totalCount == 0) {
             return 0.0;
         }
-        return ((double) voteCount / totalCount);
+        final double votePercent = ((double) voteCount / totalCount) * 100;
+        return Math.round(votePercent * 10) / 10.0;
     }
 
     public static PostOptionVoteResultResponse ofGuest(

--- a/backend/src/main/java/com/votogether/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/Post.java
@@ -205,4 +205,10 @@ public class Post extends BaseEntity {
         return postContentImages.get(0);
     }
 
+    public long getTotalVoteCount() {
+        return postOptions.stream()
+                .mapToLong(PostOption::getVoteCount)
+                .sum();
+    }
+
 }

--- a/backend/src/main/java/com/votogether/domain/post/service/PostCommandService.java
+++ b/backend/src/main/java/com/votogether/domain/post/service/PostCommandService.java
@@ -83,7 +83,7 @@ public class PostCommandService {
     }
 
     private PostOption createPostOptionFromRequest(int sequence, final PostOptionCreateRequest postOptionCreate) {
-        final String imageUrl = imageUploader.upload(postOptionCreate.getOptionImage());
+        final String imageUrl = imageUploader.upload(postOptionCreate.getImageFile());
         return PostOption.builder()
                 .sequence(sequence)
                 .content(postOptionCreate.getContent())

--- a/backend/src/main/java/com/votogether/infra/image/ImageName.java
+++ b/backend/src/main/java/com/votogether/infra/image/ImageName.java
@@ -12,7 +12,7 @@ public class ImageName {
 
     private static final String DOT = ".";
     private static final String UNDER_BAR = "_";
-    private static final Set<String> IMAGE_EXTENSIONS = Set.of("jpeg", "jpg", "png", "webp");
+    private static final Set<String> IMAGE_EXTENSIONS = Set.of("jpeg", "jpg", "png", "webp", "heic", "heif");
 
     public static String from(final String originalFilename) {
         final String extension = StringUtils.getFilenameExtension(originalFilename);

--- a/backend/src/main/java/com/votogether/infra/image/LocalUploader.java
+++ b/backend/src/main/java/com/votogether/infra/image/LocalUploader.java
@@ -1,11 +1,8 @@
 package com.votogether.infra.image;
 
 import com.votogether.global.exception.ImageException;
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import javax.imageio.ImageIO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,7 +27,7 @@ public class LocalUploader implements ImageUploader {
     public String upload(final MultipartFile image) {
         final File directory = loadDirectory(getImageStorePath());
 
-        if (isEmptyFileOrNotImage(image)) {
+        if (isEmptyImage(image)) {
             return null;
         }
         final String saveFileName = ImageName.from(image.getOriginalFilename());
@@ -51,16 +48,8 @@ public class LocalUploader implements ImageUploader {
         return directory;
     }
 
-    private boolean isEmptyFileOrNotImage(final MultipartFile multipartFile) {
-        return multipartFile == null || multipartFile.isEmpty() || isNotImageFile(multipartFile);
-    }
-
-    private boolean isNotImageFile(final MultipartFile file) {
-        try (InputStream originalInputStream = new BufferedInputStream(file.getInputStream())) {
-            return ImageIO.read(originalInputStream) == null;
-        } catch (IOException e) {
-            throw new ImageException(ImageExceptionType.INVALID_IMAGE_READ);
-        }
+    private boolean isEmptyImage(final MultipartFile multipartFile) {
+        return multipartFile == null || multipartFile.isEmpty();
     }
 
     private void transferFile(final MultipartFile file, final File uploadPath) {

--- a/backend/src/test/java/com/votogether/domain/post/service/PostGuestServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/service/PostGuestServiceTest.java
@@ -58,7 +58,7 @@ class PostGuestServiceTest extends ServiceTest {
             List<PostResponse> result = postGuestService.getPosts(0, PostClosingType.ALL, PostSortType.LATEST, null);
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
         }
 
@@ -105,7 +105,7 @@ class PostGuestServiceTest extends ServiceTest {
             PostResponse result = postGuestService.getPost(post.getId());
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
         }
 
@@ -178,7 +178,7 @@ class PostGuestServiceTest extends ServiceTest {
                     postGuestService.searchPosts(post.getTitle(), 0, PostClosingType.ALL, PostSortType.LATEST);
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
         }
 

--- a/backend/src/test/java/com/votogether/domain/post/service/PostQueryServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/post/service/PostQueryServiceTest.java
@@ -77,7 +77,7 @@ class PostQueryServiceTest extends ServiceTest {
                     postQueryService.getPosts(0, PostClosingType.ALL, PostSortType.LATEST, null, member);
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
         }
 
@@ -99,7 +99,7 @@ class PostQueryServiceTest extends ServiceTest {
                     postQueryService.getPosts(0, PostClosingType.ALL, PostSortType.LATEST, null, member);
 
             // then
-            PostResponse expected = expectedResponse(post, member, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, member, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
         }
 
@@ -122,7 +122,7 @@ class PostQueryServiceTest extends ServiceTest {
                     postQueryService.getPosts(0, PostClosingType.ALL, PostSortType.LATEST, null, member);
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, postOption.getId(), 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, postOption.getId(), 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
         }
 
@@ -195,7 +195,7 @@ class PostQueryServiceTest extends ServiceTest {
             PostResponse result = postQueryService.getPost(post.getId(), member);
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
         }
 
@@ -216,7 +216,7 @@ class PostQueryServiceTest extends ServiceTest {
             PostResponse result = postQueryService.getPost(post.getId(), member);
 
             // then
-            PostResponse expected = expectedResponse(post, member, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, member, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
         }
 
@@ -238,7 +238,7 @@ class PostQueryServiceTest extends ServiceTest {
             PostResponse result = postQueryService.getPost(post.getId(), member);
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, postOption.getId(), 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, postOption.getId(), 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
         }
 
@@ -287,7 +287,7 @@ class PostQueryServiceTest extends ServiceTest {
                     postQueryService.searchPosts(post.getTitle(), 0, PostClosingType.ALL, PostSortType.LATEST, member);
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
         }
 
@@ -309,7 +309,7 @@ class PostQueryServiceTest extends ServiceTest {
                     postQueryService.searchPosts(post.getTitle(), 0, PostClosingType.ALL, PostSortType.LATEST, member);
 
             // then
-            PostResponse expected = expectedResponse(post, member, postOption, 0L, 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, member, postOption, 0L, 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
         }
 
@@ -332,7 +332,7 @@ class PostQueryServiceTest extends ServiceTest {
                     postQueryService.searchPosts(post.getTitle(), 0, PostClosingType.ALL, PostSortType.LATEST, member);
 
             // then
-            PostResponse expected = expectedResponse(post, writer, postOption, postOption.getId(), 1, 1, 1.0);
+            PostResponse expected = expectedResponse(post, writer, postOption, postOption.getId(), 1, 1, 100.0);
             assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expected));
         }
 
@@ -363,8 +363,8 @@ class PostQueryServiceTest extends ServiceTest {
                 postQueryService.getPostsWrittenByMe(0, PostClosingType.ALL, PostSortType.LATEST, member);
 
         // then
-        PostResponse expectedA = expectedResponse(postA, member, postOptionA, 0L, 1, 1, 1.0);
-        PostResponse expectedB = expectedResponse(postB, member, postOptionB, 0L, 1, 1, 1.0);
+        PostResponse expectedA = expectedResponse(postA, member, postOptionA, 0L, 1, 1, 100.0);
+        PostResponse expectedB = expectedResponse(postB, member, postOptionB, 0L, 1, 1, 100.0);
         assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expectedB, expectedA));
     }
 
@@ -394,8 +394,8 @@ class PostQueryServiceTest extends ServiceTest {
                 postQueryService.getPostsVotedByMe(0, PostClosingType.ALL, PostSortType.LATEST, member);
 
         // then
-        PostResponse expectedA = expectedResponse(postA, writer, postOptionA, postOptionA.getId(), 1, 1, 1.0);
-        PostResponse expectedB = expectedResponse(postB, writer, postOptionB, postOptionB.getId(), 1, 1, 1.0);
+        PostResponse expectedA = expectedResponse(postA, writer, postOptionA, postOptionA.getId(), 1, 1, 100.0);
+        PostResponse expectedB = expectedResponse(postB, writer, postOptionB, postOptionB.getId(), 1, 1, 100.0);
         assertThat(result).usingRecursiveComparison().isEqualTo(List.of(expectedB, expectedA));
     }
 

--- a/backend/src/test/java/com/votogether/infra/image/LocalUploaderTest.java
+++ b/backend/src/test/java/com/votogether/infra/image/LocalUploaderTest.java
@@ -1,6 +1,7 @@
 package com.votogether.infra.image;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.votogether.global.exception.ImageException;
 import com.votogether.test.ServiceTest;
@@ -98,21 +99,20 @@ class LocalUploaderTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("이미지 파일이 아니라면 null 이미지 경로를 반환한다.")
+        @DisplayName("이미지 파일이 아니라면 예외를 던진다.")
         void invalidImage() {
             // given
             MultipartFile multipartFile = new MockMultipartFile(
                     "images",
-                    "votogether.png",
+                    "votogether.txt",
                     MediaType.TEXT_PLAIN_VALUE,
                     "hello".getBytes()
             );
 
-            // when
-            String imagePath = localUploader.upload(multipartFile);
-
-            // then
-            assertThat(imagePath).isNull();
+            // when, then
+            assertThatThrownBy(() -> localUploader.upload(multipartFile))
+                    .isInstanceOf(ImageException.class)
+                    .hasMessage("이미지 파일만 업로드할 수 있습니다.");
         }
 
     }


### PR DESCRIPTION
## 🔥 연관 이슈

* close: #642

## 📝 작업 요약

게시글 이미지 저장 버그를 수정하였습니다.

## ⏰ 소요 시간

10분

## 🔎 작업 상세 설명

1. 게시글 이미지 저장 버그를 수정하였습니다.
2. 사라졌던 인기 게시글 랭킹 조회 API 복원했습니다.

## 🌟 논의 사항

컨플릭트 해결 힘들어요 :(