### PR TITLE
댓글 및 게시글에 대한 중복 Mutation 방지 처리, 가공된 에러 메시지를 Toast로 띄우도록 수정

### DIFF
--- a/frontend/src/components/PostForm/PostForm.stories.tsx
+++ b/frontend/src/components/PostForm/PostForm.stories.tsx
@@ -62,7 +62,7 @@ export const NewPost = () => {
   const { mutate } = useCreatePost();
   return (
     <>
-      <PostForm mutate={mutate} />
+      <PostForm mutate={mutate} isSubmitting={false} />
     </>
   );
 };
@@ -72,7 +72,7 @@ export const OldPost = () => {
   const { mutate } = useEditPost(examplePostId);
   return (
     <>
-      <PostForm data={MOCK_DATA} mutate={mutate} />
+      <PostForm data={MOCK_DATA} mutate={mutate} isSubmitting={false} />
     </>
   );
 };

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -47,9 +47,10 @@ import { checkValidationPost } from './validation';
 interface PostFormProps extends HTMLAttributes<HTMLFormElement> {
   data?: PostInfo;
   mutate: UseMutateFunction<any, unknown, FormData, unknown>;
+  isSubmitting: boolean;
 }
 
-export default function PostForm({ data, mutate }: PostFormProps) {
+export default function PostForm({ data, mutate, isSubmitting }: PostFormProps) {
   const {
     postId,
     title,
@@ -186,8 +187,8 @@ export default function PostForm({ data, mutate }: PostFormProps) {
       <S.HeaderWrapper>
         <NarrowTemplateHeader>
           <HeaderTextButton onClick={() => navigate('/')}>취소</HeaderTextButton>
-          <HeaderTextButton type="submit" form="form-post">
-            저장
+          <HeaderTextButton type="submit" form="form-post" disabled={isSubmitting}>
+            {isSubmitting ? '저장 중...' : '저장'}
           </HeaderTextButton>
         </NarrowTemplateHeader>
       </S.HeaderWrapper>
@@ -283,9 +284,10 @@ export default function PostForm({ data, mutate }: PostFormProps) {
             <S.SaveButtonWrapper>
               <SquareButton
                 aria-label="글쓰기가 저장됩니다. 저장이 완료되면 메인화면으로 이동됩니다."
-                theme="fill"
+                theme={isSubmitting ? 'gray' : 'fill'}
                 type="submit"
                 form="form-post"
+                disabled={isSubmitting}
               >
                 저장
               </SquareButton>

--- a/frontend/src/components/ReportModal/ReportModal.stories.tsx
+++ b/frontend/src/components/ReportModal/ReportModal.stories.tsx
@@ -11,18 +11,33 @@ type Story = StoryObj<typeof ReportModal>;
 
 export const Nickname: Story = {
   render: () => (
-    <ReportModal reportType="NICKNAME" handleCancelClick={() => {}} handleReportClick={() => {}} />
+    <ReportModal
+      reportType="NICKNAME"
+      handleCancelClick={() => {}}
+      handleReportClick={() => {}}
+      isReportLoading={false}
+    />
   ),
 };
 
 export const Comment: Story = {
   render: () => (
-    <ReportModal reportType="COMMENT" handleCancelClick={() => {}} handleReportClick={() => {}} />
+    <ReportModal
+      reportType="COMMENT"
+      handleCancelClick={() => {}}
+      handleReportClick={() => {}}
+      isReportLoading={false}
+    />
   ),
 };
 
 export const Post: Story = {
   render: () => (
-    <ReportModal reportType="POST" handleCancelClick={() => {}} handleReportClick={() => {}} />
+    <ReportModal
+      reportType="POST"
+      handleCancelClick={() => {}}
+      handleReportClick={() => {}}
+      isReportLoading={false}
+    />
   ),
 };

--- a/frontend/src/components/ReportModal/index.tsx
+++ b/frontend/src/components/ReportModal/index.tsx
@@ -11,19 +11,21 @@ interface UserReportModalProps {
   reportType: ReportType;
   handleCancelClick: () => void;
   handleReportClick: (reason: string) => void;
+  isReportLoading: boolean;
 }
 
 export default function ReportModal({
   reportType,
   handleCancelClick,
   handleReportClick,
+  isReportLoading,
 }: UserReportModalProps) {
   const { name, reportMessageList } = REPORT_TYPE[reportType];
   const defaultReportMessage = Object.keys(reportMessageList)[0];
   const { selectedOption, handleOptionChange } = useSelect(defaultReportMessage);
 
   const handlePrimaryButtonClick = () => {
-    handleReportClick(selectedOption);
+    !isReportLoading && handleReportClick(selectedOption);
     handleCancelClick();
   };
 

--- a/frontend/src/components/comment/CommentList/CommentItem/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentItem/index.tsx
@@ -29,6 +29,9 @@ interface CommentItemProps {
 }
 
 export default function CommentItem({ comment, userType }: CommentItemProps) {
+  const [isReportCommentLoading, setIsReportCommentLoading] = useState(false);
+  const [isReportNicknameLoading, setIsReportNicknameLoading] = useState(false);
+
   const { isOpen, toggleComponent, closeComponent } = useToggle();
   const { isToastOpen, openToast, toastMessage } = useToast();
   const { id, member, content, createdAt, isEdit } = comment;
@@ -37,7 +40,7 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
   const params = useParams() as { postId: string };
   const postId = Number(params.postId);
 
-  const { mutate, isError, error } = useDeleteComment(postId, id);
+  const { mutate, isError, error, isLoading: isCommentDeleting } = useDeleteComment(postId, id);
 
   const handleMenuClick = (menu: CommentAction) => {
     closeComponent();
@@ -46,6 +49,7 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
 
   const handleCommentReportClick = async (reason: string) => {
     const reportData: ReportRequest = { type: 'COMMENT', id, reason };
+    setIsReportCommentLoading(true);
 
     await reportContent(reportData)
       .then(res => {
@@ -58,11 +62,15 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
           return;
         }
         openToast('댓글 신고가 실패했습니다.');
+      })
+      .finally(() => {
+        setIsReportCommentLoading(false);
       });
   };
 
   const handleNicknameReportClick = async (reason: string) => {
     const reportData: ReportRequest = { type: 'NICKNAME', id: member.id, reason };
+    setIsReportNicknameLoading(true);
 
     await reportContent(reportData)
       .then(res => {
@@ -75,6 +83,9 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
           return;
         }
         openToast('작성자 닉네임 신고가 실패했습니다.');
+      })
+      .finally(() => {
+        setIsReportNicknameLoading(false);
       });
   };
 
@@ -146,6 +157,7 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
           target="COMMENT"
           handleCancelClick={handleCancelClick}
           handleDeleteClick={handleDeleteClick}
+          isDeleting={isCommentDeleting}
         />
       )}
       {action === COMMENT_ACTION.USER_REPORT && (
@@ -153,6 +165,7 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
           reportType="NICKNAME"
           handleReportClick={handleNicknameReportClick}
           handleCancelClick={handleCancelClick}
+          isReportLoading={isReportNicknameLoading}
         />
       )}
       {action === COMMENT_ACTION.COMMENT_REPORT && (
@@ -160,6 +173,7 @@ export default function CommentItem({ comment, userType }: CommentItemProps) {
           reportType="COMMENT"
           handleReportClick={handleCommentReportClick}
           handleCancelClick={handleCancelClick}
+          isReportLoading={isReportCommentLoading}
         />
       )}
       {isToastOpen && (

--- a/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
@@ -50,13 +50,17 @@ export default function CommentTextForm({
     isLoading: editLoading,
   } = useEditComment(postId, commentId);
 
-  const updateComment = isEdit
-    ? () => {
-        editComment({ ...initialComment, content: deleteOverlappingNewLine(content) });
-      }
-    : () => {
-        createComment({ content: deleteOverlappingNewLine(content) });
-      };
+  const handleUpdateComment = () => {
+    if (content.trim() === '') {
+      openToast('댓글에 내용을 입력해주세요.');
+      return;
+    }
+    if (isEdit) {
+      editComment({ ...initialComment, content: deleteOverlappingNewLine(content) });
+      return;
+    }
+    createComment({ content: deleteOverlappingNewLine(content) });
+  };
 
   useEffect(() => {
     isCreateSuccess && resetText();
@@ -97,7 +101,7 @@ export default function CommentTextForm({
         <S.ButtonWrapper>
           <SquareButton
             aria-label="댓글 저장"
-            onClick={() => updateComment()}
+            onClick={handleUpdateComment}
             theme={createLoading || editLoading ? 'gray' : 'fill'}
             type="button"
             disabled={isEdit ? editLoading : createLoading}

--- a/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
@@ -71,11 +71,19 @@ export default function CommentTextForm({
   }, [isEditSuccess]);
 
   useEffect(() => {
-    isCreateError && createError instanceof Error && openToast(createError.message);
+    if (isCreateError && createError instanceof Error) {
+      const errorResponse = JSON.parse(createError.message);
+      openToast(errorResponse.message);
+      return;
+    }
   }, [isCreateError, createError]);
 
   useEffect(() => {
-    isEditError && editError instanceof Error && openToast(editError.message);
+    if (isEditError && editError instanceof Error) {
+      const errorResponse = JSON.parse(editError.message);
+      openToast(errorResponse.message);
+      return;
+    }
   }, [isEditError, editError]);
 
   return (

--- a/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
@@ -40,12 +40,14 @@ export default function CommentTextForm({
     isSuccess: isCreateSuccess,
     isError: isCreateError,
     error: createError,
+    isLoading: createLoading,
   } = useCreateComment(postId);
   const {
     mutate: editComment,
     isSuccess: isEditSuccess,
     isError: isEditError,
     error: editError,
+    isLoading: editLoading,
   } = useEditComment(postId, commentId);
 
   const updateComment = isEdit
@@ -96,8 +98,9 @@ export default function CommentTextForm({
           <SquareButton
             aria-label="댓글 저장"
             onClick={() => updateComment()}
-            theme="blank"
+            theme={createLoading || editLoading ? 'gray' : 'fill'}
             type="button"
+            disabled={isEdit ? editLoading : createLoading}
           >
             저장
           </SquareButton>

--- a/frontend/src/components/common/DeleteModal/DeleteModal.stories.tsx
+++ b/frontend/src/components/common/DeleteModal/DeleteModal.stories.tsx
@@ -11,12 +11,22 @@ type Story = StoryObj<typeof DeleteModal>;
 
 export const Post: Story = {
   render: () => (
-    <DeleteModal target="POST" handleCancelClick={() => {}} handleDeleteClick={() => {}} />
+    <DeleteModal
+      target="POST"
+      handleCancelClick={() => {}}
+      handleDeleteClick={() => {}}
+      isDeleting={false}
+    />
   ),
 };
 
 export const User: Story = {
   render: () => (
-    <DeleteModal target="MEMBERSHIP" handleCancelClick={() => {}} handleDeleteClick={() => {}} />
+    <DeleteModal
+      target="MEMBERSHIP"
+      handleCancelClick={() => {}}
+      handleDeleteClick={() => {}}
+      isDeleting={false}
+    />
   ),
 };

--- a/frontend/src/components/common/DeleteModal/index.tsx
+++ b/frontend/src/components/common/DeleteModal/index.tsx
@@ -14,15 +14,17 @@ interface DeleteModalProps {
   target: TargetForDelete;
   handleCancelClick: () => void;
   handleDeleteClick: () => void;
+  isDeleting: boolean;
 }
 
 export default function DeleteModal({
   target,
   handleCancelClick,
   handleDeleteClick,
+  isDeleting,
 }: DeleteModalProps) {
   const handlePrimaryButtonClick = () => {
-    handleDeleteClick();
+    !isDeleting && handleDeleteClick();
     handleCancelClick();
   };
 

--- a/frontend/src/components/common/HeaderTextButton/index.tsx
+++ b/frontend/src/components/common/HeaderTextButton/index.tsx
@@ -4,11 +4,20 @@ import * as S from './style';
 
 interface HeaderTextButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: string;
+  isLoading?: boolean;
 }
 
 /* 헤더에 포함되어 취소, 확인, 신고 등 사용될 버튼
  * props로 s/m/l 크기를 받음
  */
-export default function HeaderTextButton({ children, ...rest }: HeaderTextButtonProps) {
-  return <S.Button {...rest}>{children}</S.Button>;
+export default function HeaderTextButton({
+  children,
+  isLoading = false,
+  ...rest
+}: HeaderTextButtonProps) {
+  return (
+    <S.Button $isLoading={isLoading} {...rest}>
+      {children}
+    </S.Button>
+  );
 }

--- a/frontend/src/components/common/HeaderTextButton/style.ts
+++ b/frontend/src/components/common/HeaderTextButton/style.ts
@@ -1,11 +1,11 @@
 import { styled } from 'styled-components';
 
-export const Button = styled.button`
+export const Button = styled.button<{ $isLoading: boolean }>`
   background-color: rgba(0, 0, 0, 0);
-  color: var(--white);
+  color: ${props => (props.$isLoading ? 'gray' : 'var(--white)')};
 
   font: var(--text-caption);
-  font-weight: 500;
+  font-weight: ${props => (props.$isLoading ? 600 : 500)};
 
   cursor: pointer;
 `;

--- a/frontend/src/components/common/Post/index.tsx
+++ b/frontend/src/components/common/Post/index.tsx
@@ -46,13 +46,13 @@ export default function Post({ postInfo, isPreview }: PostProps) {
 
   const {
     mutate: createVote,
-    isError: isCreateError,
-    error: createError,
+    isError: isCreateVoteError,
+    error: createVoteError,
   } = useCreateVote({ isPreview, postId });
   const {
     mutate: editVote,
-    isError: isEditError,
-    error: editError,
+    isError: isEditVoteError,
+    error: editVoteError,
   } = useEditVote({ isPreview, postId });
 
   const isActive = !checkClosedPost(deadline);
@@ -90,16 +90,20 @@ export default function Post({ postInfo, isPreview }: PostProps) {
   };
 
   useEffect(() => {
-    if (isCreateError && createError instanceof Error) {
-      openToast(createError.message);
+    if (isCreateVoteError && createVoteError instanceof Error) {
+      const errorResponse = JSON.parse(createVoteError.message);
+      openToast(errorResponse.message);
+      return;
     }
-  }, [isCreateError, createError]);
+  }, [isCreateVoteError, createVoteError]);
 
   useEffect(() => {
-    if (isEditError && editError instanceof Error) {
-      openToast(editError.message);
+    if (isEditVoteError && editVoteError instanceof Error) {
+      const errorResponse = JSON.parse(editVoteError.message);
+      openToast(errorResponse.message);
+      return;
     }
-  }, [isEditError, editError]);
+  }, [isEditVoteError, editVoteError]);
 
   const isPreviewTabIndex = isPreview ? undefined : 0;
 

--- a/frontend/src/hooks/query/post/useDeletePost.ts
+++ b/frontend/src/hooks/query/post/useDeletePost.ts
@@ -7,7 +7,7 @@ import { QUERY_KEY } from '@constants/queryKey';
 export const useDeletePost = (postId: number, isLogged: boolean) => {
   const queryClient = useQueryClient();
 
-  const { mutate, isSuccess, isError, error } = useMutation({
+  const { mutate, isSuccess, isError, error, isLoading } = useMutation({
     mutationFn: () => deletePost(postId),
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.USER_INFO, isLogged]);
@@ -17,5 +17,5 @@ export const useDeletePost = (postId: number, isLogged: boolean) => {
     },
   });
 
-  return { mutate, isSuccess, isError, error };
+  return { mutate, isSuccess, isError, error, isLoading };
 };

--- a/frontend/src/pages/post/CreatePostPage/index.tsx
+++ b/frontend/src/pages/post/CreatePostPage/index.tsx
@@ -14,7 +14,7 @@ import { SORTING, STATUS } from '@constants/post';
 export default function CreatePostPage() {
   const navigate = useNavigate();
 
-  const { mutate, isSuccess, isError, error } = useCreatePost();
+  const { mutate, isSuccess, isError, error, isLoading } = useCreatePost();
   const { isToastOpen, openToast, toastMessage } = useToast();
   const { setPostOption } = useContext(PostOptionContext);
 
@@ -35,7 +35,7 @@ export default function CreatePostPage() {
 
   return (
     <Layout isSidebarVisible={false}>
-      <PostForm mutate={mutate} />
+      <PostForm mutate={mutate} isSubmitting={isLoading} />
       {isToastOpen && (
         <Toast size="md" position="bottom">
           {toastMessage}

--- a/frontend/src/pages/post/EditPostPage/EditPost/index.tsx
+++ b/frontend/src/pages/post/EditPostPage/EditPost/index.tsx
@@ -18,7 +18,7 @@ export default function EditPost() {
   const { postId } = useParams();
 
   const { data } = usePostDetail(true, Number(postId));
-  const { mutate, isSuccess, isError, error } = useEditPost(Number(postId));
+  const { mutate, isSuccess, isError, error, isLoading } = useEditPost(Number(postId));
   const { isToastOpen, openToast, toastMessage } = useToast();
   const { setPostOption } = useContext(PostOptionContext);
 
@@ -39,7 +39,7 @@ export default function EditPost() {
 
   return (
     <>
-      <PostForm data={data} mutate={mutate} />
+      <PostForm data={data} mutate={mutate} isSubmitting={isLoading} />
       {isToastOpen && (
         <Toast size="md" position="bottom">
           {toastMessage}

--- a/frontend/src/pages/post/PostDetail/BottomButtonPart/BottomButtonPart.stories.tsx
+++ b/frontend/src/pages/post/PostDetail/BottomButtonPart/BottomButtonPart.stories.tsx
@@ -1,3 +1,4 @@
+import type { LoadingType } from '../types';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import BottomButtonPart from '.';
@@ -24,18 +25,52 @@ const handleEvent = {
 export default meta;
 type Story = StoryObj<typeof BottomButtonPart>;
 
+const isEventLoading: Record<LoadingType, boolean> = {
+  isDeletePostLoading: false,
+  isReportPostLoading: false,
+  isReportNicknameLoading: false,
+};
+
 export const isWriterAndIsClosedCase: Story = {
-  render: () => <BottomButtonPart isWriter={true} isClosed={true} handleEvent={handleEvent} />,
+  render: () => (
+    <BottomButtonPart
+      isWriter={true}
+      isClosed={true}
+      handleEvent={handleEvent}
+      isEventLoading={isEventLoading}
+    />
+  ),
 };
 
 export const isNotWriterAndIsClosedCase: Story = {
-  render: () => <BottomButtonPart isWriter={false} isClosed={true} handleEvent={handleEvent} />,
+  render: () => (
+    <BottomButtonPart
+      isWriter={false}
+      isClosed={true}
+      handleEvent={handleEvent}
+      isEventLoading={isEventLoading}
+    />
+  ),
 };
 
 export const isWriterAndIsNotClosedCase: Story = {
-  render: () => <BottomButtonPart isWriter={true} isClosed={false} handleEvent={handleEvent} />,
+  render: () => (
+    <BottomButtonPart
+      isWriter={true}
+      isClosed={false}
+      handleEvent={handleEvent}
+      isEventLoading={isEventLoading}
+    />
+  ),
 };
 
 export const isNotWriterAndIsNotClosedCase: Story = {
-  render: () => <BottomButtonPart isWriter={false} isClosed={false} handleEvent={handleEvent} />,
+  render: () => (
+    <BottomButtonPart
+      isWriter={false}
+      isClosed={false}
+      handleEvent={handleEvent}
+      isEventLoading={isEventLoading}
+    />
+  ),
 };

--- a/frontend/src/pages/post/PostDetail/BottomButtonPart/index.tsx
+++ b/frontend/src/pages/post/PostDetail/BottomButtonPart/index.tsx
@@ -1,3 +1,5 @@
+import type { LoadingType } from '../types';
+
 import { useContext, useState } from 'react';
 
 import { AuthContext } from '@hooks/context/auth';
@@ -9,7 +11,6 @@ import ReportModal from '@components/ReportModal';
 import * as S from './style';
 
 type MovePageEvent = 'moveWritePostPage' | 'moveVoteStatisticsPage' | 'movePostListPage';
-
 interface PostDetailPageChildProps {
   isWriter: boolean;
   isClosed: boolean;
@@ -23,17 +24,19 @@ interface PostDetailPageChildProps {
     };
     openToast: (text: string) => void;
   };
+  isEventLoading: Record<LoadingType, boolean>;
 }
 
 export default function BottomButtonPart({
   isWriter,
   isClosed,
   handleEvent: { movePage, controlPost, openToast },
+  isEventLoading,
 }: PostDetailPageChildProps) {
   const { loggedInfo } = useContext(AuthContext);
   const { moveWritePostPage, moveVoteStatisticsPage } = movePage;
   const { setEarlyClosePost, deletePost, reportPost, reportNickname } = controlPost;
-
+  const { isDeletePostLoading, isReportPostLoading, isReportNicknameLoading } = isEventLoading;
   const [action, setAction] = useState<string | null>(null);
 
   const handleActionButtonClick = (action: string) => {
@@ -53,10 +56,18 @@ export default function BottomButtonPart({
     <S.BottomButtonContainer>
       {!isWriter ? (
         <>
-          <SquareButton theme="fill" onClick={() => handleActionButtonClick('POST_REPORT')}>
+          <SquareButton
+            aria-label="게시글 신고"
+            theme={isReportPostLoading ? 'gray' : 'fill'}
+            onClick={() => handleActionButtonClick('POST_REPORT')}
+          >
             게시물 신고
           </SquareButton>
-          <SquareButton theme="fill" onClick={() => handleActionButtonClick('NICKNAME_REPORT')}>
+          <SquareButton
+            aria-label="작성자 닉네임 신고"
+            theme={isReportNicknameLoading ? 'gray' : 'fill'}
+            onClick={() => handleActionButtonClick('NICKNAME_REPORT')}
+          >
             작성자 닉네임 신고
           </SquareButton>
         </>
@@ -71,7 +82,7 @@ export default function BottomButtonPart({
 
           <SquareButton
             aria-label="게시글 삭제"
-            theme="fill"
+            theme={isDeletePostLoading ? 'gray' : 'fill'}
             onClick={() => handleActionButtonClick('DELETE')}
           >
             삭 제
@@ -84,8 +95,9 @@ export default function BottomButtonPart({
           </SquareButton>
           <SquareButton
             aria-label="게시글 삭제"
-            theme="fill"
+            theme={isDeletePostLoading ? 'gray' : 'fill'}
             onClick={() => handleActionButtonClick('DELETE')}
+            disabled={isDeletePostLoading}
           >
             삭 제
           </SquareButton>
@@ -96,6 +108,7 @@ export default function BottomButtonPart({
           target="POST"
           handleCancelClick={handleCancelClick}
           handleDeleteClick={deletePost}
+          isDeleting={isEventLoading.isDeletePostLoading}
         />
       )}
       {action === 'POST_REPORT' && (
@@ -103,6 +116,7 @@ export default function BottomButtonPart({
           reportType="POST"
           handleReportClick={reportPost}
           handleCancelClick={handleCancelClick}
+          isReportLoading={isReportPostLoading}
         />
       )}
       {action === 'NICKNAME_REPORT' && (
@@ -110,6 +124,7 @@ export default function BottomButtonPart({
           reportType="NICKNAME"
           handleReportClick={reportNickname}
           handleCancelClick={handleCancelClick}
+          isReportLoading={isReportNicknameLoading}
         />
       )}
     </S.BottomButtonContainer>

--- a/frontend/src/pages/post/PostDetail/BottomButtonPart/index.tsx
+++ b/frontend/src/pages/post/PostDetail/BottomButtonPart/index.tsx
@@ -108,7 +108,7 @@ export default function BottomButtonPart({
           target="POST"
           handleCancelClick={handleCancelClick}
           handleDeleteClick={deletePost}
-          isDeleting={isEventLoading.isDeletePostLoading}
+          isDeleting={isDeletePostLoading}
         />
       )}
       {action === 'POST_REPORT' && (

--- a/frontend/src/pages/post/PostDetail/InnerHeaderPart/InnerHeaderPart.stories.tsx
+++ b/frontend/src/pages/post/PostDetail/InnerHeaderPart/InnerHeaderPart.stories.tsx
@@ -2,11 +2,22 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import NarrowTemplateHeader from '@components/common/NarrowTemplateHeader';
 
+import { LoadingType } from '../types';
+
 import InnerHeaderPart from '.';
 
 const meta: Meta<typeof InnerHeaderPart> = {
   component: InnerHeaderPart,
   decorators: [storyFn => <NarrowTemplateHeader>{storyFn()}</NarrowTemplateHeader>],
+};
+
+export default meta;
+type Story = StoryObj<typeof InnerHeaderPart>;
+
+const isEventLoading: Record<LoadingType, boolean> = {
+  isDeletePostLoading: false,
+  isReportPostLoading: false,
+  isReportNicknameLoading: false,
 };
 
 const handleEvent = {
@@ -23,21 +34,46 @@ const handleEvent = {
   },
 };
 
-export default meta;
-type Story = StoryObj<typeof InnerHeaderPart>;
-
 export const isWriterAndIsClosedCase: Story = {
-  render: () => <InnerHeaderPart isWriter={true} isClosed={true} handleEvent={handleEvent} />,
+  render: () => (
+    <InnerHeaderPart
+      isWriter={true}
+      isClosed={true}
+      handleEvent={handleEvent}
+      isEventLoading={isEventLoading}
+    />
+  ),
 };
 
 export const isNotWriterAndIsClosedCase: Story = {
-  render: () => <InnerHeaderPart isWriter={false} isClosed={true} handleEvent={handleEvent} />,
+  render: () => (
+    <InnerHeaderPart
+      isWriter={false}
+      isClosed={true}
+      handleEvent={handleEvent}
+      isEventLoading={isEventLoading}
+    />
+  ),
 };
 
 export const isWriterAndIsNotClosedCase: Story = {
-  render: () => <InnerHeaderPart isWriter={true} isClosed={false} handleEvent={handleEvent} />,
+  render: () => (
+    <InnerHeaderPart
+      isWriter={true}
+      isClosed={false}
+      handleEvent={handleEvent}
+      isEventLoading={isEventLoading}
+    />
+  ),
 };
 
 export const isNotWriterAndIsNotClosedCase: Story = {
-  render: () => <InnerHeaderPart isWriter={false} isClosed={false} handleEvent={handleEvent} />,
+  render: () => (
+    <InnerHeaderPart
+      isWriter={false}
+      isClosed={false}
+      handleEvent={handleEvent}
+      isEventLoading={isEventLoading}
+    />
+  ),
 };

--- a/frontend/src/pages/post/PostDetail/InnerHeaderPart/index.tsx
+++ b/frontend/src/pages/post/PostDetail/InnerHeaderPart/index.tsx
@@ -109,6 +109,7 @@ export default function InnerHeaderPart({
               aria-label="게시글 삭제"
               onClick={() => handleMenuClick('DELETE')}
               disabled={isDeletePostLoading}
+              isLoading={isDeletePostLoading}
             >
               {isDeletePostLoading ? '삭제 중...' : '삭제'}
             </HeaderTextButton>

--- a/frontend/src/pages/post/PostDetail/InnerHeaderPart/index.tsx
+++ b/frontend/src/pages/post/PostDetail/InnerHeaderPart/index.tsx
@@ -12,6 +12,8 @@ import PostMenu from '@components/common/PostMenu';
 import TagButton from '@components/common/TagButton';
 import ReportModal from '@components/ReportModal';
 
+import { LoadingType } from '../types';
+
 import * as S from './style';
 
 type MovePageEvent = 'moveWritePostPage' | 'moveVoteStatisticsPage' | 'movePostListPage';
@@ -28,6 +30,7 @@ interface PostDetailPageChildProps {
       reportNickname: (reason: string) => void;
     };
   };
+  isEventLoading: Record<LoadingType, boolean>;
 }
 
 const menuList: PostMenuItem[] = [
@@ -39,6 +42,7 @@ export default function InnerHeaderPart({
   isWriter,
   isClosed,
   handleEvent: { movePage, controlPost },
+  isEventLoading,
 }: PostDetailPageChildProps) {
   const navigate = useNavigate();
 
@@ -46,6 +50,8 @@ export default function InnerHeaderPart({
   const { setEarlyClosePost, deletePost, reportPost, reportNickname } = controlPost;
   const { isOpen, toggleComponent, closeComponent } = useToggle();
   const [action, setAction] = useState<PostAction | null>(null);
+
+  const { isDeletePostLoading, isReportNicknameLoading, isReportPostLoading } = isEventLoading;
 
   const handleMenuClick = (action: PostAction) => {
     closeComponent();
@@ -84,8 +90,12 @@ export default function InnerHeaderPart({
             <HeaderTextButton aria-label="게시글 수정" onClick={moveWritePostPage}>
               수정
             </HeaderTextButton>
-            <HeaderTextButton aria-label="게시글 삭제" onClick={() => handleMenuClick('DELETE')}>
-              삭제
+            <HeaderTextButton
+              aria-label="게시글 삭제"
+              onClick={() => handleMenuClick('DELETE')}
+              disabled={isDeletePostLoading}
+            >
+              {isDeletePostLoading ? '삭제 중...' : '삭제'}
             </HeaderTextButton>
             <S.TagButtonWrapper>
               <TagButton aria-label="게시글 조기마감" size="sm" onClick={setEarlyClosePost}>
@@ -95,8 +105,12 @@ export default function InnerHeaderPart({
           </>
         ) : (
           <>
-            <HeaderTextButton aria-label="게시글 삭제" onClick={() => handleMenuClick('DELETE')}>
-              삭제
+            <HeaderTextButton
+              aria-label="게시글 삭제"
+              onClick={() => handleMenuClick('DELETE')}
+              disabled={isDeletePostLoading}
+            >
+              {isDeletePostLoading ? '삭제 중...' : '삭제'}
             </HeaderTextButton>
             <S.TagButtonWrapper>
               <TagButton aria-label="게시글 통계보기" size="sm" onClick={moveVoteStatisticsPage}>
@@ -110,6 +124,7 @@ export default function InnerHeaderPart({
             target="POST"
             handleCancelClick={handleCancelClick}
             handleDeleteClick={deletePost}
+            isDeleting={isDeletePostLoading}
           />
         )}
         {action === 'POST_REPORT' && (
@@ -117,6 +132,7 @@ export default function InnerHeaderPart({
             reportType="POST"
             handleReportClick={reportPost}
             handleCancelClick={handleCancelClick}
+            isReportLoading={isReportPostLoading}
           />
         )}
         {action === 'NICKNAME_REPORT' && (
@@ -124,6 +140,7 @@ export default function InnerHeaderPart({
             reportType="NICKNAME"
             handleReportClick={reportNickname}
             handleCancelClick={handleCancelClick}
+            isReportLoading={isReportNicknameLoading}
           />
         )}
       </S.HeaderWrapper>

--- a/frontend/src/pages/post/PostDetail/PostDetail/index.tsx
+++ b/frontend/src/pages/post/PostDetail/PostDetail/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useContext, useEffect } from 'react';
+import { Suspense, useContext, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { PostInfo } from '@type/post';
@@ -30,6 +30,9 @@ import * as S from './style';
 export default function PostDetail() {
   const navigate = useNavigate();
 
+  const [isReportPostLoading, setIsReportPostLoading] = useState(false);
+  const [isReportNicknameLoading, setIsReportNicknameLoading] = useState(false);
+
   const params = useParams() as { postId: string };
   const postId = Number(params.postId);
   const { isToastOpen, openToast, toastMessage } = useToast();
@@ -43,6 +46,7 @@ export default function PostDetail() {
     isSuccess: isDeleteSuccess,
     isError: isDeleteError,
     error: deleteError,
+    isLoading: isDeletePostLoading,
   } = useDeletePost(postId, loggedInfo.isLoggedIn);
   const { mutate: earlyClosePost } = useEarlyClosePost(postId);
 
@@ -79,6 +83,7 @@ export default function PostDetail() {
       deletePost();
     },
     reportPost: async (reason: string) => {
+      setIsReportPostLoading(true);
       const reportData: ReportRequest = { type: 'POST', id: postId, reason };
 
       await reportContent(reportData)
@@ -92,9 +97,13 @@ export default function PostDetail() {
             return;
           }
           openToast('게시글 신고가 실패했습니다.');
+        })
+        .finally(() => {
+          setIsReportPostLoading(false);
         });
     },
     reportNickname: async (reason: string) => {
+      setIsReportNicknameLoading(true);
       const reportData: ReportRequest = {
         type: 'NICKNAME',
         id: postDataFallback.writer.id,
@@ -112,6 +121,9 @@ export default function PostDetail() {
             return;
           }
           openToast('작성자 닉네임 신고가 실패했습니다.');
+        })
+        .finally(() => {
+          setIsReportNicknameLoading(false);
         });
     },
   };
@@ -136,6 +148,11 @@ export default function PostDetail() {
             isClosed={isClosed}
             isWriter={isWriter}
             handleEvent={{ movePage, controlPost }}
+            isEventLoading={{
+              isDeletePostLoading,
+              isReportPostLoading,
+              isReportNicknameLoading,
+            }}
           />
         </NarrowTemplateHeader>
       </S.HeaderContainer>
@@ -145,6 +162,11 @@ export default function PostDetail() {
           isClosed={isClosed}
           isWriter={isWriter}
           handleEvent={{ movePage, controlPost, openToast }}
+          isEventLoading={{
+            isDeletePostLoading,
+            isReportPostLoading,
+            isReportNicknameLoading,
+          }}
         />
       </S.MainContainer>
       <S.BottomContainer>

--- a/frontend/src/pages/post/PostDetail/types.ts
+++ b/frontend/src/pages/post/PostDetail/types.ts
@@ -1,0 +1,1 @@
+export type LoadingType = 'isDeletePostLoading' | 'isReportPostLoading' | 'isReportNicknameLoading';


### PR DESCRIPTION
## 🔥 연관 이슈

close: #473
close: #611
close: #646 
close: #648 

## 📝 작업 요약
* 마감된 게시글에 투표하는 경우 code 등 불필요한 정보까지 Toast에 뜨지 않도록 에러 메시지를 가공했습니다.
* 삭제된 게시글에 투표하는 경우에도 마찬가지로, message만 Toast에 뜨도록 하였습니다. (현재 `알 수 없는 서버 에러입니다` 라는 이슈는 #658 에서 해결 중입니다!)
* 댓글에 빈 문자열이나 공백, 개행만 입력하고 저장하는 것을 방지하였습니다.
* 기존의 Mutation이 로딩 중인데, 중복으로 Mutation 하는 경우를 방지하였습니다.
  * 기존의 Mutation이 로딩 중이라면, SquareButton이 gray이고 disabled 되도록 하였습니다.

## ⏰ 소요 시간
4시간

## 🔎 작업 상세 설명
useMutation이 사용되는 기능은 아래와 같습니다. (✅는 이 pr에서 적용한 부분입니다.)
- 댓글 생성/수정 (POST/PATCH) ✅
- 댓글 삭제 (DELETE) ✅ -> DeleteModal이 열고 닫히는 텀이 있음 (이벤트 핸들러만 작동 못하게 제어할 것)

- 게시글 생성/수정 (POST/PATCH) ✅
- 게시글 삭제 (DELETE) ✅ -> DeleteModal이 열고 닫히는 텀이 있음 (이벤트 핸들러만 작동 못하게 제어할 것, 단 데스크탑에서는 '게시글 삭제' 버튼이 disabled, 회색으로 되도록 함)
---
남은 기능 중 Mutation은 아래와 같습니다.
- 닉네임 변경 (PUT) 
- 개인정보 등록 (POST) 
- 탈퇴 (DELETE)

- 투표 생성 (POST) 
- 투표 수정 (PATCH) 

- 카테고리 즐겨찾기 (POST) 

- 조기 마감 (POST)
## 🌟 논의 사항
남은 기능들 중 중복 Mutation을 필수로 꼭 막아줬으면 하는 기능이 있나요?! 
여러분의 의견이 궁금합니다🤔😃
