### PR TITLE
useMemo/useCallback/React.memo를 사용하여 최적화하기

### DIFF
--- a/frontend/src/components/common/InputNSubmitButton/index.tsx
+++ b/frontend/src/components/common/InputNSubmitButton/index.tsx
@@ -1,0 +1,44 @@
+import React, { ChangeEvent } from 'react';
+
+import { useText } from '@hooks/useText';
+
+import SquareButton from '@components/common/SquareButton';
+
+import { TextLimit } from '@constants/user';
+
+import * as S from './style';
+
+interface InputNSubmitButtonProps {
+  handleSubmit: (newText: string) => void;
+  limitText: TextLimit;
+  initText?: string;
+  ariaLabel?: string;
+}
+
+export default function InputNSubmitButton({
+  handleSubmit,
+  limitText,
+  initText = '',
+  ariaLabel = '정보',
+}: InputNSubmitButtonProps) {
+  const { text, handleTextChange } = useText(initText);
+
+  return (
+    <S.InputWrapper>
+      <S.Input
+        value={text}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => handleTextChange(e, limitText)}
+        placeholder={`새로운 ${ariaLabel}을 입력해주세요`}
+      />
+      <S.ButtonWrapper>
+        <SquareButton
+          aria-label={`${ariaLabel} 변경`}
+          theme="fill"
+          onClick={() => handleSubmit(text)}
+        >
+          변경
+        </SquareButton>
+      </S.ButtonWrapper>
+    </S.InputWrapper>
+  );
+}

--- a/frontend/src/components/common/InputNSubmitButton/style.ts
+++ b/frontend/src/components/common/InputNSubmitButton/style.ts
@@ -1,0 +1,18 @@
+import { styled } from 'styled-components';
+
+export const InputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+export const Input = styled.input`
+  width: 80%;
+  border: 1px solid #f2f2f2;
+  padding: 20px;
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 90px;
+  height: 50px;
+`;

--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { memo, useContext, useEffect } from 'react';
 
 import { PostInfo } from '@type/post';
 
@@ -27,7 +27,7 @@ interface PostProps {
   isPreview: boolean;
 }
 
-export default function Post({ postInfo, isPreview }: PostProps) {
+export default memo(function Post({ postInfo, isPreview }: PostProps) {
   const {
     postId,
     category,
@@ -188,4 +188,4 @@ export default function Post({ postInfo, isPreview }: PostProps) {
       )}
     </S.Container>
   );
-}
+});

--- a/frontend/src/constants/user.ts
+++ b/frontend/src/constants/user.ts
@@ -1,9 +1,14 @@
-export const NICKNAME = {
+export interface TextLimit {
+  MAX_LENGTH: number;
+  MIN_LENGTH: number;
+}
+
+export const NICKNAME: TextLimit = {
   MAX_LENGTH: 15,
   MIN_LENGTH: 2,
 } as const;
 
-export const BIRTH_YEAR = {
+export const BIRTH_YEAR: TextLimit = {
   MAX_LENGTH: new Date().getFullYear(),
   MIN_LENGTH: 1900,
 } as const;

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -1,10 +1,9 @@
-import { useContext, ChangeEvent, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { AuthContext } from '@hooks/context/auth';
 import { useModifyUser } from '@hooks/query/user/useModifyUser';
 import { useWithdrawalMembership } from '@hooks/query/user/useWithdrawalMembership';
-import { useText } from '@hooks/useText';
 import { useToast } from '@hooks/useToast';
 import { useToggle } from '@hooks/useToggle';
 
@@ -19,6 +18,8 @@ import Toast from '@components/common/Toast';
 
 import { NICKNAME_POLICY } from '@constants/policyMessage';
 import { NICKNAME } from '@constants/user';
+
+import InputNSubmitButton from '../../components/common/InputNSubmitButton';
 
 import DeleteMemberModal from './DeleteMemberModal';
 import * as S from './style';
@@ -43,11 +44,8 @@ export default function MyInfo() {
 
   const { isOpen, openComponent, closeComponent } = useToggle();
   const { loggedInfo, clearLoggedInfo } = useContext(AuthContext);
-  const { text: newNickname, handleTextChange: handleNicknameChange } = useText(
-    loggedInfo.userInfo?.nickname ?? ''
-  );
 
-  const handleModifyNickname = () => {
+  const handleModifyNickname = (newNickname: string) => {
     modifyNickname(newNickname);
   };
 
@@ -111,18 +109,12 @@ export default function MyInfo() {
               <li>- {NICKNAME_POLICY.NO_DUPLICATION}</li>
               <li>- {NICKNAME_POLICY.LIMIT_KOREAN}</li>
             </S.DescribeUl>
-            <S.InputWrapper>
-              <S.Input
-                value={newNickname}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => handleNicknameChange(e, NICKNAME)}
-                placeholder="새로운 닉네임을 입력해주세요"
-              />
-              <S.ButtonWrapper>
-                <SquareButton aria-label="닉네임 변경" theme="fill" onClick={handleModifyNickname}>
-                  변경
-                </SquareButton>
-              </S.ButtonWrapper>
-            </S.InputWrapper>
+            <InputNSubmitButton
+              initText={loggedInfo.userInfo?.nickname}
+              handleSubmit={handleModifyNickname}
+              ariaLabel="닉네임"
+              limitText={NICKNAME}
+            />
           </Accordion>
           <Accordion title="회원 탈퇴">
             <S.ButtonWrapper>

--- a/frontend/src/pages/MyInfo/style.ts
+++ b/frontend/src/pages/MyInfo/style.ts
@@ -49,23 +49,6 @@ export const DescribeUl = styled.ul`
   margin: 0 0 20px 5px;
 `;
 
-export const InputWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 10px;
-`;
-
-export const Input = styled.input`
-  width: 80%;
-  border: 1px solid #f2f2f2;
-  padding: 20px;
-`;
-
-export const ButtonWrapper = styled.div`
-  width: 90px;
-  height: 50px;
-`;
-
 export const ModalBody = styled.div`
   display: flex;
   flex-direction: column;
@@ -94,5 +77,10 @@ export const ButtonListWrapper = styled.div`
   gap: 20px;
 
   width: 90%;
+  height: 50px;
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 90px;
   height: 50px;
 `;

--- a/frontend/src/pages/Ranking/PageContent/index.tsx
+++ b/frontend/src/pages/Ranking/PageContent/index.tsx
@@ -1,0 +1,45 @@
+import { Suspense } from 'react';
+
+import { useToggleSwitch } from '@hooks/useToggleSwitch';
+
+import ErrorBoundary from '@pages/ErrorBoundary';
+
+import LoadingSpinner from '@components/common/LoadingSpinner';
+import ToggleSwitch from '@components/common/ToggleSwitch';
+
+import PassionUserRanking from '../PassionUser';
+import PopularPost from '../PopularPost';
+import * as RS from '../RankingTableStyle';
+
+export default function PageContent() {
+  const { selectedButton, firstButton, secondButton } = useToggleSwitch('열정 유저', '인기글 유저');
+
+  return (
+    <>
+      <ToggleSwitch
+        size="md"
+        selectedButton={selectedButton}
+        firstButton={firstButton}
+        secondButton={secondButton}
+      />
+      {selectedButton === '열정 유저' && (
+        <RS.Background>
+          <ErrorBoundary>
+            <Suspense fallback={<LoadingSpinner size="md" />}>
+              <PassionUserRanking />
+            </Suspense>
+          </ErrorBoundary>
+        </RS.Background>
+      )}
+      {selectedButton === '인기글 유저' && (
+        <RS.Background>
+          <ErrorBoundary>
+            <Suspense fallback={<LoadingSpinner size="md" />}>
+              <PopularPost />
+            </Suspense>
+          </ErrorBoundary>
+        </RS.Background>
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Ranking/index.tsx
+++ b/frontend/src/pages/Ranking/index.tsx
@@ -1,24 +1,14 @@
-import { Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-import { useToggleSwitch } from '@hooks/useToggleSwitch';
-
-import ErrorBoundary from '@pages/ErrorBoundary';
 
 import IconButton from '@components/common/IconButton';
 import Layout from '@components/common/Layout';
-import LoadingSpinner from '@components/common/LoadingSpinner';
 import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
-import ToggleSwitch from '@components/common/ToggleSwitch';
 
-import PassionUserRanking from './PassionUser';
-import PopularPost from './PopularPost';
-import * as RS from './RankingTableStyle';
+import PageContent from './PageContent';
 import * as S from './style';
 
 export default function Ranking() {
   const navigate = useNavigate();
-  const { selectedButton, firstButton, secondButton } = useToggleSwitch('열정 유저', '인기글 유저');
 
   return (
     <Layout isSidebarVisible={true}>
@@ -35,30 +25,7 @@ export default function Ranking() {
       <S.Container>
         <S.PageHeader>🏆 랭킹 🏆</S.PageHeader>
         <S.ContentContainer>
-          <ToggleSwitch
-            size="md"
-            selectedButton={selectedButton}
-            firstButton={firstButton}
-            secondButton={secondButton}
-          />
-          {selectedButton === '열정 유저' && (
-            <RS.Background>
-              <ErrorBoundary>
-                <Suspense fallback={<LoadingSpinner size="md" />}>
-                  <PassionUserRanking />
-                </Suspense>
-              </ErrorBoundary>
-            </RS.Background>
-          )}
-          {selectedButton === '인기글 유저' && (
-            <RS.Background>
-              <ErrorBoundary>
-                <Suspense fallback={<LoadingSpinner size="md" />}>
-                  <PopularPost />
-                </Suspense>
-              </ErrorBoundary>
-            </RS.Background>
-          )}
+          <PageContent />
         </S.ContentContainer>
       </S.Container>
     </Layout>


### PR DESCRIPTION


## 🔥 연관 이슈

close: #650 

## 📝 작업 요약
React.memo를 이용해 새로운 게시글 불러올 때 기존 데이터 리렌더링 하지 않기 

## ⏰ 소요 시간
3시간
: 지료를 찾아본 시간이 길고, 상태를 확인하는 시간이 길었음

## 🔎 작업 상세 설명
1. 작업한 내용 
    -  새로운 게시글 불러올 때 기존 데이터 리렌더링 하지 않기
        - React.memo를 이용하여 post 컴포넌트를 감쌈

2. 작업하지 않은 내용 + 이유
    -  랭킹 페이지 토글 전환 시 레이아웃 리렌더링하지 않기
        - 페이지에서 상태를 가지고 있는데, 이를 분리하거나 라우터로 레이아웃을 옮겨야지만 리렌더링을 해결 할 수 있음
        - 분리한다면 불필요한 레이어가 하나 더 씌인다고 생각됨
        - 라우터로 레이아웃을 옮기면 다른 페이지와의 통일성이 없음. 그렇다고 모든 페이지의 레이아웃을 라우터로 옮기는 것도 과하다고 생각됨.
        - 리렌더링을 줄이는 것보다 코드변경에 드는 비용이 더 크다고 생각되어 수정하지 않음
    -  댓글 작성하는 경우 저장 버튼과 다른 댓글들 리렌더링 하지 않기
    -  닉네임 변경 input에서 changeEvent 발생시 input 제외하고 리렌더링 하지 않기
    -   게시글 작성 폼에서 input 작성 시 모든 폼 태그가 리렌더링되지 않게 하기
        - 위 세가지는 동일한 문제인데, 작성할 때 changeEvent로 제어하기 때문에 state가 변경되어 관련된 컴포넌트가 렌더링되는 문제점을 가지고 있음. 이를 해결하기 위해서는 비제어컴포넌트로 변경해야 함. 디바운스를 고려해보기도 하였으나 그러면 content가 사용자 눈에는 버벅이며 입력될 것으로 예상되어 기각함. 위와 마찬가지로 렌더링을 위해 제어를 비제어로 수정하는 것은 비효율적이라고 생각되어 수정하지 않음.
    - 게시글 목록에서 투표하는 경우 투표한 게시물만 리렌더링
        - 코드를 보다 제가 간과한 점을 깨닮. 투표를 하면 캐시를 무효화하고, 새로운 데이터를 가지고 옴. 때문에 이는 무조건 리렌더링이 일어날 수 밖에 없는 상황.


## 🌟 논의 사항
혹시 읽어보시고 더 할 수 있을 것 같은 개선점이나 더 좋은 방법이 있다면 말씀해주세요!
리렌더링이 일어나는것부터 확인하다보니  생각보다 시간이 오래 걸렸습니다ㅠ

현재 라우터를 제외하고 페이지 내 상호작용은 관련된 부분만 렌더링된다고 판단할 수 있는 수준이라 따로 기록/정리하지는 않았습니다.

## 📕 참고자료
- [리렌더링 최적화 7가지 방법](https://www.owl-dev.me/blog/49)