### PR TITLE
게시글 작성 시 본문 링크 삽입을 하지 않더라도 사용자에게 링크 클릭이 가능하도록 변경

### DIFF
--- a/frontend/__test__/convertTextToUrl.test.ts
+++ b/frontend/__test__/convertTextToUrl.test.ts
@@ -22,6 +22,10 @@ test.each([
     '[[https://votogether.com/ranking]] https://www.naver.com/',
     '[[https://votogether.com/ranking]] [[https://www.naver.com/]]',
   ],
+  [
+    'www.naver.com www.naver.com www.naver.com https://www.npmjs.com/package/dotenv-webpack',
+    '[[www.naver.com]] [[www.naver.com]] [[www.naver.com]] [[https://www.npmjs.com/package/dotenv-webpack]]',
+  ],
 ])(
   'convertTextToUrl 함수에서 링크가 포함된 문자를 입력했을 때 문자에서 링크는 [[]]로 감싸서 반환한다.',
   (word, expectedWord) => {

--- a/frontend/__test__/convertTextToUrl.test.ts
+++ b/frontend/__test__/convertTextToUrl.test.ts
@@ -1,0 +1,32 @@
+import { convertTextToUrl } from '@utils/post/convertTextToUrl';
+
+test.each([
+  ['www.naver.com 이걸 어째', '[[www.naver.com]] 이걸 어째'],
+  [
+    '반갑다 https://github.com/woowacourse-teams/2023-votogether/issues/703    임',
+    '반갑다 [[https://github.com/woowacourse-teams/2023-votogether/issues/703]]    임',
+  ],
+  ['안녕 wwwww.naver.com', '안녕 wwwww.naver.com'],
+  ['http://localhost:3000/ 피카츄', '[[http://localhost:3000/]] 피카츄'],
+  [
+    'http://localhost:3000/http://localhost:3000/ 피카츄',
+    '[[http://localhost:3000/http://localhost:3000/]] 피카츄',
+  ],
+  ['www.naver.com', '[[www.naver.com]]'],
+  ['[[www.naver.com]] www.naver.com', '[[www.naver.com]] [[www.naver.com]]'],
+  [
+    '[[http://localhost:3000/]] http://localhost:3000/',
+    '[[http://localhost:3000/]] [[http://localhost:3000/]]',
+  ],
+  [
+    '[[https://votogether.com/ranking]] https://www.naver.com/',
+    '[[https://votogether.com/ranking]] [[https://www.naver.com/]]',
+  ],
+])(
+  'convertTextToUrl 함수에서 링크가 포함된 문자를 입력했을 때 문자에서 링크는 [[]]로 감싸서 반환한다.',
+  (word, expectedWord) => {
+    const result = convertTextToUrl(word);
+
+    expect(result).toBe(expectedWord);
+  }
+);

--- a/frontend/src/components/PostForm/index.tsx
+++ b/frontend/src/components/PostForm/index.tsx
@@ -101,11 +101,7 @@ export default function PostForm({ data, mutate, isSubmitting }: PostFormProps) 
   };
 
   const { text: writingTitle, handleTextChange: handleTitleChange } = useText(title ?? '');
-  const {
-    text: writingContent,
-    handleTextChange: handleContentChange,
-    addText: addContent,
-  } = useText(content ?? '');
+  const { text: writingContent, handleTextChange: handleContentChange } = useText(content ?? '');
   const multiSelectHook = useMultiSelect(categoryIds ?? [], POST_CATEGORY.MAX_AMOUNT);
 
   const handleDeadlineButtonClick = (option: DeadlineOptionInfo) => {
@@ -126,10 +122,6 @@ export default function PostForm({ data, mutate, isSubmitting }: PostFormProps) 
       };
       setTime(updatedTime);
     }
-  };
-
-  const handleInsertContentLink = () => {
-    addContent('[[이 괄호 안에 링크를 작성해주세요]] ');
   };
 
   const handlePostFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -223,11 +215,6 @@ export default function PostForm({ data, mutate, isSubmitting }: PostFormProps) 
               onPaste={handlePasteImage}
               required
             />
-            <S.ContentLinkButtonWrapper>
-              <S.Button onClick={handleInsertContentLink} type="button">
-                본문에 링크 넣기
-              </S.Button>
-            </S.ContentLinkButtonWrapper>
             <S.ContentImagePartWrapper $hasImage={!!contentImageHook.contentImage}>
               <ContentImagePart size="lg" contentImageHook={contentImageHook} />
             </S.ContentImagePartWrapper>

--- a/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
@@ -26,12 +26,7 @@ export default function CommentTextForm({
   initialComment,
   handleCancelClick,
 }: CommentTextFormProps) {
-  const {
-    text: content,
-    handleTextChange,
-    resetText,
-    addText: addContent,
-  } = useText(initialComment.content);
+  const { text: content, handleTextChange, resetText } = useText(initialComment.content);
   const { isToastOpen, openToast, toastMessage } = useToast();
 
   const params = useParams() as { postId: string };
@@ -111,16 +106,6 @@ export default function CommentTextForm({
             </SquareButton>
           </S.ButtonWrapper>
         )}
-        <S.ButtonWrapper>
-          <SquareButton
-            aria-label="댓글에 링크 넣기"
-            onClick={() => addContent('[[괄호 안에 링크 작성]] ')}
-            theme="blank"
-            type="button"
-          >
-            링크 넣기
-          </SquareButton>
-        </S.ButtonWrapper>
         <S.ButtonWrapper>
           <SquareButton
             aria-label="댓글 저장"

--- a/frontend/src/components/post/Post/index.tsx
+++ b/frontend/src/components/post/Post/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useContext, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { PostInfo } from '@type/post';
 
@@ -30,6 +31,7 @@ interface PostProps {
 }
 
 export default memo(function Post({ postInfo, isPreview }: PostProps) {
+  const navigate = useNavigate();
   const {
     postId,
     category,
@@ -112,8 +114,14 @@ export default memo(function Post({ postInfo, isPreview }: PostProps) {
   return (
     <S.Container as={isPreview ? 'li' : 'div'}>
       <S.DetailLink
+        role={isPreview ? 'link' : 'none'}
+        tabIndex={0}
         as={isPreview ? '' : 'main'}
-        to={isPreview ? `${PATH.POST}/${postId}` : '#'}
+        onClick={() => {
+          if (!isPreview) return;
+
+          navigate(`${PATH.POST}/${postId}`);
+        }}
         $isPreview={isPreview}
         aria-describedby={
           isPreview
@@ -164,7 +172,7 @@ export default memo(function Post({ postInfo, isPreview }: PostProps) {
           aria-label={`내용: ${content}`}
           $isPreview={isPreview}
         >
-          {convertTextToElement(content, !isPreview)}
+          {convertTextToElement(content)}
         </S.Content>
         {!isPreview && imageUrl && <S.Image src={imageUrl} alt={'본문에 포함된 이미지'} />}
       </S.DetailLink>

--- a/frontend/src/components/post/Post/index.tsx
+++ b/frontend/src/components/post/Post/index.tsx
@@ -164,7 +164,7 @@ export default memo(function Post({ postInfo, isPreview }: PostProps) {
           aria-label={`내용: ${content}`}
           $isPreview={isPreview}
         >
-          {convertTextToElement(content)}
+          {convertTextToElement(content, !isPreview)}
         </S.Content>
         {!isPreview && imageUrl && <S.Image src={imageUrl} alt={'본문에 포함된 이미지'} />}
       </S.DetailLink>

--- a/frontend/src/components/post/Post/style.ts
+++ b/frontend/src/components/post/Post/style.ts
@@ -1,5 +1,3 @@
-import { Link } from 'react-router-dom';
-
 import { styled } from 'styled-components';
 
 import { theme } from '@styles/theme';
@@ -91,10 +89,12 @@ export const Content = styled.div<{ $isPreview: boolean }>`
   }
 `;
 
-export const DetailLink = styled(Link)<{ $isPreview: boolean }>`
+export const DetailLink = styled.button<{ $isPreview: boolean }>`
   display: flex;
   flex-direction: column;
   gap: 10px;
+
+  cursor: ${({ $isPreview }) => $isPreview && 'pointer'};
 `;
 
 export const Image = styled.img`

--- a/frontend/src/hooks/useText.ts
+++ b/frontend/src/hooks/useText.ts
@@ -26,9 +26,5 @@ export const useText = (originalText: string) => {
     setText('');
   };
 
-  const addText = (newTextToAdd: string) => {
-    setText(text + newTextToAdd);
-  };
-
-  return { text, setText, handleTextChange, resetText, addText };
+  return { text, setText, handleTextChange, resetText };
 };

--- a/frontend/src/utils/post/convertTextToElement.tsx
+++ b/frontend/src/utils/post/convertTextToElement.tsx
@@ -1,7 +1,10 @@
+import { convertTextToUrl } from './convertTextToUrl';
+
 export const convertTextToElement = (text: string) => {
+  const convertedUrlText = convertTextToUrl(text);
   const linkPattern = /\[\[([^[\]]+)\]\]/g;
 
-  const parts = text.split(linkPattern);
+  const parts = convertedUrlText.split(linkPattern);
 
   const elementList = parts.map((part, index) => {
     if (index % 2 === 1) {

--- a/frontend/src/utils/post/convertTextToElement.tsx
+++ b/frontend/src/utils/post/convertTextToElement.tsx
@@ -1,13 +1,13 @@
 import { convertTextToUrl } from './convertTextToUrl';
 
-export const convertTextToElement = (text: string) => {
+export const convertTextToElement = (text: string, isLinkEnabled = true) => {
   const convertedUrlText = convertTextToUrl(text);
   const linkPattern = /\[\[([^[\]]+)\]\]/g;
 
   const parts = convertedUrlText.split(linkPattern);
 
   const elementList = parts.map((part, index) => {
-    if (index % 2 === 1) {
+    if (index % 2 === 1 && isLinkEnabled) {
       // 링크
       const linkText = part;
       const linkUrl = linkText.startsWith('http' || 'https') ? linkText : `https://${linkText}`;
@@ -25,7 +25,7 @@ export const convertTextToElement = (text: string) => {
     }
 
     // 링크가 아닌 문자열
-    return <span>{part}</span>;
+    return <span key={index}>{part}</span>;
   });
 
   return elementList;

--- a/frontend/src/utils/post/convertTextToElement.tsx
+++ b/frontend/src/utils/post/convertTextToElement.tsx
@@ -1,14 +1,12 @@
+import { MouseEvent } from 'react';
+
 import { convertTextToUrl } from './convertTextToUrl';
 
-export const convertTextToElement = (text: string, isLinkEnabled = true) => {
+export const convertTextToElement = (text: string) => {
   const convertedUrlText = convertTextToUrl(text);
   const linkPattern = /\[\[([^[\]]+)\]\]/g;
 
   const parts = convertedUrlText.split(linkPattern);
-
-  if (!isLinkEnabled) {
-    return parts.join('');
-  }
 
   const elementList = parts.map((part, index) => {
     if (index % 2 === 1) {
@@ -17,6 +15,9 @@ export const convertTextToElement = (text: string, isLinkEnabled = true) => {
       const linkUrl = linkText.startsWith('http' || 'https') ? linkText : `https://${linkText}`;
       return (
         <a
+          onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+            event.stopPropagation();
+          }}
           key={index}
           href={linkUrl}
           target="_blank"

--- a/frontend/src/utils/post/convertTextToElement.tsx
+++ b/frontend/src/utils/post/convertTextToElement.tsx
@@ -6,8 +6,12 @@ export const convertTextToElement = (text: string, isLinkEnabled = true) => {
 
   const parts = convertedUrlText.split(linkPattern);
 
+  if (!isLinkEnabled) {
+    return parts.join('');
+  }
+
   const elementList = parts.map((part, index) => {
-    if (index % 2 === 1 && isLinkEnabled) {
+    if (index % 2 === 1) {
       // 링크
       const linkText = part;
       const linkUrl = linkText.startsWith('http' || 'https') ? linkText : `https://${linkText}`;

--- a/frontend/src/utils/post/convertTextToUrl.ts
+++ b/frontend/src/utils/post/convertTextToUrl.ts
@@ -8,7 +8,7 @@
  * (?!\]\]) 는 뒤에 ]]로 끝나는 지 여부를 확인한다.
  * [^\s] 는 공백이 아닌 문자인지 여부를 확인한다.
  */
-const httpsOrHttpRegex = /(?<!\[\[)(https?:\/\/[^\s]+)(?!\]\])/;
+const httpsOrHttpRegex = /(?<!\[\[)(https?:\/\/[^\s]+)(?!\]\])/g;
 
 /**
  * www.naver.com
@@ -19,7 +19,7 @@ const httpsOrHttpRegex = /(?<!\[\[)(https?:\/\/[^\s]+)(?!\]\])/;
  * [^\s] 는 공백이 아닌 문자인지 여부를 확인한다.
  * (?!\]\]) 는 뒤에 ]]로 끝나는 지 여부를 확인한다.
  */
-const wwwRegex = /(?<!\[\[)(?<!\/)\b(w{3})\b[^\s]+(?!\]\])/;
+const wwwRegex = /(?<!\[\[)(?<!\/)\b(w{3})\b[^\s]+(?!\]\])/g;
 
 export const convertTextToUrl = (text: string) => {
   const httpOrHttpsConvertedText = text.replace(httpsOrHttpRegex, url => `[[${url}]]`);

--- a/frontend/src/utils/post/convertTextToUrl.ts
+++ b/frontend/src/utils/post/convertTextToUrl.ts
@@ -3,22 +3,27 @@
  * https://votogether.com/
  * http://localhost:3000/posts/100035
  * http://votogether.com/
- * ^reg는 뒤의 문자열로 시작하는지 여부를 확인한다.
- * /w 는 영문, 숫자, 언더바 문자에 매칭된다. [A-Za-z0-9_] 와 동일하다.
+ * (?<!\[\[) 는 앞에 [[로 시작하는 지 여부를 확인한다
+ * https?:\/\/는 http:// 혹은 https:// 로 시작하는 지 여부를 확인한다.
+ * (?!\]\]) 는 뒤에 ]]로 끝나는 지 여부를 확인한다.
+ * [^\s] 는 공백이 아닌 문자인지 여부를 확인한다.
  */
-const httpsOrHttpRegex = /^https?:\/\/[\w]/;
+const httpsOrHttpRegex = /(?<!\[\[)(https?:\/\/[^\s]+)(?!\]\])/;
 
 /**
  * www.naver.com
  * www.tistory.com
- * ^reg는 뒤의 문자열로 시작하는지 여부를 확인한다.
- * /w 는 영문, 숫자, 언더바 문자에 매칭된다. [A-Za-z0-9_] 와 동일하다.
+ * (?<!\[\[) 는 앞에 [[로 시작하는 지 여부를 확인한다
+ * (?<!\/)는 앞에 /로 시작하는 지 여부를 확인한다. https://www 에서 www 앞에 /가 있기에 중복되어 확인하는 것을 방지하기 위함
+ * \b(w{3})\b 는 www로 시작하는 지 여부를 정확히 확인한다. w가 4개인 경우 판별하지 않음
+ * [^\s] 는 공백이 아닌 문자인지 여부를 확인한다.
+ * (?!\]\]) 는 뒤에 ]]로 끝나는 지 여부를 확인한다.
  */
-const wwwRegex = /^www\.[\w]/;
+const wwwRegex = /(?<!\[\[)(?<!\/)\b(w{3})\b[^\s]+(?!\]\])/;
 
 export const convertTextToUrl = (text: string) => {
-  const wwwConvertedText = text.replaceAll(wwwRegex, `[[$]]`);
-  const httpOrHttpsConvertedText = wwwConvertedText.replaceAll(httpsOrHttpRegex, `[[$]]`);
+  const httpOrHttpsConvertedText = text.replace(httpsOrHttpRegex, url => `[[${url}]]`);
+  const wwwConvertedText = httpOrHttpsConvertedText.replace(wwwRegex, url => `[[${url}]]`);
 
-  return httpOrHttpsConvertedText;
+  return wwwConvertedText;
 };

--- a/frontend/src/utils/post/convertTextToUrl.ts
+++ b/frontend/src/utils/post/convertTextToUrl.ts
@@ -1,0 +1,24 @@
+/**
+ * https://abc.co.kr/@abc/4
+ * https://votogether.com/
+ * http://localhost:3000/posts/100035
+ * http://votogether.com/
+ * ^reg는 뒤의 문자열로 시작하는지 여부를 확인한다.
+ * /w 는 영문, 숫자, 언더바 문자에 매칭된다. [A-Za-z0-9_] 와 동일하다.
+ */
+const httpsOrHttpRegex = /^https?:\/\/[\w]/;
+
+/**
+ * www.naver.com
+ * www.tistory.com
+ * ^reg는 뒤의 문자열로 시작하는지 여부를 확인한다.
+ * /w 는 영문, 숫자, 언더바 문자에 매칭된다. [A-Za-z0-9_] 와 동일하다.
+ */
+const wwwRegex = /^www\.[\w]/;
+
+export const convertTextToUrl = (text: string) => {
+  const wwwConvertedText = text.replaceAll(wwwRegex, `[[$]]`);
+  const httpOrHttpsConvertedText = wwwConvertedText.replaceAll(httpsOrHttpRegex, `[[$]]`);
+
+  return httpOrHttpsConvertedText;
+};


### PR DESCRIPTION
## 🔥 연관 이슈

close: #703 

## 📝 작업 요약

- 게시글 작성 시 본문 링크 삽입을 하지 않더라도 사용자에게 링크 클릭이 가능하도록 변경

## ⏰ 소요 시간

2시간

## 🔎 작업 상세 설명

- 본문 링크 삽입 시 [[ ]] 을 붙혀주고 있는데, 이걸 작성자에게 붙히도록 하지 않고 렌더링 시 http | https | www 로 시작하는 문자를 정규표현식을 이용하여 [[ 주소 ]]를 붙혀주도록 함
- 이 때 기존의 사용되던 [[ 링크 ]] 텍스트가 있다면 변환되지 않도록 하였음 
- 현재 홈에서 게시글 본문에 링크가 있다면 a 태그 내부에 a 태그가 있다는 에러가 나는데 본문에서 링크 렌더링 시 span으로 렌더되도록 수정

### 개선 전

![image](https://github.com/woowacourse-teams/2023-votogether/assets/80146176/dcdad30c-9e51-4dfa-a371-f64354d46873)
![image](https://github.com/woowacourse-teams/2023-votogether/assets/80146176/ab155f2e-8bde-4272-aa47-59342043c707)

#### 콘솔에서 key를 설정하라는 에러와 a 태그 내부에 a 태그가 있으면 안된다는 에러

```
react-jsx-runtime.development.js:87 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `Post`. See https://reactjs.org/link/warning-keys for more information.
```
```
react_devtools_backend_compact.js:13096 Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
    at a
```

![image](https://github.com/woowacourse-teams/2023-votogether/assets/80146176/f8edaece-13d4-403f-a747-f44e54b4798b)



### 개선 후

https://github.com/woowacourse-teams/2023-votogether/assets/80146176/39254188-91a6-4758-9f51-2ee8d25df5d5

#### 에러 개수 0인 모습

![image](https://github.com/woowacourse-teams/2023-votogether/assets/80146176/e1f2b392-b28b-4434-a042-5c6e53030e2e)


## 참고자료

https://regex101.com/r/dVEb0X/1  (정규 표현식 테스트 사이트)

https://teco.chat/chats/1015 (GPT와 페어 프로그래밍)


