### PR TITLE
리프레시 토큰 중복된 요청 보내지 않도록 하기

### DIFF
--- a/frontend/src/utils/token/silentLogin.ts
+++ b/frontend/src/utils/token/silentLogin.ts
@@ -6,10 +6,14 @@ import { getLocalStorage, removeLocalStorage, setLocalStorage } from '../localSt
 
 import { isRefreshTokenRequested } from './isRefreshTokenRequested';
 
+let isRequest = false;
+
 export const silentLogin = async () => {
-  if (!isRefreshTokenRequested()) {
+  if (!isRefreshTokenRequested() || isRequest) {
     return;
   }
+
+  isRequest = true;
 
   try {
     const accessToken = getLocalStorage<string>(ACCESS_TOKEN_KEY);
@@ -23,8 +27,10 @@ export const silentLogin = async () => {
     setLocalStorage(ACCESS_TOKEN_KEY, updatedAccessToken);
   } catch (error) {
     removeLocalStorage(ACCESS_TOKEN_KEY);
-    window.location.href = '/login';
+    // window.location.href = '/login';
 
     throw new Error('로그인에 실패했습니다. 다시 로그인 해주세요.');
+  } finally {
+    isRequest = false;
   }
 };


### PR DESCRIPTION
로그인 페이지로 보내지 않게 설정하기, 에러 로그 보기 위해서

## 🔥 연관 이슈

close: #656 

## 📝 작업 요약

- 리프레시 토큰 중복된 요청 보내지 않도록 하기
- 네트워크 탭 확인을 위해 실패했을 때 로그인 페이지로 보내는 코드 주석 처리

## ⏰ 소요 시간

5분

