### PR TITLE
테스트 컨테이너를 이용한 리프레시 토큰 검증 추가

### DIFF
--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -57,13 +57,8 @@ public class AuthService {
         redisTemplate.delete(refreshTokenByRequest);
         validateTokenInfo(accessTokenPayload, refreshTokenPayload);
 
-        System.out.println("ac.memberID = " + accessTokenPayload.memberId());
-        System.out.println("rc.memberID = " + refreshTokenPayload.memberId());
-
         final String newAccessToken = tokenProcessor.generateAccessToken(accessTokenPayload.memberId());
         final String newRefreshToken = tokenProcessor.generateRefreshToken(refreshTokenPayload.memberId());
-        System.out.println("refreshTokenByRequest = " + refreshTokenByRequest);
-        System.out.println("newRefreshToken = " + newRefreshToken);
         redisTemplate.opsForValue().set(newRefreshToken, accessTokenPayload.memberId(), Duration.ofDays(14L));
         return new ReissuedTokenDto(newAccessToken, newRefreshToken);
     }

--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -57,8 +57,13 @@ public class AuthService {
         redisTemplate.delete(refreshTokenByRequest);
         validateTokenInfo(accessTokenPayload, refreshTokenPayload);
 
+        System.out.println("ac.memberID = " + accessTokenPayload.memberId());
+        System.out.println("rc.memberID = " + refreshTokenPayload.memberId());
+
         final String newAccessToken = tokenProcessor.generateAccessToken(accessTokenPayload.memberId());
-        final String newRefreshToken = tokenProcessor.generateRefreshToken(accessTokenPayload.memberId());
+        final String newRefreshToken = tokenProcessor.generateRefreshToken(refreshTokenPayload.memberId());
+        System.out.println("refreshTokenByRequest = " + refreshTokenByRequest);
+        System.out.println("newRefreshToken = " + newRefreshToken);
         redisTemplate.opsForValue().set(newRefreshToken, accessTokenPayload.memberId(), Duration.ofDays(14L));
         return new ReissuedTokenDto(newAccessToken, newRefreshToken);
     }

--- a/backend/src/test/java/com/votogether/domain/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/auth/service/AuthServiceTest.java
@@ -64,8 +64,8 @@ class AuthServiceTest {
             ReissuedTokenDto reissuedTokenDto = authService.reissueAuthToken(request, refreshToken);
 
             // then
-            final Long savedMemberId = redisTemplate.opsForValue().get(reissuedTokenDto.refreshToken());
-            final Long dbSize = Objects.requireNonNull(redisTemplate.getConnectionFactory())
+            Long savedMemberId = redisTemplate.opsForValue().get(reissuedTokenDto.refreshToken());
+            Long dbSize = Objects.requireNonNull(redisTemplate.getConnectionFactory())
                     .getConnection()
                     .serverCommands()
                     .dbSize();

--- a/backend/src/test/java/com/votogether/domain/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,111 @@
+package com.votogether.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.votogether.domain.auth.dto.request.AccessTokenRequest;
+import com.votogether.domain.auth.service.dto.ReissuedTokenDto;
+import com.votogether.domain.auth.service.oauth.KakaoOAuthClient;
+import com.votogether.domain.member.service.MemberService;
+import com.votogether.global.exception.BadRequestException;
+import com.votogether.global.jwt.TokenProcessor;
+import com.votogether.test.config.RedisTestConfig;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Import(RedisTestConfig.class)
+@SpringBootTest
+class AuthServiceTest {
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    KakaoOAuthClient kakaoOAuthClient;
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    TokenProcessor tokenProcessor;
+
+    @Autowired
+    RedisTemplate<String, Long> redisTemplate;
+
+    @Nested
+    @DisplayName("인증 토큰을 재발급 받을 때")
+    class ReissueAuthToken {
+
+        @AfterEach
+        void tearDown() {
+            Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().serverCommands().flushAll();
+        }
+
+        @Test
+        @DisplayName("정상적으로 인증 토큰을 재발급한다.")
+        void success() {
+            // given
+            Long memberId = 1L;
+            String accessToken = tokenProcessor.generateAccessToken(memberId);
+            String refreshToken = tokenProcessor.generateRefreshToken(memberId);
+            AccessTokenRequest request = new AccessTokenRequest(accessToken);
+
+            redisTemplate.opsForValue().set(refreshToken, memberId);
+
+            // when
+            ReissuedTokenDto reissuedTokenDto = authService.reissueAuthToken(request, refreshToken);
+
+            // then
+            redisTemplate.opsForValue().get(reissuedTokenDto.refreshToken());
+            assertThat(reissuedTokenDto.refreshToken()).isEqualTo(refreshToken);
+        }
+
+        @Test
+        @DisplayName("인증 토큰과 갱신 토큰의 회원 아이디가 다르면 예외가 발생한다.")
+        void throwsExceptionWhenInformationOfAccessAndRefresh() {
+            // given
+            Long accessTokenMemberId = 1L;
+            Long refreshTokenMemberId = 2L;
+            String accessToken = tokenProcessor.generateAccessToken(accessTokenMemberId);
+            String refreshToken = tokenProcessor.generateRefreshToken(refreshTokenMemberId);
+            AccessTokenRequest request = new AccessTokenRequest(accessToken);
+
+            redisTemplate.opsForValue().set(refreshToken, refreshTokenMemberId);
+
+            // when, then
+            assertThatThrownBy(() -> authService.reissueAuthToken(request, refreshToken))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("토큰 간의 정보가 일치하지 않습니다.");
+        }
+
+    }
+
+    @Nested
+    @DisplayName("갱신 토큰을 삭제할 때")
+    class DeleteRefreshToken {
+
+        @Test
+        @DisplayName("정상적으로 삭제한다.")
+        void deleteRefreshToken() {
+            // given
+            Long memberId = 3L;
+            String refreshToken = "ihg.fed.cba";
+            redisTemplate.opsForValue().set(refreshToken, memberId);
+
+            // when
+            authService.deleteRefreshToken(refreshToken);
+
+            // then
+            assertThat(redisTemplate.keys(refreshToken).size()).isZero();
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #688 

## 📝 작업 요약

이전에 인프라 문제로 실패했던 테스트 컨테이너를 사용한 갱신 토큰에 대한 검증을 추가했습니다.

## ⏰ 소요 시간

10분

## 🔎 작업 상세 설명

없음.

## 🌟 논의 사항

없음.
