### PR TITLE
이미지 압축 패키지를 Browser Image Compression에서 upload-images-converter로 변경

### DIFF
--- a/frontend/__test__/calculateAspectRatioSize.test.ts
+++ b/frontend/__test__/calculateAspectRatioSize.test.ts
@@ -1,0 +1,31 @@
+import { calculateAspectRatioSize } from '@utils/calculateAspectRatioSize';
+
+test.each([
+  [
+    { originWidth: 3000, originHeight: 820, maxWidthOrHeight: 1280 },
+    { width: 1280, height: 349.9 },
+  ],
+  [
+    { originWidth: 1280, originHeight: 1303, maxWidthOrHeight: 1280 },
+    { width: 1257.4, height: 1280 },
+  ],
+  [
+    { originWidth: 2403, originHeight: 603, maxWidthOrHeight: 1280 },
+    { width: 1280, height: 321.2 },
+  ],
+  [
+    { originWidth: 1200, originHeight: 820, maxWidthOrHeight: 1280 },
+    { width: 1200, height: 820 },
+  ],
+  [
+    { originWidth: 200, originHeight: 200, maxWidthOrHeight: 1280 },
+    { width: 200, height: 200 },
+  ],
+])(
+  'calculateAspectRatioSize에서 입력받은 너비, 높이가 `maxWidthOrHeight`보다 크다면, 너비를 `maxWidthOrHeight`로 설정하고, 높이를 원래의 가로 세로 비율을 유지하며 계산하여 반환합니다. 너비, 높이 둘 중 긴 값이 최대 너비 혹은 높이보다 작다면 기존의 너비, 높이를 반환합니다.',
+  ({ originWidth, originHeight, maxWidthOrHeight }, expected) => {
+    const result = calculateAspectRatioSize({ originWidth, originHeight, maxWidthOrHeight });
+
+    expect(result).toEqual(expected);
+  }
+);

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -13,6 +13,8 @@ dotenv.config({ path: './.env.test' });
  *    SyntaxError: Unexpected token 'export'
 
     > 1 | import { imageConverter } from 'upload-images-converter';
+    
+    https://github.com/nrwl/nx/issues/7844#issuecomment-1220559108
  */
 jest.mock('upload-images-converter', () => ({
   __esModule: true,

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -7,6 +7,17 @@ import { handlers } from './src/mocks/handlers';
 
 dotenv.config({ path: './.env.test' });
 
+/**
+ * 이 코드가 없다면 jest에서 upload-images-converter 패키지에 관한 에러가 발생합니다.
+ * 
+ *    SyntaxError: Unexpected token 'export'
+
+    > 1 | import { imageConverter } from 'upload-images-converter';
+ */
+jest.mock('upload-images-converter', () => ({
+  __esModule: true,
+}));
+
 export const server = setupServer(...handlers);
 
 beforeAll(() => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,13 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-query": "^4.29.19",
-        "browser-image-compression": "^2.0.2",
         "dotenv": "^16.3.1",
         "msw": "^1.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-ga4": "^2.1.0",
-        "react-router-dom": "^6.14.1"
+        "react-router-dom": "^6.14.1",
+        "upload-images-converter": "^2.0.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.22.6",
@@ -9418,14 +9418,6 @@
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
-    },
-    "node_modules/browser-image-compression": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
-      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
-      "dependencies": {
-        "uzip": "0.20201231.0"
-      }
     },
     "node_modules/browserify-zlib": {
       "version": "0.1.4",
@@ -22535,7 +22527,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22738,6 +22730,11 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/upload-images-converter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upload-images-converter/-/upload-images-converter-2.0.2.tgz",
+      "integrity": "sha512-cltVwZ+RU70Qx8heZrSj8OpQhR9mFHZ6CXudosKkFlM91Iiznl8Oluw/x+9DTnSKkvipvkf1oCvyVw5UPIpZ1Q=="
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -22818,11 +22815,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/uzip": {
-      "version": "0.20201231.0",
-      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
-      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -24193,7 +24185,8 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.18.6",
@@ -25287,7 +25280,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
       "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@esbuild/android-arm": {
       "version": "0.17.19",
@@ -26387,7 +26381,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "find-up": {
           "version": "5.0.0",
@@ -26888,7 +26883,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -28329,7 +28325,8 @@
       "version": "7.0.26",
       "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-7.0.26.tgz",
       "integrity": "sha512-heobG4IovYAD9fo7qmUHylCSQjDd1eXDCOaTiy+XVKobHAJgkz1gKqbaFSP6KLkPE4cKyScku2K9mY0tcKIhMw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@storybook/react-webpack5": {
       "version": "7.0.26",
@@ -29649,19 +29646,22 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
       "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
       "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/serve": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
       "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xmldom/xmldom": {
       "version": "0.8.9",
@@ -29739,13 +29739,15 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -30050,7 +30052,8 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-jest": {
       "version": "29.6.0",
@@ -30435,14 +30438,6 @@
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
       "dev": true
-    },
-    "browser-image-compression": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
-      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
-      "requires": {
-        "uzip": "0.20201231.0"
-      }
     },
     "browserify-zlib": {
       "version": "0.1.4",
@@ -32426,7 +32421,8 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
       "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -32633,7 +32629,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-storybook": {
       "version": "0.6.12",
@@ -33213,7 +33210,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -33984,7 +33982,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -35616,7 +35615,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -37078,7 +37078,8 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.2.1.tgz",
       "integrity": "sha512-9HrdzBAo0+sFz9ZYAGT5fB8ilzTW+q6lPocRxrIesMO+aB40V9MgFfbfMXxlGjf22OpRy+IXlvVaQenicdpgbg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "mdast-util-definitions": {
       "version": "4.0.0",
@@ -38025,7 +38026,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -38387,7 +38389,8 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-docgen": {
       "version": "5.4.3",
@@ -38422,7 +38425,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
       "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-dom": {
       "version": "18.2.0",
@@ -38467,7 +38471,8 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.2.tgz",
       "integrity": "sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",
@@ -39513,7 +39518,8 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.3.tgz",
       "integrity": "sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "styled-components": {
       "version": "6.0.2",
@@ -39787,7 +39793,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -40135,7 +40142,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "dev": true
+      "devOptional": true
     },
     "uglify-js": {
       "version": "3.17.4",
@@ -40266,6 +40273,11 @@
         "picocolors": "^1.0.0"
       }
     },
+    "upload-images-converter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upload-images-converter/-/upload-images-converter-2.0.2.tgz",
+      "integrity": "sha512-cltVwZ+RU70Qx8heZrSj8OpQhR9mFHZ6CXudosKkFlM91Iiznl8Oluw/x+9DTnSKkvipvkf1oCvyVw5UPIpZ1Q=="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -40297,7 +40309,8 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util": {
       "version": "0.12.5",
@@ -40333,11 +40346,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
-    },
-    "uzip": {
-      "version": "0.20201231.0",
-      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
-      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",
@@ -40473,7 +40481,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -40834,7 +40843,8 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,13 +22,13 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.29.19",
-    "browser-image-compression": "^2.0.2",
     "dotenv": "^16.3.1",
     "msw": "^1.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-ga4": "^2.1.0",
-    "react-router-dom": "^6.14.1"
+    "react-router-dom": "^6.14.1",
+    "upload-images-converter": "^2.0.2"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/src/hooks/useContentImage.ts
+++ b/frontend/src/hooks/useContentImage.ts
@@ -9,6 +9,8 @@ export const useContentImage = (imageUrl: string = '') => {
   const handlePasteImage = (event: ClipboardEvent<HTMLTextAreaElement>) => {
     const file = event.clipboardData.files[0];
 
+    if (!file) return;
+
     if (file.type.slice(0, 5) === 'image') {
       event.preventDefault();
 

--- a/frontend/src/utils/calculateAspectRatioSize.ts
+++ b/frontend/src/utils/calculateAspectRatioSize.ts
@@ -1,0 +1,27 @@
+export const calculateAspectRatioSize = ({
+  originWidth,
+  originHeight,
+  maxWidthOrHeight,
+}: {
+  originWidth: number;
+  originHeight: number;
+  maxWidthOrHeight: number;
+}) => {
+  const maxSize = Math.max(originWidth, originHeight);
+
+  if (maxSize <= maxWidthOrHeight) {
+    return { width: originWidth, height: originHeight };
+  }
+
+  if (originWidth === maxSize) {
+    const width = maxWidthOrHeight;
+    const height = Number(((originHeight * maxWidthOrHeight) / originWidth).toFixed(1));
+
+    return { width, height };
+  }
+
+  const width = Number(((originWidth * maxWidthOrHeight) / originHeight).toFixed(1));
+  const height = maxWidthOrHeight;
+
+  return { width, height };
+};

--- a/frontend/src/utils/getImageSize.ts
+++ b/frontend/src/utils/getImageSize.ts
@@ -1,0 +1,27 @@
+export const getImageSize = (imageFile: File): Promise<{ width: number; height: number }> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const reader = new FileReader();
+
+    img.onload = () => {
+      const width = img.naturalWidth;
+      const height = img.naturalHeight;
+
+      resolve({ width, height });
+    };
+
+    reader.onload = () => {
+      img.src = reader.result?.toString() ?? '';
+    };
+
+    reader.readAsDataURL(imageFile);
+
+    img.onerror = error => {
+      reject(error);
+    };
+
+    reader.onerror = error => {
+      reject(error);
+    };
+  });
+};

--- a/frontend/src/utils/resizeImage.ts
+++ b/frontend/src/utils/resizeImage.ts
@@ -1,13 +1,24 @@
-import imageCompression from 'browser-image-compression';
+import { imageConverter } from 'upload-images-converter';
+
+import { calculateAspectRatioSize } from './calculateAspectRatioSize';
+import { getImageSize } from './getImageSize';
 
 export const convertImageToWebP = async (imageFile: File) => {
-  const compressedBlob = await imageCompression(imageFile, {
+  const { width: originWidth, height: originHeight } = await getImageSize(imageFile);
+
+  const { width, height } = calculateAspectRatioSize({
+    originWidth,
+    originHeight,
     maxWidthOrHeight: 1280,
-    initialQuality: 0.5,
-    fileType: 'image/webp',
   });
 
-  const outputWebpFile = new File([compressedBlob], `${Date.now().toString()}.webp`);
+  const compressedBlob = await imageConverter({
+    files: [imageFile],
+    width,
+    height,
+  });
+
+  const outputWebpFile = new File([compressedBlob[0]], `${Date.now().toString()}.webp`);
 
   const dataTransfer = new DataTransfer();
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #683 

## 📝 작업 요약

- 이미지 압축 패키지를 Browser Image Compression에서 upload-images-converter로 변경
- 이미지 너비, 높이를 반환하는 함수 구현
- 이미지 너비, 높이를 이미지 비율대로 재조정하여 반환하는 함수 구현

## ⏰ 소요 시간

1시간

## 🔎 작업 상세 설명

- upload-image-converter은 기존에 사용하던 패키지와 달리 이미지를 비율대로가 아닌 지정한 값으로 자르는 옵션만 설정할 수 있어서 직접 비율대로 자르기 위해 해당 함수를 구현
- jest에서 upload-image-converter을 인식하지 못해서 따로 jest.mock 하는 코드를 추가하였고, 이를 설명하는 주석을 추가했습니다



### 처리하는 시간

#### 네트워크 부하 (자바스크립트 코드로 처리하기 때문에 네트워크 속도와는 관련이 없음)

처리 속도 : 6ms

<img width="991" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/5603f1bf-84ad-41b9-bc3b-a62b183946c6">

<img width="995" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/a9e59913-721c-4bfc-8f4b-d963534093d4">

#### 맥북 에어(cpu 6배 부하)

처리 속도: 20ms

<img width="974" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/faaf0cc6-2700-46aa-a351-e940eb526f49">


### 웹팩 번들 크기 비교

####Browser Image Compression

크기: 55kb

<img width="1440" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/e68f324a-76c5-4351-a90e-a5eef24f5ebd">


#### upload-images-converter

크기: 5kb

<img width="1434" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/420ad6c6-bb44-412f-85d2-053bef20d0cd">






## 🌟 논의 사항

크루들과 이야기 해보고 싶은 부분을 적어주세요.
