### PR TITLE
채널톡이 앱설치 프롬프트와 랭킹 페이지의 내랭킹을 가리는 버그 수정

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22436,7 +22436,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24003,8 +24003,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.18.6",
@@ -25098,8 +25097,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
       "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@esbuild/android-arm": {
       "version": "0.17.19",
@@ -26199,8 +26197,7 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "find-up": {
           "version": "5.0.0",
@@ -26695,8 +26692,7 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -28137,8 +28133,7 @@
       "version": "7.0.26",
       "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-7.0.26.tgz",
       "integrity": "sha512-heobG4IovYAD9fo7qmUHylCSQjDd1eXDCOaTiy+XVKobHAJgkz1gKqbaFSP6KLkPE4cKyScku2K9mY0tcKIhMw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@storybook/react-webpack5": {
       "version": "7.0.26",
@@ -29458,22 +29453,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
       "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
       "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/serve": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
       "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xmldom/xmldom": {
       "version": "0.8.9",
@@ -29551,15 +29543,13 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -29864,8 +29854,7 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-jest": {
       "version": "29.6.0",
@@ -32235,8 +32224,7 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
       "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -32443,8 +32431,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-storybook": {
       "version": "0.6.12",
@@ -33024,8 +33011,7 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -33787,8 +33773,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -35420,8 +35405,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -36853,8 +36837,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.2.1.tgz",
       "integrity": "sha512-9HrdzBAo0+sFz9ZYAGT5fB8ilzTW+q6lPocRxrIesMO+aB40V9MgFfbfMXxlGjf22OpRy+IXlvVaQenicdpgbg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "mdast-util-definitions": {
       "version": "4.0.0",
@@ -37789,8 +37772,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -38152,8 +38134,7 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-docgen": {
       "version": "5.4.3",
@@ -38188,8 +38169,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
       "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-dom": {
       "version": "18.2.0",
@@ -38234,8 +38214,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.2.tgz",
       "integrity": "sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-is": {
       "version": "16.13.1",
@@ -39270,8 +39249,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.3.tgz",
       "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "styled-components": {
       "version": "6.0.2",
@@ -39545,8 +39523,7 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -39888,7 +39865,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "devOptional": true
+      "dev": true
     },
     "uglify-js": {
       "version": "3.17.4",
@@ -40050,8 +40027,7 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "requires": {}
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
     },
     "util": {
       "version": "0.12.5",
@@ -40227,8 +40203,7 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -40531,8 +40506,7 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/frontend/src/components/ChannelTalk/index.tsx
+++ b/frontend/src/components/ChannelTalk/index.tsx
@@ -79,6 +79,7 @@ class ChannelTalk {
   loadScript() {
     (function () {
       let w = window;
+      if (w.ChannelIO) return;
       let ch: IChannelIO = function () {
         ch.c?.(arguments);
       };

--- a/frontend/src/components/ChannelTalk/index.tsx
+++ b/frontend/src/components/ChannelTalk/index.tsx
@@ -79,9 +79,6 @@ class ChannelTalk {
   loadScript() {
     (function () {
       let w = window;
-      if (w.ChannelIO) {
-        return w.console.error('ChannelIO script included twice.');
-      }
       let ch: IChannelIO = function () {
         ch.c?.(arguments);
       };

--- a/frontend/src/components/common/AppInstallPrompt/BookMarkPrompt/style.ts
+++ b/frontend/src/components/common/AppInstallPrompt/BookMarkPrompt/style.ts
@@ -18,6 +18,14 @@ export const Container = styled.div`
   background-color: white;
 
   z-index: ${theme.zIndex.modal};
+
+  @media (max-width: 375px) {
+    margin-top: 30px;
+  }
+
+  @media (max-width: 375px) and (min-width: 280px) {
+    margin-top: 0;
+  }
 `;
 
 export const Content = styled.div`
@@ -34,6 +42,10 @@ export const Header = styled.div`
   justify-content: space-between;
 
   margin-bottom: 50px;
+
+  @media (max-width: 376px) {
+    margin-bottom: 20px;
+  }
 `;
 
 export const LogoImage = styled.img`
@@ -41,6 +53,11 @@ export const LogoImage = styled.img`
 
   width: 80px;
   height: 80px;
+
+  @media (max-width: 375px) and (min-width: 280px) {
+    width: 50px;
+    height: 50px;
+  }
 `;
 
 export const HeaderContent = styled.div`
@@ -66,6 +83,10 @@ export const Title = styled.span`
 export const Description = styled.p`
   font-size: 1.6rem;
   font-weight: 700;
+
+  @media (max-width: 376px) and (min-width: 280px) {
+    font-size: 1.4rem;
+  }
 `;
 
 export const CancelButton = styled.button`
@@ -81,6 +102,11 @@ export const CancelButton = styled.button`
 export const IconImage = styled.img`
   width: 24px;
   height: 24px;
+
+  @media (max-width: 375px) and (min-width: 280px) {
+    width: 18px;
+    height: 18px;
+  }
 `;
 
 export const DescriptionWrapper = styled.div`

--- a/frontend/src/components/common/AppInstallPrompt/BookMarkPrompt/style.ts
+++ b/frontend/src/components/common/AppInstallPrompt/BookMarkPrompt/style.ts
@@ -84,7 +84,7 @@ export const Description = styled.p`
   font-size: 1.6rem;
   font-weight: 700;
 
-  @media (max-width: 376px) and (min-width: 280px) {
+  @media (max-width: 375px) and (min-width: 280px) {
     font-size: 1.4rem;
   }
 `;

--- a/frontend/src/components/common/AppInstallPrompt/index.tsx
+++ b/frontend/src/components/common/AppInstallPrompt/index.tsx
@@ -1,5 +1,7 @@
 import { Fragment, useEffect, useState } from 'react';
 
+import ChannelTalk from '@components/ChannelTalk';
+
 import { getCookie, setCookie } from '@utils/cookie';
 
 import { BeforeInstallPromptEvent } from '../../../../window';
@@ -11,6 +13,8 @@ const isBookMarkPromptActive = () => {
   const isActive = JSON.parse(getCookie().isAppInstallVisible || 'true');
 
   if (isActive) {
+    ChannelTalk.hideChannelButton();
+
     return true;
   }
 
@@ -38,6 +42,8 @@ export default function AppInstallPrompt() {
     setCookie({ key: 'isAppInstallVisible', value: 'false', maxAge: 7 * 24 * 60 * 60 });
     setBookMarkPrompt(null);
     setDeferredPrompt(null);
+
+    ChannelTalk.showChannelButton();
   };
 
   const handleBeforeInstallPrompt = (event: BeforeInstallPromptEvent) => {

--- a/frontend/src/components/common/Layout/index.tsx
+++ b/frontend/src/components/common/Layout/index.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren } from 'react';
 
+import ChannelTalk from '@components/ChannelTalk';
 import Dashboard from '@components/common/Dashboard';
 import WideHeader from '@components/common/WideHeader';
 
@@ -7,9 +8,16 @@ import * as S from './style';
 
 interface LayoutProps extends PropsWithChildren {
   isSidebarVisible: boolean;
+  isChannelTalkVisible?: boolean;
 }
 
-export default function Layout({ children, isSidebarVisible }: LayoutProps) {
+export default function Layout({
+  children,
+  isSidebarVisible,
+  isChannelTalkVisible = true,
+}: LayoutProps) {
+  isChannelTalkVisible ? ChannelTalk.showChannelButton() : ChannelTalk.hideChannelButton();
+
   return (
     <S.Container>
       <S.WideHeaderWrapper>

--- a/frontend/src/components/common/Layout/index.tsx
+++ b/frontend/src/components/common/Layout/index.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 
 import ChannelTalk from '@components/ChannelTalk';
 import Dashboard from '@components/common/Dashboard';
@@ -16,7 +16,9 @@ export default function Layout({
   isSidebarVisible,
   isChannelTalkVisible = true,
 }: LayoutProps) {
-  isChannelTalkVisible ? ChannelTalk.showChannelButton() : ChannelTalk.hideChannelButton();
+  useEffect(() => {
+    isChannelTalkVisible ? ChannelTalk.showChannelButton() : ChannelTalk.hideChannelButton();
+  }, [isChannelTalkVisible]);
 
   return (
     <S.Container>

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -21,7 +21,7 @@ export default function Ranking() {
   const { selectedButton, firstButton, secondButton } = useToggleSwitch('열정 유저', '인기글 유저');
 
   return (
-    <Layout isSidebarVisible={true}>
+    <Layout isSidebarVisible={true} isChannelTalkVisible={false}>
       <S.HeaderWrapper>
         <NarrowTemplateHeader>
           <IconButton


### PR DESCRIPTION
## 🔥 연관 이슈

close: #595 
close: #609 

## 📝 작업 요약
* 앱설치 프롬프트 하단이 채널톡에 가려지는 버그를 수정함.
* 랭킹페이지의 내랭킹이 채널톡에 가려지는 버그를 수정함.

## ⏰ 소요 시간
* 2시간

## 🔎 작업 상세 설명
* 채널톡의 `hideChannelButton`, `showChannelButton` 이라는 함수들을 활용했습니다.
* 랭킹 페이지에서는 채널톡 버튼을 가렸습니다.
* 앱설치 프롬프트가 열려있는 경우 채널톡 버튼을 가리고, 프롬프트 창을 닫으면 채널톡 버튼이 보이게 했습니다.
* 앱설치 프롬프트가 Iphone SE와 Galaxy Fold 같은 너비가 작은 디바이스에서는 폰트 사이즈 등의 스타일을 조정하였습니다.
## 🌟 논의 사항
없음.
