### PR TITLE
[REFACTOR] 투표 도메인 리팩터링

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/votogether/domain/post/entity/Post.java
@@ -4,11 +4,6 @@ import com.votogether.domain.category.entity.Category;
 import com.votogether.domain.common.BaseEntity;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.post.entity.comment.Comment;
-import com.votogether.domain.post.exception.PostExceptionType;
-import com.votogether.domain.post.exception.PostOptionExceptionType;
-import com.votogether.domain.vote.entity.Vote;
-import com.votogether.domain.vote.exception.VoteExceptionType;
-import com.votogether.global.exception.BadRequestException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -128,38 +123,7 @@ public class Post extends BaseEntity {
         this.postDeadline.close();
     }
 
-    public Vote makeVote(final Member voter, final PostOption postOption) {
-        validateDeadLine();
-        validateVoter(voter);
-        validatePostOption(postOption);
-
-        final Vote vote = Vote.builder()
-                .member(voter)
-                .build();
-
-        postOption.addVote(vote);
-        return vote;
-    }
-
-    public void validateDeadLine() {
-        if (isClosed()) {
-            throw new BadRequestException(PostExceptionType.CLOSED);
-        }
-    }
-
-    private void validateVoter(final Member voter) {
-        if (Objects.equals(this.writer.getId(), voter.getId())) {
-            throw new BadRequestException(VoteExceptionType.CANNOT_VOTE_MY_POST);
-        }
-    }
-
-    private void validatePostOption(final PostOption postOption) {
-        if (!hasPostOption(postOption)) {
-            throw new BadRequestException(PostOptionExceptionType.NOT_FOUND);
-        }
-    }
-
-    private boolean hasPostOption(final PostOption postOption) {
+    public boolean hasPostOption(final PostOption postOption) {
         return this.postOptions.contains(postOption);
     }
 

--- a/backend/src/main/java/com/votogether/domain/vote/controller/VoteControllerDocs.java
+++ b/backend/src/main/java/com/votogether/domain/vote/controller/VoteControllerDocs.java
@@ -23,7 +23,11 @@ public interface VoteControllerDocs {
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class))),
             @ApiResponse(
                     responseCode = "404",
-                    description = "1.존재하지 않는 게시글\t\n2.존재하지 않는 선택지",
+                    description = """
+                            1.존재하지 않는 게시글
+                                                        
+                            2.존재하지 않는 선택지
+                            """,
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     })
     ResponseEntity<Void> vote(
@@ -37,7 +41,11 @@ public interface VoteControllerDocs {
             @ApiResponse(responseCode = "200", description = "투표 수정 성공"),
             @ApiResponse(
                     responseCode = "404",
-                    description = "1.존재하지 않는 게시글\t\n2.존재하지 않는 선택지",
+                    description = """
+                            1.존재하지 않는 게시글
+                                                        
+                            2.존재하지 않는 선택지
+                            """,
                     content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     })
     ResponseEntity<Void> changeVote(

--- a/backend/src/main/java/com/votogether/domain/vote/entity/Vote.java
+++ b/backend/src/main/java/com/votogether/domain/vote/entity/Vote.java
@@ -41,11 +41,8 @@ public class Vote extends BaseEntity {
         this.postOption = postOption;
     }
 
-    public boolean isVoteByMember(final Member member) {
-        return this.member.equals(member);
-    }
-
     public void setPostOption(final PostOption postOption) {
         this.postOption = postOption;
     }
+    
 }

--- a/backend/src/main/java/com/votogether/domain/vote/entity/Vote.java
+++ b/backend/src/main/java/com/votogether/domain/vote/entity/Vote.java
@@ -3,6 +3,8 @@ package com.votogether.domain.vote.entity;
 import com.votogether.domain.common.BaseEntity;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.post.entity.PostOption;
+import com.votogether.domain.vote.exception.VoteExceptionType;
+import com.votogether.global.exception.BadRequestException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -37,12 +39,19 @@ public class Vote extends BaseEntity {
 
     @Builder
     private Vote(final Member member, final PostOption postOption) {
+        validateVotingRights(member, postOption);
         this.member = member;
         this.postOption = postOption;
+    }
+
+    private void validateVotingRights(final Member member, final PostOption postOption) {
+        if (postOption.getPost().isWriter(member)) {
+            throw new BadRequestException(VoteExceptionType.CANNOT_VOTE_MY_POST);
+        }
     }
 
     public void setPostOption(final PostOption postOption) {
         this.postOption = postOption;
     }
-    
+
 }

--- a/backend/src/main/java/com/votogether/domain/vote/exception/VoteExceptionType.java
+++ b/backend/src/main/java/com/votogether/domain/vote/exception/VoteExceptionType.java
@@ -6,11 +6,10 @@ import lombok.Getter;
 @Getter
 public enum VoteExceptionType implements ExceptionType {
 
-    CANNOT_VOTE_MY_POST(700, "해당 게시글 작성자는 투표할 수 없습니다."),
+    CANNOT_VOTE_MY_POST(700, "게시글 작성자는 투표할 수 없습니다."),
     NOT_FOUND(701, "참여한 투표가 존재하지 않습니다."),
     ALREADY_VOTED(702, "이미 참여한 투표입니다."),
     ;
-
 
     private final int code;
     private final String message;

--- a/backend/src/test/java/com/votogether/domain/vote/entity/VoteTest.java
+++ b/backend/src/test/java/com/votogether/domain/vote/entity/VoteTest.java
@@ -1,0 +1,31 @@
+package com.votogether.domain.vote.entity;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.post.entity.Post;
+import com.votogether.domain.post.entity.PostOption;
+import com.votogether.global.exception.BadRequestException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class VoteTest {
+
+    @Test
+    @DisplayName("게시글 작성자가 투표를 하면 예외가 발생한다.")
+    void voteException() {
+        // given
+        Member writer = Member.builder().nickname("글쓴이").build();
+        ReflectionTestUtils.setField(writer, "id", 1L);
+        Post post = Post.builder().title("제목").content("내용").deadline(LocalDateTime.now()).writer(writer).build();
+        PostOption postOption = PostOption.builder().post(post).content("내용").build();
+
+        // when, then
+        assertThatThrownBy(() -> Vote.builder().member(writer).postOption(postOption).build())
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("게시글 작성자는 투표할 수 없습니다.");
+    }
+
+}

--- a/backend/src/test/java/com/votogether/domain/vote/service/VoteServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/vote/service/VoteServiceTest.java
@@ -1,0 +1,248 @@
+package com.votogether.domain.vote.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.votogether.domain.member.entity.Member;
+import com.votogether.domain.post.entity.Post;
+import com.votogether.domain.post.entity.PostOption;
+import com.votogether.domain.post.repository.PostOptionRepository;
+import com.votogether.domain.post.repository.PostRepository;
+import com.votogether.domain.vote.entity.Vote;
+import com.votogether.domain.vote.repository.VoteRepository;
+import com.votogether.global.exception.BadRequestException;
+import com.votogether.global.exception.NotFoundException;
+import com.votogether.test.ServiceTest;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class VoteServiceTest extends ServiceTest {
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    VoteRepository voteRepository;
+
+    @Autowired
+    PostOptionRepository postOptionRepository;
+
+    @Autowired
+    VoteService voteService;
+
+    @Nested
+    @DisplayName("게시글에 투표 시")
+    class vote {
+
+        @Test
+        @DisplayName("투표 성공.")
+        void vote() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOption = postTestPersister.postOptionBuilder().post(post).save();
+            post.addPostOption(postOption);
+
+            // when
+            voteService.vote(member, post.getId(), postOption.getId());
+
+            // then
+            int count = voteRepository.countByMember(member);
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("본인의 게시글에 투표하는 경우 예외 발생")
+        void vote1() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().writer(member).save();
+            PostOption postOption = postTestPersister.postOptionBuilder().post(post).save();
+            post.addPostOption(postOption);
+
+            // when, then
+            assertThatThrownBy(() -> voteService.vote(member, post.getId(), postOption.getId()))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("게시글 작성자는 투표할 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("마감기간이 지난 게시글인 경우 예외 발생")
+        void vote2() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().deadline(LocalDateTime.now().minusDays(1L)).save();
+            PostOption postOption = postTestPersister.postOptionBuilder().post(post).save();
+            post.addPostOption(postOption);
+
+            // when, then
+            assertThatThrownBy(() -> voteService.vote(member, post.getId(), postOption.getId()))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("게시글이 마감되었습니다.");
+        }
+
+        @Test
+        @DisplayName("게시글에 해당되는 투표 선택지가 아닌 경우 예외 발생")
+        void vote3() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOptionA = postTestPersister.postOptionBuilder().post(post).save();
+            post.addPostOption(postOptionA);
+            PostOption postOptionB = postTestPersister.postOptionBuilder().save();
+
+            // when, then
+            assertThatThrownBy(() -> voteService.vote(member, post.getId(), postOptionB.getId()))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("게시글 투표 옵션이 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("이미 해당 선택지에 투표를 한 경우 예외 발생")
+        void vote4() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOption = postTestPersister.postOptionBuilder().post(post).save();
+            post.addPostOption(postOption);
+            voteTestPersister.builder().member(member).postOption(postOption).save();
+
+            // when, then
+            assertThatThrownBy(() -> voteService.vote(member, post.getId(), postOption.getId()))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessage("이미 참여한 투표입니다.");
+        }
+
+        @Test
+        @DisplayName("게시글이 존재하지 않는 경우 예외 발생")
+        void vote5() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOption = postTestPersister.postOptionBuilder().post(post).save();
+            post.addPostOption(postOption);
+            voteTestPersister.builder().member(member).postOption(postOption).save();
+
+            // when, then
+            assertThatThrownBy(() -> voteService.vote(member, -1L, postOption.getId()))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("게시글이 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("투표 선택지 옵션이 존재하지 않는 경우 예외 발생")
+        void vote6() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOption = postTestPersister.postOptionBuilder().post(post).save();
+            post.addPostOption(postOption);
+            voteTestPersister.builder().member(member).postOption(postOption).save();
+
+            // when, then
+            assertThatThrownBy(() -> voteService.vote(member, post.getId(), -1L))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("게시글 투표 옵션이 존재하지 않습니다.");
+        }
+
+    }
+
+    @Nested
+    @DisplayName("게시글의 투표 변경 시")
+    class changingVote {
+
+        @Test
+        @DisplayName("변경 성공.")
+        void changeVote() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOptionA = postTestPersister.postOptionBuilder().post(post).sequence(1).save();
+            PostOption postOptionB = postTestPersister.postOptionBuilder().post(post).sequence(2).save();
+            post.addPostOption(postOptionA);
+            post.addPostOption(postOptionB);
+            voteService.vote(member, post.getId(), postOptionA.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            voteService.changeVote(member, post.getId(), postOptionA.getId(), postOptionB.getId());
+
+            // then
+            Vote vote = voteRepository.findAllByMember(member).get(0);
+            assertThat(vote.getPostOption().getId()).isEqualTo(postOptionB.getId());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글인 경우 예외 발생")
+        void changeVote1() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOptionA = postTestPersister.postOptionBuilder().post(post).sequence(1).save();
+            PostOption postOptionB = postTestPersister.postOptionBuilder().post(post).sequence(2).save();
+            post.addPostOption(postOptionA);
+            post.addPostOption(postOptionB);
+            voteService.vote(member, post.getId(), postOptionA.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            // when, then
+            assertThatThrownBy(() -> voteService.changeVote(member, -1L, postOptionA.getId(), postOptionB.getId()))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("게시글이 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("이전 투표가 존재 하지 않는 경우 예외 발생")
+        void changeVote2() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOptionA = postTestPersister.postOptionBuilder().post(post).sequence(1).save();
+            PostOption postOptionB = postTestPersister.postOptionBuilder().post(post).sequence(2).save();
+            PostOption postOptionC = postTestPersister.postOptionBuilder().save();
+            post.addPostOption(postOptionA);
+            post.addPostOption(postOptionB);
+            voteService.vote(member, post.getId(), postOptionA.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            // when, then
+            assertThatThrownBy(
+                    () -> voteService.changeVote(member, post.getId(), postOptionC.getId(), postOptionB.getId()))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("참여한 투표가 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("게시글 선택지가 존재하지 않는 경우 예외 발생")
+        void changeVote3() {
+            // given
+            Member member = memberTestPersister.builder().save();
+            Post post = postTestPersister.postBuilder().save();
+            PostOption postOptionA = postTestPersister.postOptionBuilder().post(post).sequence(1).save();
+            PostOption postOptionB = postTestPersister.postOptionBuilder().post(post).sequence(2).save();
+            post.addPostOption(postOptionA);
+            post.addPostOption(postOptionB);
+            voteService.vote(member, post.getId(), postOptionA.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            // when, then
+            assertThatThrownBy(
+                    () -> voteService.changeVote(member, post.getId(), -1L, postOptionB.getId()))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("게시글 투표 옵션이 존재하지 않습니다.");
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #514 

## 📝 작업 요약

- Vote 도메인을 리펙터링 하였습니다.
- 기존에는 Post가 Vote를 생성하였는데 VoteService에서 생성하도록 하여 의존도를 분리했습니다.
- Post에서 투표에 대한 검증 로직을 VoteService와 Vote에 위임하여 예외처리 책임을 분리했습니다.
- VoteSerivce의 테스트 코드를 추가하였습니다.

## ⏰ 소요 시간

3시간

## 🔎 작업 상세 설명

## 🌟 논의 사항
