### PR TITLE
lightHouse 웹 접근성 93점을 98점으로 올렸음

### DIFF
--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/ProgressBar/index.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/ProgressBar/index.tsx
@@ -10,7 +10,7 @@ interface ProgressBarProps {
 export default function ProgressBar({ percent, isSelected }: ProgressBarProps) {
   return (
     <S.Container>
-      <S.Bar progress={percent} $isSelected={isSelected} />
+      <S.Bar $progress={percent} $isSelected={isSelected} />
     </S.Container>
   );
 }

--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/ProgressBar/style.ts
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/ProgressBar/style.ts
@@ -8,10 +8,10 @@ export const Container = styled.div`
   background-color: rgba(0, 0, 0, 0.15);
 `;
 
-export const Bar = styled.div<{ progress: number; $isSelected: boolean }>`
+export const Bar = styled.div<{ $progress: number; $isSelected: boolean }>`
   border-radius: 4px;
 
-  width: ${({ progress }) => `${progress}%`};
+  width: ${({ $progress }) => `${$progress}%`};
   height: 8px;
 
   background-color: ${({ $isSelected }) => ($isSelected ? 'var(--primary-color)' : '#9F9F9F')};

--- a/frontend/src/components/post/Post/index.tsx
+++ b/frontend/src/components/post/Post/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext, useEffect } from 'react';
+import { ForwardedRef, forwardRef, memo, useContext, useEffect } from 'react';
 
 import { PostInfo } from '@type/post';
 
@@ -29,7 +29,10 @@ interface PostProps {
   isPreview: boolean;
 }
 
-export default memo(function Post({ postInfo, isPreview }: PostProps) {
+const Post = forwardRef(function Post(
+  { postInfo, isPreview }: PostProps,
+  ref: ForwardedRef<HTMLLIElement>
+) {
   const {
     postId,
     category,
@@ -110,7 +113,7 @@ export default memo(function Post({ postInfo, isPreview }: PostProps) {
   const isPreviewTabIndex = isPreview ? undefined : 0;
 
   return (
-    <S.Container as={isPreview ? 'li' : 'div'}>
+    <S.Container as={isPreview ? 'li' : 'div'} ref={ref}>
       <S.DetailLink
         as={isPreview ? '' : 'main'}
         to={isPreview ? `${PATH.POST}/${postId}` : '#'}
@@ -195,3 +198,5 @@ export default memo(function Post({ postInfo, isPreview }: PostProps) {
     </S.Container>
   );
 });
+
+export default memo(Post);

--- a/frontend/src/components/post/Post/index.tsx
+++ b/frontend/src/components/post/Post/index.tsx
@@ -113,7 +113,7 @@ const Post = forwardRef(function Post(
   const isPreviewTabIndex = isPreview ? undefined : 0;
 
   return (
-    <S.Container as={isPreview ? 'li' : 'div'} ref={ref}>
+    <S.Container as={isPreview ? 'li' : 'div'} ref={ref} $isPreview={isPreview}>
       <S.DetailLink
         as={isPreview ? '' : 'main'}
         to={isPreview ? `${PATH.POST}/${postId}` : '#'}

--- a/frontend/src/components/post/Post/style.ts
+++ b/frontend/src/components/post/Post/style.ts
@@ -4,7 +4,7 @@ import { styled } from 'styled-components';
 
 import { theme } from '@styles/theme';
 
-export const Container = styled.li`
+export const Container = styled.li<{ $isPreview: boolean }>`
   width: 100%;
 
   position: relative;
@@ -12,6 +12,9 @@ export const Container = styled.li`
   font: var(--text-small);
   letter-spacing: 0.5px;
   line-height: 1.5;
+
+  padding-bottom: ${({ $isPreview }) => $isPreview && '30px'};
+  border-bottom: ${({ $isPreview }) => $isPreview && '1px solid rgba(0, 0, 0, 0.1)'};
 
   @media (min-width: ${theme.breakpoint.sm}) {
     font: var(--text-caption);

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -62,7 +62,7 @@ export default function PostList() {
 
   return (
     <S.Container>
-      <button ref={topButtonRef} role="contentinfo" aria-label="최상단입니다"></button>
+      <button ref={topButtonRef} role="contentinfo" aria-label="최상단입니다" />
       <S.SelectContainer>
         <S.SelectWrapper>
           <Select<PostStatus>
@@ -108,10 +108,7 @@ export default function PostList() {
               return <Post key={post.postId} isPreview={true} postInfo={post} />;
             })}
             <li key={`${pageIndex}UserButton`}>
-              <S.HiddenButton
-                onClick={focusTopContent}
-                aria-label="스크롤 맨 위로가기"
-              ></S.HiddenButton>
+              <S.HiddenButton onClick={focusTopContent} aria-label="스크롤 맨 위로가기" />
               <S.HiddenLink aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE} />
             </li>
           </React.Fragment>

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -107,17 +107,17 @@ export default function PostList() {
 
               return <Post key={post.postId} isPreview={true} postInfo={post} />;
             })}
-            <li>
-              <S.HiddenButton
+            <li key={`${pageIndex}UserButton`}>
+              <S.HiddenList
+                role="button"
                 onClick={focusTopContent}
                 aria-label="스크롤 맨 위로가기"
-              ></S.HiddenButton>
-            </li>
-            <li>
+              ></S.HiddenList>
               <S.HiddenLink
+                role="link"
                 aria-label="게시글 작성 페이지로 이동"
                 to={PATH.POST_WRITE}
-              ></S.HiddenLink>
+              />
             </li>
           </React.Fragment>
         ))}

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -108,11 +108,11 @@ export default function PostList() {
               return <Post key={post.postId} isPreview={true} postInfo={post} />;
             })}
             <li key={`${pageIndex}UserButton`}>
-              <S.HiddenList
+              <S.HiddenButton
                 role="button"
                 onClick={focusTopContent}
                 aria-label="스크롤 맨 위로가기"
-              ></S.HiddenList>
+              ></S.HiddenButton>
               <S.HiddenLink
                 role="link"
                 aria-label="게시글 작성 페이지로 이동"

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -109,15 +109,10 @@ export default function PostList() {
             })}
             <li key={`${pageIndex}UserButton`}>
               <S.HiddenButton
-                role="button"
                 onClick={focusTopContent}
                 aria-label="스크롤 맨 위로가기"
               ></S.HiddenButton>
-              <S.HiddenLink
-                role="link"
-                aria-label="게시글 작성 페이지로 이동"
-                to={PATH.POST_WRITE}
-              />
+              <S.HiddenLink aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE} />
             </li>
           </React.Fragment>
         ))}

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -102,23 +102,23 @@ export default function PostList() {
           <React.Fragment key={pageIndex}>
             {postListInfo.postList.map((post, index) => {
               if (index === 7) {
-                return (
-                  <div key={post.postId} ref={targetRef}>
-                    <Post isPreview={true} postInfo={post} />
-                  </div>
-                );
+                return <Post key={post.postId} ref={targetRef} isPreview={true} postInfo={post} />;
               }
 
               return <Post key={post.postId} isPreview={true} postInfo={post} />;
             })}
-            <S.HiddenButton
-              onClick={focusTopContent}
-              aria-label="스크롤 맨 위로가기"
-            ></S.HiddenButton>
-            <S.HiddenLink
-              aria-label="게시글 작성 페이지로 이동"
-              to={PATH.POST_WRITE}
-            ></S.HiddenLink>
+            <li>
+              <S.HiddenButton
+                onClick={focusTopContent}
+                aria-label="스크롤 맨 위로가기"
+              ></S.HiddenButton>
+            </li>
+            <li>
+              <S.HiddenLink
+                aria-label="게시글 작성 페이지로 이동"
+                to={PATH.POST_WRITE}
+              ></S.HiddenLink>
+            </li>
           </React.Fragment>
         ))}
         {isFetchingNextPage && <Skeleton isLarge={false} />}

--- a/frontend/src/components/post/PostList/style.ts
+++ b/frontend/src/components/post/PostList/style.ts
@@ -30,11 +30,6 @@ export const PostListContainer = styled.ul`
 
   padding: 30px 20px;
 
-  > div > li {
-    padding-bottom: 30px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  }
-
   > li {
     padding-bottom: 30px;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);

--- a/frontend/src/components/post/PostList/style.ts
+++ b/frontend/src/components/post/PostList/style.ts
@@ -44,6 +44,10 @@ export const SelectWrapper = styled.div`
   }
 `;
 
+export const HiddenButton = styled.button`
+  position: absolute;
+`;
+
 export const HiddenLink = styled(Link)`
   position: absolute;
 `;

--- a/frontend/src/components/post/PostList/style.ts
+++ b/frontend/src/components/post/PostList/style.ts
@@ -29,11 +29,6 @@ export const PostListContainer = styled.ul`
   gap: 30px;
 
   padding: 30px 20px;
-
-  > li {
-    padding-bottom: 30px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  }
 `;
 
 export const SelectWrapper = styled.div`
@@ -49,10 +44,11 @@ export const SelectWrapper = styled.div`
   }
 `;
 
-export const HiddenButton = styled.button`
+export const HiddenLink = styled(Link)`
   position: absolute;
 `;
 
-export const HiddenLink = styled(Link)`
-  position: absolute;
+export const HiddenList = styled.li`
+  padding-bottom: none;
+  border-bottom: none;
 `;

--- a/frontend/src/components/post/PostList/style.ts
+++ b/frontend/src/components/post/PostList/style.ts
@@ -51,8 +51,3 @@ export const HiddenButton = styled.button`
 export const HiddenLink = styled(Link)`
   position: absolute;
 `;
-
-export const HiddenList = styled.li`
-  padding-bottom: none;
-  border-bottom: none;
-`;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #700 

## 📝 작업 요약

라이트 하우스 웹 접근성 점수를93점에서 98점으로 올림

## ⏰ 소요 시간

1시간

## 🔎 작업 상세 설명

- forwardRef로 Post에서 ref를 받도록 하여 기존에 div -> li로 사용하던 코드 삭제
- 스타일드 컴포넌트 props에서 $를 안붙히고 사용하던 코드 수정

<img width="1440" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/51e269e8-65e8-4aaa-8574-417e9ccd4bfc">


### 이전의 점수 기록은 해당 이슈에 정리 해놓았습니다

https://github.com/woowacourse-teams/2023-votogether/issues/700



## 🌟 논의 사항

웹 접근성에서 우리 색이 자꾸 대비가 낮다고 하는데 저는 무시하고 싶어요 얘네들이 권장하는 색까지 대비를 해보았더니 너무 안이쁘더라구요

### 대비 색 해볼수 있는 사이트

https://dequeuniversity.com/rules/axe/4.7/color-contrast



<img width="509" alt="image" src="https://github.com/woowacourse-teams/2023-votogether/assets/80146176/bbc55bba-a784-4bf9-b68d-ca30b6b92444">




