### PR TITLE
Cmd(Ctrl) + Enter를 입력했을 때 댓글이 작성되도록 구현

### DIFF
--- a/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect } from 'react';
+import { ChangeEvent, KeyboardEvent, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Comment } from '@type/comment';
@@ -61,6 +61,14 @@ export default function CommentTextForm({
     createComment({ content: deleteOverlappingNewLine(content) });
   };
 
+  const handleKeyboardCommentSubmit = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    const isPressCtrlEnterKey = event.ctrlKey && event.key === 'Enter';
+
+    if (isPressCtrlEnterKey) {
+      handleUpdateComment();
+    }
+  };
+
   useEffect(() => {
     isCreateSuccess && resetText();
   }, [isCreateSuccess]);
@@ -92,6 +100,7 @@ export default function CommentTextForm({
         value={content}
         placeholder="댓글을 입력해주세요. &#13;&#10;타인의 권리를 침해하거나 도배성/광고성/음란성 내용을 포함하는 경우, 댓글의 운영 원칙 및 관련 법률에 의하여 제재를 받을 수 있습니다."
         onChange={(e: ChangeEvent<HTMLTextAreaElement>) => handleTextChange(e, POST_COMMENT)}
+        onKeyDown={handleKeyboardCommentSubmit}
       />
       <S.ButtonContainer>
         {isEdit && (

--- a/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
@@ -62,9 +62,9 @@ export default function CommentTextForm({
   };
 
   const handleKeyboardCommentSubmit = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    const isPressCtrlEnterKey = event.ctrlKey && event.key === 'Enter';
+    const isPressCtrlAndEnterKey = event.ctrlKey && event.key === 'Enter';
 
-    if (isPressCtrlEnterKey) {
+    if (isPressCtrlAndEnterKey) {
       handleUpdateComment();
     }
   };


### PR DESCRIPTION
## 🔥 연관 이슈

close: #732 

## 📝 작업 요약

- Cmd(Ctrl) + Enter를 입력했을 때 댓글이 작성되도록 구현

## ⏰ 소요 시간

10분

## 🔎 작업 상세 설명

- Ctrl + Enter를 입력했을 때 댓글이 작성되도록 구현
- Cmd + Enter가 되는 지는 캠퍼스의 맥북을 이용해서 테스트해봐야될 것 같음
- KeyboardEvent의 event.ctrlKey , event.code을 통해서 구현

