### PR TITLE
배너 공지사항 조회 / 공지사항 목록 조회 / 공지사항 상세 조회 / 공지사항 수정 / 공지사항 삭제 / 공지사항 생성 api 구현 및 query hook 구현

### DIFF
--- a/frontend/__test__/api/notice.test.ts
+++ b/frontend/__test__/api/notice.test.ts
@@ -1,0 +1,71 @@
+import {
+  createNotice,
+  deleteNotice,
+  getBannerNotice,
+  getNoticeDetail,
+  getNoticeList,
+  modifyNotice,
+} from '@api/notice';
+
+import { MOCK_TRANSFORM_NOTICE, MOCK_TRANSFORM_NOTICE_LIST } from '@mocks/mockData/notice';
+import { MOCK_NOTICE_TEST } from '@mocks/notice';
+
+describe('서버와 통신하여 공지사항 관련된 api를 통신할 수 있어야 한다. ', () => {
+  test('공지사항을 생성한다.', async () => {
+    const data = {
+      title: '갤럭시',
+      content: '공지사항입니다',
+      deadline: '2023-10-12 15:13',
+      bannerTitle: '아이폰',
+      bannerSubtitle: '공지사항입니다',
+    };
+
+    await createNotice(data);
+
+    const result = MOCK_NOTICE_TEST;
+
+    expect(result).toBe(data.title);
+  });
+
+  test('배너 공지 사항을 조회한다.', async () => {
+    const result = await getBannerNotice();
+
+    expect(result).toEqual(MOCK_TRANSFORM_NOTICE);
+  });
+
+  test('공지 사항 목록을 조회한다.', async () => {
+    const result = await getNoticeList(0);
+
+    expect(result).toEqual(MOCK_TRANSFORM_NOTICE_LIST);
+  });
+
+  test('공지 사항의 상세 내용을 조회한다.', async () => {
+    const result = await getNoticeDetail(1);
+
+    expect(result).toEqual(MOCK_TRANSFORM_NOTICE);
+  });
+
+  test('공지 사항을 수정한다.', async () => {
+    const data = {
+      title: '아이폰입니다',
+      content: '공지사항입니다',
+      deadline: '2023-10-12 15:13',
+      bannerTitle: '아이폰',
+      bannerSubtitle: '공지사항입니다',
+    };
+
+    await modifyNotice({ noticeId: 0, notice: data });
+
+    const result = MOCK_NOTICE_TEST;
+
+    expect(result).toBe(data.title);
+  });
+
+  test('공지 사항을 삭제한다.', async () => {
+    await deleteNotice(1);
+
+    const result = MOCK_NOTICE_TEST;
+
+    expect(result).toBe('삭제된 공지사항');
+  });
+});

--- a/frontend/__test__/hooks/query/notice/useBannerNotice.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useBannerNotice.test.tsx
@@ -1,0 +1,24 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useBannerNotice } from '@hooks';
+
+import { MOCK_TRANSFORM_NOTICE } from '@mocks/mockData/notice';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useBannerNotice 훅이 배너 공지사항을 불러오는지 확인한다.', () => {
+  test('배너 공지사항을 확인한다', async () => {
+    const { result } = renderHook(() => useBannerNotice(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(MOCK_TRANSFORM_NOTICE));
+  });
+});

--- a/frontend/__test__/hooks/query/notice/useBannerNotice.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useBannerNotice.test.tsx
@@ -13,7 +13,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-describe('useBannerNotice 훅이 배너 공지사항을 불러오는지 확인한다.', () => {
+describe('배너 공지사항을 불러오는지 확인한다.', () => {
   test('배너 공지사항을 확인한다', async () => {
     const { result } = renderHook(() => useBannerNotice(), {
       wrapper,

--- a/frontend/__test__/hooks/query/notice/useCreateNotice.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useCreateNotice.test.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useCreateNotice } from '@hooks';
+
+import { MOCK_NOTICE_TEST } from '@mocks/notice';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useCreateNotice 훅이 공지 사항을 생성하는 지 확인한다.', () => {
+  test('공지 사항을 생성한다.', async () => {
+    const data = {
+      title: '갤럭시',
+      content: '공지사항입니다',
+      deadline: '2023-10-12 15:13',
+      bannerTitle: '아이폰',
+      bannerSubtitle: '공지사항입니다',
+    };
+
+    const { result } = renderHook(() => useCreateNotice(), {
+      wrapper,
+    });
+
+    const { mutate } = result.current;
+
+    await waitFor(() => {
+      mutate(data);
+
+      expect(MOCK_NOTICE_TEST).toBe(data.title);
+    });
+  });
+});

--- a/frontend/__test__/hooks/query/notice/useCreateNotice.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useCreateNotice.test.tsx
@@ -13,7 +13,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-describe('useCreateNotice 훅이 공지 사항을 생성하는 지 확인한다.', () => {
+describe('공지 사항을 생성하는 지 확인한다.', () => {
   test('공지 사항을 생성한다.', async () => {
     const data = {
       title: '갤럭시',

--- a/frontend/__test__/hooks/query/notice/useDeleteNotice.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useDeleteNotice.test.tsx
@@ -1,0 +1,30 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useDeleteNotice } from '@hooks';
+
+import { MOCK_NOTICE_TEST } from '@mocks/notice';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useDeleteNotice 훅이 공지 사항을 삭제하는 지 확인한다.', () => {
+  test('공지 사항을 삭제한다.', async () => {
+    const { result } = renderHook(() => useDeleteNotice(), {
+      wrapper,
+    });
+
+    const { mutate } = result.current;
+
+    await waitFor(() => {
+      mutate(1);
+
+      expect(MOCK_NOTICE_TEST).toBe('삭제된 공지사항');
+    });
+  });
+});

--- a/frontend/__test__/hooks/query/notice/useDeleteNotice.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useDeleteNotice.test.tsx
@@ -13,7 +13,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-describe('useDeleteNotice 훅이 공지 사항을 삭제하는 지 확인한다.', () => {
+describe('요청을 통해 공지 사항을 삭제하는 지 확인한다.', () => {
   test('공지 사항을 삭제한다.', async () => {
     const { result } = renderHook(() => useDeleteNotice(), {
       wrapper,

--- a/frontend/__test__/hooks/query/notice/useModifyNotice.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useModifyNotice.test.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useModifyNotice } from '@hooks';
+
+import { MOCK_NOTICE_TEST } from '@mocks/notice';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useModifyNotice 훅이 공지 사항을 수정하는 지 확인한다.', () => {
+  test('공지 사항을 생성한다.', async () => {
+    const data = {
+      title: '아이폰입니다',
+      content: '공지사항입니다',
+      deadline: '2023-10-12 15:13',
+      bannerTitle: '아이폰',
+      bannerSubtitle: '공지사항입니다',
+    };
+
+    const { result } = renderHook(() => useModifyNotice(), {
+      wrapper,
+    });
+
+    const { mutate } = result.current;
+
+    await waitFor(() => {
+      mutate({ notice: data, noticeId: 1 });
+
+      expect(MOCK_NOTICE_TEST).toEqual(data.title);
+    });
+  });
+});

--- a/frontend/__test__/hooks/query/notice/useModifyNotice.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useModifyNotice.test.tsx
@@ -13,7 +13,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-describe('useModifyNotice 훅이 공지 사항을 수정하는 지 확인한다.', () => {
+describe('요청을 통해 공지 사항을 수정하는 지 확인한다.', () => {
   test('공지 사항을 생성한다.', async () => {
     const data = {
       title: '아이폰입니다',

--- a/frontend/__test__/hooks/query/notice/useNoticeDetail.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useNoticeDetail.test.tsx
@@ -13,7 +13,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-describe('useNoticeDetail 훅이 공지 사항 상세 정보를 불러오는 지 확인한다.', () => {
+describe('공지 사항 상세 정보를 불러오는 지 확인한다.', () => {
   test('공지 사항 상세 정보를 불러온다.', async () => {
     const { result } = renderHook(() => useNoticeDetail(1), {
       wrapper,

--- a/frontend/__test__/hooks/query/notice/useNoticeDetail.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useNoticeDetail.test.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useNoticeDetail } from '@hooks';
+
+import { MOCK_TRANSFORM_NOTICE } from '@mocks/mockData/notice';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useNoticeDetail 훅이 공지 사항 상세 정보를 불러오는 지 확인한다.', () => {
+  test('공지 사항 상세 정보를 불러온다.', async () => {
+    const { result } = renderHook(() => useNoticeDetail(1), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(MOCK_TRANSFORM_NOTICE);
+    });
+  });
+});

--- a/frontend/__test__/hooks/query/notice/usePagedNoticeList.test.tsx
+++ b/frontend/__test__/hooks/query/notice/usePagedNoticeList.test.tsx
@@ -14,7 +14,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-describe('usePagedNoticeList 훅이 공지 사항 리스트를 페이지 버튼을 눌러 불러오는 지 확인한다.', () => {
+describe('페이지 버튼을 눌러 공지 사항 리스트를 불러오는 지 확인한다.', () => {
   test('초기 설정으로는 0 페이지를 불러온다.', async () => {
     const { result } = renderHook(() => usePagedNoticeList(), {
       wrapper,
@@ -25,7 +25,7 @@ describe('usePagedNoticeList 훅이 공지 사항 리스트를 페이지 버튼�
     });
   });
 
-  test('초기 페이지를 인자를 넣어 설정할 수 있다..', async () => {
+  test('초기 페이지를 인자를 넣어 설정할 수 있다.', async () => {
     const { result } = renderHook(() => usePagedNoticeList(5), {
       wrapper,
     });

--- a/frontend/__test__/hooks/query/notice/usePagedNoticeList.test.tsx
+++ b/frontend/__test__/hooks/query/notice/usePagedNoticeList.test.tsx
@@ -1,0 +1,139 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+
+import { usePagedNoticeList } from '@hooks';
+
+import { MOCK_TRANSFORM_NOTICE_LIST } from '@mocks/mockData/notice';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('usePagedNoticeList 훅이 공지 사항 리스트를 페이지 버튼을 눌러 불러오는 지 확인한다.', () => {
+  test('초기 설정으로는 0 페이지를 불러온다.', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(), {
+      wrapper,
+    });
+
+    waitFor(() => {
+      expect(result.current.page).toEqual(0);
+    });
+  });
+
+  test('초기 페이지를 인자를 넣어 설정할 수 있다..', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(5), {
+      wrapper,
+    });
+
+    waitFor(() => {
+      expect(result.current.page).toEqual(5);
+    });
+  });
+
+  test('현재 페이지를 3으로 설정했을 때 3페이지를 데이터만 불러온다. 클라이언트 측에서 3으로 설정했어도 서버로는 2를 보내야 하기 때문에 현재 페이지는 2로 설정된다.', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.setPage(3);
+    });
+
+    waitFor(() => {
+      expect(result.current.page).toEqual(2);
+    });
+  });
+
+  test('현재 페이지가 0이고, 다음 페이지를 불러올 때 현재 페이지 + 1을 하여 불러온다.', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(), {
+      wrapper,
+    });
+
+    const currentPage = result.current.page;
+
+    act(() => {
+      result.current.fetchNextPage();
+    });
+
+    waitFor(() => {
+      expect(result.current.page).toEqual(currentPage + 1);
+    });
+  });
+
+  test('현재 페이지가 5이고, 이전의 페이지를 불러올 때 현재 페이지 - 1을 하여 불러온다.', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(5), {
+      wrapper,
+    });
+
+    waitFor(() => {
+      result.current.fetchPrevPage();
+
+      expect(result.current.page).toEqual(3);
+    });
+  });
+
+  test('총 페이지보다 현재 페이지가 작다면 다음 페이지 여부를 반환하는 변수가 true로 동작한다.', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(), {
+      wrapper,
+    });
+
+    const totalPage = MOCK_TRANSFORM_NOTICE_LIST.totalPageNumber;
+
+    const currentPage = result.current.page;
+
+    act(() => {
+      result.current.setPage(totalPage + 1);
+    });
+
+    waitFor(() => {
+      expect(totalPage > currentPage).toBe(true);
+      expect(result.current.hasNextPage).toBe(true);
+    });
+  });
+
+  test('총 페이지와 현재 페이지가 같다면 다음 페이지 여부를 반환하는 변수가 false로 동작한다.', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(), {
+      wrapper,
+    });
+
+    const totalPage = MOCK_TRANSFORM_NOTICE_LIST.totalPageNumber;
+
+    const currentPage = result.current.page;
+
+    act(() => {
+      result.current.setPage(totalPage + 1);
+    });
+
+    waitFor(() => {
+      expect(totalPage === currentPage).toBe(true);
+      expect(result.current.hasNextPage).toBe(false);
+    });
+  });
+
+  test('공지 사항 목록 0 페이지를 불러온다.', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(MOCK_TRANSFORM_NOTICE_LIST);
+    });
+  });
+
+  test('공지 사항 목록 0 페이지를 불러오고 페이지 설정을 통해 3페이지를 불러온다. 페이지 설정 버튼을 누른다면 해당 페이지의 데이터 1개를 배열로 보내준다.', async () => {
+    const { result } = renderHook(() => usePagedNoticeList(), {
+      wrapper,
+    });
+
+    result.current.setPage(3);
+
+    act(() => {
+      expect(result.current.data).toEqual(MOCK_TRANSFORM_NOTICE_LIST);
+    });
+  });
+});

--- a/frontend/__test__/hooks/query/notice/useStackedNoticeList.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useStackedNoticeList.test.tsx
@@ -1,0 +1,42 @@
+import React, { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+
+import { useStackedNoticeList } from '@hooks';
+
+import { MOCK_TRANSFORM_NOTICE_LIST } from '@mocks/mockData/notice';
+
+const queryClient = new QueryClient();
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('useStackedNoticeList 훅이 공지 사항 리스트를 불러오는 지 확인한다.', () => {
+  test('공지 사항 목록 0 페이지를 불러온다.', async () => {
+    const { result } = renderHook(() => useStackedNoticeList(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages[0]).toEqual(MOCK_TRANSFORM_NOTICE_LIST);
+    });
+  });
+
+  test('공지 사항 목록 0 페이지를 불러온다. 그리고 다음 페이지를 불러온다', async () => {
+    const { result } = renderHook(() => useStackedNoticeList(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages[0]).toEqual(MOCK_TRANSFORM_NOTICE_LIST);
+      expect(result.current.data?.pages[1]).toEqual(MOCK_TRANSFORM_NOTICE_LIST);
+    });
+  });
+});

--- a/frontend/__test__/hooks/query/notice/useStackedNoticeList.test.tsx
+++ b/frontend/__test__/hooks/query/notice/useStackedNoticeList.test.tsx
@@ -14,7 +14,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
-describe('useStackedNoticeList 훅이 공지 사항 리스트를 불러오는 지 확인한다.', () => {
+describe('더보기 버튼을 눌러 공지 사항 리스트 데이터를 불러와서 여러 페이지의 데이터를 가지고 있는 지 확인한다..', () => {
   test('공지 사항 목록 0 페이지를 불러온다.', async () => {
     const { result } = renderHook(() => useStackedNoticeList(), {
       wrapper,

--- a/frontend/src/api/notice.ts
+++ b/frontend/src/api/notice.ts
@@ -10,7 +10,7 @@ export const transformNotice = ({
   deadline,
   bannerTitle,
   bannerSubtitle,
-}: NoticeResponse): Notice => {
+}: Notice): Notice => {
   return {
     id,
     title,
@@ -22,23 +22,13 @@ export const transformNotice = ({
   };
 };
 
-export interface NoticeResponse {
-  id: number;
-  title: string;
-  content: string;
-  createdAt: string;
-  deadline: string;
-  bannerTitle: string;
-  bannerSubtitle: string;
-}
-
 export interface NoticeListResponse {
   totalPageNumber: number;
   currentPageNumber: number;
-  notices: NoticeResponse[];
+  notices: Notice[];
 }
 
-export type NoticeRequest = Omit<NoticeResponse, 'createdAt' | 'id'>;
+export type NoticeRequest = Omit<Notice, 'createdAt' | 'id'>;
 
 const BASE_URL = process.env.VOTOGETHER_BASE_URL ?? '';
 
@@ -47,7 +37,7 @@ export const createNotice = async (notice: NoticeRequest) => {
 };
 
 export const getBannerNotice = async () => {
-  const bannerNotice = await getFetch<NoticeResponse>(`${BASE_URL}/notices/progress`);
+  const bannerNotice = await getFetch<Notice>(`${BASE_URL}/notices/progress`);
 
   return transformNotice(bannerNotice);
 };
@@ -63,7 +53,7 @@ export const getNoticeList = async (page: number): Promise<NoticeList> => {
 };
 
 export const getNoticeDetail = async (noticeId: number) => {
-  const noticeDetail = await getFetch<NoticeResponse>(`${BASE_URL}/notices/${noticeId}`);
+  const noticeDetail = await getFetch<Notice>(`${BASE_URL}/notices/${noticeId}`);
 
   return transformNotice(noticeDetail);
 };

--- a/frontend/src/api/notice.ts
+++ b/frontend/src/api/notice.ts
@@ -1,0 +1,83 @@
+import { Notice, NoticeList } from '@type/notice';
+
+import { deleteFetch, getFetch, patchFetch, postFetch } from '@utils/fetch';
+
+export const transformNotice = ({
+  id,
+  title,
+  content,
+  createdAt,
+  deadline,
+  bannerTitle,
+  bannerSubtitle,
+}: NoticeResponse): Notice => {
+  return {
+    id,
+    title,
+    content,
+    createdAt,
+    deadline,
+    bannerTitle,
+    bannerSubtitle,
+  };
+};
+
+export interface NoticeResponse {
+  id: number;
+  title: string;
+  content: string;
+  createdAt: string;
+  deadline: string;
+  bannerTitle: string;
+  bannerSubtitle: string;
+}
+
+export interface NoticeListResponse {
+  totalPageNumber: number;
+  currentPageNumber: number;
+  notices: NoticeResponse[];
+}
+
+export type NoticeRequest = Omit<NoticeResponse, 'createdAt' | 'id'>;
+
+const BASE_URL = process.env.VOTOGETHER_BASE_URL ?? '';
+
+export const createNotice = async (notice: NoticeRequest) => {
+  await postFetch(`${BASE_URL}/notices`, notice);
+};
+
+export const getBannerNotice = async () => {
+  const bannerNotice = await getFetch<NoticeResponse>(`${BASE_URL}/notices/progress`);
+
+  return transformNotice(bannerNotice);
+};
+
+export const getNoticeList = async (page: number): Promise<NoticeList> => {
+  const noticeListInfo = await getFetch<NoticeListResponse>(`${BASE_URL}/notices?page=${page}`);
+
+  return {
+    totalPageNumber: noticeListInfo.totalPageNumber,
+    currentPageNumber: noticeListInfo.currentPageNumber,
+    noticeList: noticeListInfo.notices.map(notice => transformNotice(notice)),
+  };
+};
+
+export const getNoticeDetail = async (noticeId: number) => {
+  const noticeDetail = await getFetch<NoticeResponse>(`${BASE_URL}/notices/${noticeId}`);
+
+  return transformNotice(noticeDetail);
+};
+
+export const modifyNotice = async ({
+  noticeId,
+  notice,
+}: {
+  noticeId: number;
+  notice: NoticeRequest;
+}) => {
+  return await patchFetch(`${BASE_URL}/notices/${noticeId}`, notice);
+};
+
+export const deleteNotice = async (noticeId: number) => {
+  return await deleteFetch(`${BASE_URL}/notices/${noticeId}`);
+};

--- a/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect } from 'react';
+import { ChangeEvent, KeyboardEvent, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Comment } from '@type/comment';
@@ -61,6 +61,14 @@ export default function CommentTextForm({
     createComment({ content: deleteOverlappingNewLine(content) });
   };
 
+  const handleKeyboardCommentSubmit = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    const isPressCtrlAndEnterKey = (event.metaKey || event.ctrlKey) && event.key === 'Enter';
+
+    if (isPressCtrlAndEnterKey) {
+      handleUpdateComment();
+    }
+  };
+
   useEffect(() => {
     isCreateSuccess && resetText();
   }, [isCreateSuccess]);
@@ -92,7 +100,9 @@ export default function CommentTextForm({
         value={content}
         placeholder="댓글을 입력해주세요. &#13;&#10;타인의 권리를 침해하거나 도배성/광고성/음란성 내용을 포함하는 경우, 댓글의 운영 원칙 및 관련 법률에 의하여 제재를 받을 수 있습니다."
         onChange={(e: ChangeEvent<HTMLTextAreaElement>) => handleTextChange(e, POST_COMMENT)}
+        onKeyDown={handleKeyboardCommentSubmit}
       />
+      <S.KeyDescription>Ctrl(Command) + Enter 키로 댓글을 저장할 수 있습니다</S.KeyDescription>
       <S.ButtonContainer>
         {isEdit && (
           <S.ButtonWrapper>

--- a/frontend/src/components/comment/CommentList/CommentTextForm/style.ts
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/style.ts
@@ -25,8 +25,7 @@ export const TextArea = styled.textarea`
 
   @media (max-width: ${theme.breakpoint.sm}) {
     &::placeholder {
-      font-size: 1.2rem;
-      line-height: 2rem;
+      font: var(--text-small);
     }
   }
 
@@ -63,8 +62,7 @@ export const KeyDescription = styled.span`
   margin-top: 20px;
 
   text-align: right;
-  font: var(--text-caption);
-  font-size: 1.2rem;
+  font: var(--text-small);
 
   color: var(--dark-gray);
 

--- a/frontend/src/components/comment/CommentList/CommentTextForm/style.ts
+++ b/frontend/src/components/comment/CommentList/CommentTextForm/style.ts
@@ -20,12 +20,12 @@ export const TextArea = styled.textarea`
   resize: none;
 
   &::placeholder {
-    font-size: 14px;
+    font-size: 1.4rem;
   }
 
   @media (max-width: ${theme.breakpoint.sm}) {
     &::placeholder {
-      font-size: 12px;
+      font-size: 1.2rem;
       line-height: 2rem;
     }
   }
@@ -56,5 +56,19 @@ export const ButtonWrapper = styled.div`
     height: 46px;
 
     font: var(--text-body);
+  }
+`;
+
+export const KeyDescription = styled.span`
+  margin-top: 20px;
+
+  text-align: right;
+  font: var(--text-caption);
+  font-size: 1.2rem;
+
+  color: var(--dark-gray);
+
+  @media (min-width: ${theme.breakpoint.sm}) {
+    font-size: 1.4rem;
   }
 `;

--- a/frontend/src/components/common/Drawer/index.tsx
+++ b/frontend/src/components/common/Drawer/index.tsx
@@ -35,9 +35,9 @@ export default forwardRef(function Drawer(
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDialogElement>) => {
-    event.preventDefault();
-
     if (event.currentTarget.open && event.key === 'Escape') {
+      event.preventDefault();
+
       handleDrawerClose();
     }
   };
@@ -56,7 +56,6 @@ export default forwardRef(function Drawer(
     >
       <S.CloseButton onClick={handleDrawerClose}>사이드바 닫기버튼</S.CloseButton>
       {children}
-      <div style={{ backgroundColor: 'red', width: '100%', height: '100%' }} />
     </S.Dialog>
   );
 });

--- a/frontend/src/components/common/ImageZoomModal/ImageZoomModal.stories.tsx
+++ b/frontend/src/components/common/ImageZoomModal/ImageZoomModal.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { useImageZoomModal } from '@hooks/useImageZoomModal';
+
+import { theme } from '@styles/theme';
+
+import ImageZoomModal from '.';
+
+const meta: Meta<typeof ImageZoomModal> = {
+  component: ImageZoomModal,
+};
+
+export default meta;
+type Story = StoryObj<typeof ImageZoomModal>;
+
+export const Default: Story = {
+  render: () => <ImageZoomModalStory />,
+};
+
+function ImageZoomModalStory() {
+  const { closeZoomModal, handleCloseClick, handleImageClick, imageSrc, zoomModalRef } =
+    useImageZoomModal();
+
+  return (
+    <>
+      <Container>
+        {IMAGE_URL_LIST.map(item => (
+          <Image key={item} src={item} onClick={handleImageClick} />
+        ))}
+      </Container>
+      <ImageZoomModal
+        src={imageSrc}
+        closeZoomModal={closeZoomModal}
+        handleCloseClick={handleCloseClick}
+        ref={zoomModalRef}
+      />
+    </>
+  );
+}
+
+const getRandomImageUrl = (signal: number) => `https://source.unsplash.com/random/sig=${signal}`;
+
+const IMAGE_URL_LIST = Array.from({ length: 50 }, (__, index) => getRandomImageUrl(index));
+
+const Container = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 15px;
+
+  @media (min-width: ${theme.breakpoint.md}) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  @media (min-width: ${theme.breakpoint.lg}) {
+    grid-template-columns: repeat(5, 1fr);
+  }
+`;
+
+const Image = styled.img`
+  width: 100%;
+  object-fit: contain;
+
+  cursor: pointer;
+`;

--- a/frontend/src/components/common/ImageZoomModal/index.tsx
+++ b/frontend/src/components/common/ImageZoomModal/index.tsx
@@ -1,0 +1,36 @@
+import { ForwardedRef, MouseEvent, forwardRef } from 'react';
+
+import cancel from '@assets/x_mark_black.svg';
+
+import * as S from './style';
+
+interface ImageZoomModalProps {
+  src: string;
+  handleCloseClick: (event: MouseEvent<HTMLDialogElement>) => void;
+  closeZoomModal: () => void;
+}
+
+const ImageZoomModal = forwardRef(function ImageZoomModal(
+  { src, handleCloseClick, closeZoomModal }: ImageZoomModalProps,
+  ref: ForwardedRef<HTMLDialogElement>
+) {
+  return (
+    <S.Dialog
+      ref={ref}
+      tabIndex={1}
+      aria-label="이미지를 확대해서 볼 수 있는 창이 열렸습니다. 이미지 확대 창 닫기 버튼을 누르거나 ESC를 누르면 닫을 수 있습니다."
+      aria-modal={true}
+      onClick={handleCloseClick}
+    >
+      <S.Container>
+        <S.HiddenCloseButton onClick={closeZoomModal}>이미지 확대 창 닫기</S.HiddenCloseButton>
+        <S.CloseButton onClick={closeZoomModal} aria-label="이미지 확대 창 닫기">
+          <S.IconImage src={cancel} alt="취소 아이콘" />
+        </S.CloseButton>
+        <S.Image src={src}></S.Image>
+      </S.Container>
+    </S.Dialog>
+  );
+});
+
+export default ImageZoomModal;

--- a/frontend/src/components/common/ImageZoomModal/style.ts
+++ b/frontend/src/components/common/ImageZoomModal/style.ts
@@ -1,0 +1,71 @@
+import { styled } from 'styled-components';
+
+import { theme } from '@styles/theme';
+
+export const Dialog = styled.dialog`
+  position: fixed;
+
+  margin: auto;
+
+  overflow: visible;
+
+  background: none;
+
+  z-index: ${theme.zIndex.modal};
+
+  &::backdrop {
+    background-color: rgba(0, 0, 0, 0.35);
+  }
+`;
+
+export const Container = styled.div`
+  position: relative;
+
+  width: 100%;
+  height: 100%;
+`;
+
+export const HiddenCloseButton = styled.button`
+  position: absolute;
+  top: 0;
+  right: 99999px;
+`;
+
+export const CloseButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  top: -50px;
+  left: 0;
+  right: 0;
+
+  width: fit-content;
+  margin: 0 auto;
+  padding: 8px;
+  border-radius: 50%;
+
+  transition: background-color 0.2s ease-in-out;
+
+  background-color: rgba(255, 255, 255, 0.7);
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 1);
+  }
+`;
+
+export const IconImage = styled.img`
+  width: 24px;
+  height: 24px;
+`;
+
+export const Image = styled.img`
+  width: 100%;
+  height: 100%;
+  max-height: 80vh;
+
+  object-fit: contain;
+`;

--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/index.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/index.tsx
@@ -1,8 +1,11 @@
+import { MouseEvent } from 'react';
+
 import ProgressBar from './ProgressBar';
 import * as S from './style';
 
 interface WrittenVoteOptionProps {
   handleVoteClick: () => void;
+  handleImageClick?: (event: MouseEvent<HTMLImageElement>) => void;
   text: string;
   isStatisticsVisible: boolean;
   peopleCount: number;
@@ -15,6 +18,7 @@ interface WrittenVoteOptionProps {
 
 export default function WrittenVoteOption({
   handleVoteClick,
+  handleImageClick,
   text,
   isStatisticsVisible,
   peopleCount,
@@ -31,7 +35,9 @@ export default function WrittenVoteOption({
       $isSelected={isSelected}
       onClick={handleVoteClick}
     >
-      {!isPreview && imageUrl && <S.Image src={imageUrl} alt={'선택지에 포함된 이미지'} />}
+      {!isPreview && imageUrl && (
+        <S.Image onClick={handleImageClick} src={imageUrl} alt={'선택지에 포함된 이미지'} />
+      )}
       {isPreview ? (
         <S.PreviewContent>{text}</S.PreviewContent>
       ) : (

--- a/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/style.ts
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/WrittenVoteOption/style.ts
@@ -24,11 +24,11 @@ export const Container = styled.button<{ $isSelected: boolean }>`
 `;
 
 export const Image = styled.img`
+  width: 80%;
+
   border-radius: 4px;
   border: 1px solid var(--gray);
-  margin-bottom: 10px;
-
-  width: 80%;
+  margin: 0 auto 10px auto;
 
   aspect-ratio: 1/1;
   object-fit: contain;

--- a/frontend/src/components/optionList/WrittenVoteOptionList/index.tsx
+++ b/frontend/src/components/optionList/WrittenVoteOptionList/index.tsx
@@ -1,3 +1,5 @@
+import { MouseEvent } from 'react';
+
 import { WrittenVoteOptionType } from '@type/post';
 
 import * as S from './style';
@@ -9,6 +11,7 @@ interface WrittenVoteOptionListProps {
   selectedOptionId: number;
   voteOptionList: WrittenVoteOptionType[];
   handleVoteClick: (newOptionId: number) => void;
+  handleImageClick?: (event: MouseEvent<HTMLImageElement>) => void;
 }
 
 export default function WrittenVoteOptionList({
@@ -17,6 +20,7 @@ export default function WrittenVoteOptionList({
   voteOptionList,
   selectedOptionId,
   handleVoteClick,
+  handleImageClick,
 }: WrittenVoteOptionListProps) {
   return (
     <S.VoteOptionListContainer aria-label="투표 선택지">
@@ -39,6 +43,7 @@ export default function WrittenVoteOptionList({
             isStatisticsVisible={isStatisticsVisible}
             isSelected={isSelected}
             handleVoteClick={() => handleVoteClick(voteOption.id)}
+            handleImageClick={handleImageClick}
           />
         );
       })}

--- a/frontend/src/components/post/Post/index.tsx
+++ b/frontend/src/components/post/Post/index.tsx
@@ -8,7 +8,9 @@ import { useToast } from '@hooks';
 import { AuthContext } from '@hooks/context/auth';
 import { useCreateVote } from '@hooks/query/post/useCreateVote';
 import { useEditVote } from '@hooks/query/post/useEditVote';
+import { useImageZoomModal } from '@hooks/useImageZoomModal';
 
+import ImageZoomModal from '@components/common/ImageZoomModal';
 import WrittenVoteOptionList from '@components/optionList/WrittenVoteOptionList';
 
 import { PATH } from '@constants/path';
@@ -50,6 +52,8 @@ const Post = forwardRef(function Post(
   } = postInfo;
   const { loggedInfo } = useContext(AuthContext);
   const { isToastOpen, openToast, toastMessage } = useToast();
+  const { closeZoomModal, handleCloseClick, handleImageClick, imageSrc, zoomModalRef } =
+    useImageZoomModal();
 
   const {
     mutate: createVote,
@@ -177,7 +181,9 @@ const Post = forwardRef(function Post(
         >
           {convertTextToElement(content)}
         </S.Content>
-        {!isPreview && imageUrl && <S.Image src={imageUrl} alt={'본문에 포함된 이미지'} />}
+        {!isPreview && imageUrl && (
+          <S.Image onClick={handleImageClick} src={imageUrl} alt={'본문에 포함된 이미지'} />
+        )}
       </S.DetailLink>
       <WrittenVoteOptionList
         isStatisticsVisible={isStatisticsVisible}
@@ -185,6 +191,7 @@ const Post = forwardRef(function Post(
         handleVoteClick={handleVoteClick}
         isPreview={isPreview}
         voteOptionList={voteInfo.options}
+        handleImageClick={handleImageClick}
       />
       {isPreview && (
         <S.PreviewBottom>
@@ -203,6 +210,12 @@ const Post = forwardRef(function Post(
           {toastMessage}
         </Toast>
       )}
+      <ImageZoomModal
+        ref={zoomModalRef}
+        src={imageSrc}
+        closeZoomModal={closeZoomModal}
+        handleCloseClick={handleCloseClick}
+      />
     </S.Container>
   );
 });

--- a/frontend/src/components/post/Post/style.ts
+++ b/frontend/src/components/post/Post/style.ts
@@ -111,6 +111,8 @@ export const Image = styled.img`
   aspect-ratio: 1/1;
   object-fit: contain;
 
+  cursor: pointer;
+
   @media (min-width: ${theme.breakpoint.md}) {
     margin-bottom: 20px;
   }

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -21,6 +21,8 @@ export const DEFAULT_CATEGORY_ID = 0;
 
 export const POST_AMOUNT_PER_PAGE = 10;
 
+export const NOTICE_AMOUNT_PER_PAGE = 10;
+
 /**
  * 백앤드로 보낼때 검색 쿼리키로 사용하는 문자입니다. ?keyword="검색어"
  */

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -21,8 +21,6 @@ export const DEFAULT_CATEGORY_ID = 0;
 
 export const POST_AMOUNT_PER_PAGE = 10;
 
-export const NOTICE_AMOUNT_PER_PAGE = 10;
-
 /**
  * 백앤드로 보낼때 검색 쿼리키로 사용하는 문자입니다. ?keyword="검색어"
  */

--- a/frontend/src/constants/queryKey.ts
+++ b/frontend/src/constants/queryKey.ts
@@ -7,4 +7,5 @@ export const QUERY_KEY = {
   PASSION_RANKING: 'passionRanking',
   POPULAR_RANKING: 'popularRanking',
   VOTE_STATISTICS: 'voteStatistics',
+  NOTICE: 'notice',
 };

--- a/frontend/src/hooks/index.tsx
+++ b/frontend/src/hooks/index.tsx
@@ -35,6 +35,15 @@ import { usePassionUserRanking } from './query/ranking/usePassionUserRanking';
 import { usePopularPostRanking } from './query/ranking/usePopularPostRanking';
 import { useUserRanking } from './query/ranking/useUserRanking';
 
+// 공지 사항 리엑트 쿼리 훅
+import { useBannerNotice } from './query/notice/useBannerNotice';
+import { useCreateNotice } from './query/notice/useCreateNotice';
+import { useDeleteNotice } from './query/notice/useDeleteNotice';
+import { useModifyNotice } from './query/notice/useModifyNotice';
+import { usePagedNoticeList } from './query/notice/usePagedNoticeList';
+import { useNoticeDetail } from './query/notice/useNoticeDetail';
+import { useStackedNoticeList } from './query/notice/useStackedNoticeList';
+
 // 컨텍스트 커스텀 훅
 import { AuthContext } from './context/auth';
 import { PostOptionContext } from './context/postOption';
@@ -96,6 +105,13 @@ export {
   useCreateComment,
   useDeleteComment,
   useEditComment,
+  useBannerNotice,
+  useCreateNotice,
+  useDeleteNotice,
+  useModifyNotice,
+  usePagedNoticeList,
+  useNoticeDetail,
+  useStackedNoticeList,
 };
 
 export { AuthContext, PostOptionContext };

--- a/frontend/src/hooks/query/notice/useBannerNotice.tsx
+++ b/frontend/src/hooks/query/notice/useBannerNotice.tsx
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { Notice } from '@type/notice';
+
+import { getBannerNotice } from '@api/notice';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useBannerNotice = () => {
+  const { data, isError, isLoading, error } = useQuery<Notice>(
+    [QUERY_KEY.NOTICE],
+    getBannerNotice,
+    {
+      suspense: true,
+      cacheTime: 30 * 60 * 1000,
+      staleTime: 30 * 60 * 1000,
+      onSuccess: data => {
+        return data;
+      },
+      onError: () => {
+        console.error('배너 공지 사항을 불러오는데 실패했습니다');
+      },
+    }
+  );
+
+  return { data, isError, isLoading, error };
+};

--- a/frontend/src/hooks/query/notice/useCreateNotice.tsx
+++ b/frontend/src/hooks/query/notice/useCreateNotice.tsx
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { NoticeRequest, createNotice } from '@api/notice';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useCreateNotice = () => {
+  const queryClient = useQueryClient();
+  const { mutate, isLoading, isSuccess, isError, error } = useMutation(
+    (notice: NoticeRequest) => createNotice(notice),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries([QUERY_KEY.NOTICE]);
+      },
+      onError: error => {
+        window.console.log('공지 사항 생성에 실패했습니다');
+      },
+    }
+  );
+
+  return { mutate, isLoading, isSuccess, isError, error };
+};

--- a/frontend/src/hooks/query/notice/useDeleteNotice.tsx
+++ b/frontend/src/hooks/query/notice/useDeleteNotice.tsx
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteNotice } from '@api/notice';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useDeleteNotice = () => {
+  const queryClient = useQueryClient();
+  const { mutate, isLoading, isSuccess, isError, error } = useMutation(
+    (noticeId: number) => deleteNotice(noticeId),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries([QUERY_KEY.NOTICE]);
+      },
+      onError: error => {
+        window.console.log('공지 사항 삭제에 실패했습니다');
+      },
+    }
+  );
+
+  return { mutate, isLoading, isSuccess, isError, error };
+};

--- a/frontend/src/hooks/query/notice/useModifyNotice.tsx
+++ b/frontend/src/hooks/query/notice/useModifyNotice.tsx
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { NoticeRequest, modifyNotice } from '@api/notice';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useModifyNotice = () => {
+  const queryClient = useQueryClient();
+  const { mutate, isLoading, isSuccess, isError, error } = useMutation(
+    ({ noticeId, notice }: { notice: NoticeRequest; noticeId: number }) =>
+      modifyNotice({ notice, noticeId }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries([QUERY_KEY.NOTICE]);
+      },
+      onError: error => {
+        window.console.log('공지 사항 수정에 실패했습니다');
+      },
+    }
+  );
+
+  return { mutate, isLoading, isSuccess, isError, error };
+};

--- a/frontend/src/hooks/query/notice/useNoticeDetail.tsx
+++ b/frontend/src/hooks/query/notice/useNoticeDetail.tsx
@@ -18,7 +18,7 @@ export const useNoticeDetail = (noticeId: number) => {
         return data;
       },
       onError: () => {
-        console.error('공지 사항을 상세 정보를 불러오는데 실패했습니다');
+        console.error('공지 사항의 상세 정보를 불러오는데 실패했습니다');
       },
     }
   );

--- a/frontend/src/hooks/query/notice/useNoticeDetail.tsx
+++ b/frontend/src/hooks/query/notice/useNoticeDetail.tsx
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { Notice } from '@type/notice';
+
+import { getNoticeDetail } from '@api/notice';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useNoticeDetail = (noticeId: number) => {
+  const { data, isError, isLoading, error } = useQuery<Notice>(
+    [QUERY_KEY.NOTICE],
+    () => getNoticeDetail(noticeId),
+    {
+      suspense: true,
+      cacheTime: 60 * 60 * 1000,
+      staleTime: 60 * 60 * 1000,
+      onSuccess: data => {
+        return data;
+      },
+      onError: () => {
+        console.error('공지 사항을 상세 정보를 불러오는데 실패했습니다');
+      },
+    }
+  );
+
+  return { data, isError, isLoading, error };
+};

--- a/frontend/src/hooks/query/notice/usePagedNoticeList.tsx
+++ b/frontend/src/hooks/query/notice/usePagedNoticeList.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { NoticeList } from '@type/notice';
+
+import { getNoticeList } from '@api/notice';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const usePagedNoticeList = (initialPageNumber: number = 0) => {
+  const [pageNumber, setPageNumber] = useState(initialPageNumber);
+  const { data, isError, isLoading, error } = useQuery<NoticeList>(
+    [QUERY_KEY.NOTICE, pageNumber],
+    () => getNoticeList(pageNumber),
+    {
+      suspense: true,
+      cacheTime: 30 * 60 * 1000,
+      staleTime: 30 * 60 * 1000,
+      onSuccess: data => {
+        return data;
+      },
+      onError: () => {
+        console.error('공지 사항을 리스트를 불러오는데 실패했습니다');
+      },
+    }
+  );
+
+  const setPage = (value: number) => {
+    setPageNumber(value - 1);
+  };
+
+  const hasNextPage = data && pageNumber < data.totalPageNumber;
+
+  const fetchPrevPage = () => {
+    if (pageNumber === 0) return;
+
+    setPageNumber(prev => prev - 1);
+  };
+
+  const fetchNextPage = () => {
+    if (!hasNextPage) return;
+
+    setPageNumber(prev => prev + 1);
+  };
+
+  return {
+    data,
+    isError,
+    isLoading,
+    error,
+    hasNextPage,
+    fetchNextPage,
+    fetchPrevPage,
+    page: pageNumber,
+    setPage,
+  };
+};

--- a/frontend/src/hooks/query/notice/usePagedNoticeList.tsx
+++ b/frontend/src/hooks/query/notice/usePagedNoticeList.tsx
@@ -21,7 +21,7 @@ export const usePagedNoticeList = (initialPageNumber: number = 0) => {
         return data;
       },
       onError: () => {
-        console.error('공지 사항을 리스트를 불러오는데 실패했습니다');
+        console.error('공지 사항의 리스트를 불러오는데 실패했습니다');
       },
     }
   );

--- a/frontend/src/hooks/query/notice/useStackedNoticeList.tsx
+++ b/frontend/src/hooks/query/notice/useStackedNoticeList.tsx
@@ -1,0 +1,33 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { NoticeList } from '@type/notice';
+
+import { getNoticeList } from '@api/notice';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useStackedNoticeList = () => {
+  const { data, isError, isLoading, error, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useInfiniteQuery<NoticeList>(
+      [QUERY_KEY.NOTICE],
+      ({ pageParam = 0 }) => getNoticeList(pageParam),
+      {
+        suspense: true,
+        cacheTime: 30 * 60 * 1000,
+        staleTime: 30 * 60 * 1000,
+        onSuccess: data => {
+          return data;
+        },
+        onError: () => {
+          console.error('공지 사항을 리스트를 불러오는데 실패했습니다');
+        },
+        getNextPageParam: lastPage => {
+          if (lastPage.currentPageNumber === lastPage.totalPageNumber) return;
+
+          return lastPage.currentPageNumber + 1;
+        },
+      }
+    );
+
+  return { data, isError, isLoading, error, hasNextPage, fetchNextPage, isFetchingNextPage };
+};

--- a/frontend/src/hooks/query/notice/useStackedNoticeList.tsx
+++ b/frontend/src/hooks/query/notice/useStackedNoticeList.tsx
@@ -19,7 +19,7 @@ export const useStackedNoticeList = () => {
           return data;
         },
         onError: () => {
-          console.error('공지 사항을 리스트를 불러오는데 실패했습니다');
+          console.error('공지 사항의 리스트를 불러오는데 실패했습니다');
         },
         getNextPageParam: lastPage => {
           if (lastPage.currentPageNumber === lastPage.totalPageNumber) return;

--- a/frontend/src/hooks/useDialog.tsx
+++ b/frontend/src/hooks/useDialog.tsx
@@ -1,0 +1,32 @@
+import { MouseEvent, useRef } from 'react';
+
+export const useDialog = () => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const openDialog = () => {
+    if (!dialogRef.current) return;
+
+    dialogRef.current.showModal();
+  };
+
+  const closeDialog = () => {
+    if (!dialogRef.current) return;
+
+    dialogRef.current.close();
+  };
+
+  const handleCloseClick = (event: MouseEvent<HTMLDialogElement>) => {
+    const modalBoundary = event.currentTarget.getBoundingClientRect();
+
+    if (
+      modalBoundary.left > event.clientX ||
+      modalBoundary.right < event.clientX ||
+      modalBoundary.top > event.clientY ||
+      modalBoundary.bottom < event.clientY
+    ) {
+      closeDialog();
+    }
+  };
+
+  return { dialogRef, openDialog, closeDialog, handleCloseClick };
+};

--- a/frontend/src/hooks/useImageZoomModal.ts
+++ b/frontend/src/hooks/useImageZoomModal.ts
@@ -1,0 +1,23 @@
+import { MouseEvent, useState } from 'react';
+
+import { useDialog } from './useDialog';
+
+export const useImageZoomModal = () => {
+  const [imageSrc, setImageSrc] = useState('');
+  const { closeDialog, dialogRef, handleCloseClick, openDialog } = useDialog();
+
+  const handleImageClick = (event: MouseEvent<HTMLImageElement>) => {
+    event.stopPropagation();
+    const src = event.currentTarget.src;
+    setImageSrc(src);
+    openDialog();
+  };
+
+  return {
+    imageSrc,
+    closeZoomModal: closeDialog,
+    handleCloseClick,
+    zoomModalRef: dialogRef,
+    handleImageClick,
+  };
+};

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2,6 +2,7 @@ import { mockCategoryHandlers } from './categoryList';
 import { mockComment } from './comment';
 import { example } from './example/get';
 import { mockVoteResult } from './getVoteDetail';
+import { mockNotice } from './notice';
 import { mockPost } from './post';
 import { mockPostList } from './postList';
 import { mockRanking } from './ranking';
@@ -22,4 +23,5 @@ export const handlers = [
   ...mockReport,
   ...mockRanking,
   ...mockToken,
+  ...mockNotice,
 ];

--- a/frontend/src/mocks/mockData/notice.ts
+++ b/frontend/src/mocks/mockData/notice.ts
@@ -1,6 +1,6 @@
 import { Notice, NoticeList } from '@type/notice';
 
-import { NoticeListResponse, NoticeResponse, transformNotice } from '@api/notice';
+import { NoticeListResponse, transformNotice } from '@api/notice';
 
 const noticeTitleList = [
   '방방뛰는 코끼리',
@@ -63,7 +63,7 @@ const getMockNoticeResponse = () => ({
   deadline: noticeDeadlineList[Math.floor(Math.random() * 9)],
 });
 
-export const MOCK_NOTICE_RESPONSE: NoticeResponse = getMockNoticeResponse();
+export const MOCK_NOTICE_RESPONSE: Notice = getMockNoticeResponse();
 
 export const MOCK_TRANSFORM_NOTICE: Notice = transformNotice(MOCK_NOTICE_RESPONSE);
 

--- a/frontend/src/mocks/mockData/notice.ts
+++ b/frontend/src/mocks/mockData/notice.ts
@@ -1,0 +1,80 @@
+import { Notice, NoticeList } from '@type/notice';
+
+import { NoticeListResponse, NoticeResponse, transformNotice } from '@api/notice';
+
+const noticeTitleList = [
+  '방방뛰는 코끼리',
+  '환상의 드래곤',
+  '컴퓨터 마법사',
+  '무한한 상상력',
+  '꿈을 향한 여행자',
+  '플레이메이커',
+  '뛰어난 전략가',
+  '뚜렷한 개성',
+];
+
+const noticeContentList = [
+  'Woah, your project looks awesome! How long have you been coding for? ',
+  '일하기 싫어서 화장실에 앉아서 보는 중은 아닌데 아 원숭이 김종민보려고 눈뜬거 진짜웃겨ㅠㅠㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ',
+  '진짜 다보고 나니 눈물이 ㅜㅜ 너무 참아서 눈물이 줄줄 ㅜㅜ 미쳤네요',
+  'ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ 생일 축하드립니다 🎉🎉🎉 뭔가 예전에 무한도전에서 했던 돌+아이 콘테스트도 조금 생각나요',
+  '1:08 4:01 4:20 6:04\n제가 계속 보고 싶어서 정리한 타임코드입니다\n역시나 생일파티 콘텐츠는 아무리봐도 안 질리네요\n유병재님 덕분에 오늘도 마음이 풍선해집니다💚❤️',
+  '진짜ㅋㅋㅋㅋ레전드중 레전드인 컨텐츠인 것 같아요ㅋㅋㅋ큐ㅠㅠㅠ 몇번을 봐도 웃음이 멈추질 않는ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ!!>w<!!😂💞 ㅋㅋㅋㅋ살려주세요ㅠㅠㅠ 배가ㅋㅋㅋㅋㅋㅋㅋㅋㅋ',
+  '심판들의 엄격한 평가가 있어야 한다고 봅니다!!!',
+  '나도 모르게 숨을 참게되네..',
+  '정말 멋진 프로젝트네요! 코딩을 얼마나 오래하셨나요? 저는 아직 새내기인데, 곧 리액트를 배울 생각인데 어떻게 배울 수 있을까요? 조언 좀 부탁드려도 될까요? 감사합니다!',
+  '방금 보다 너무 웃긴거 같아요ㅋㅋㅋ 글쎄요 원숭이 김종민이랑 수호랑 같이 보려고 일부러 눈뜬거 같았는데ㅋㅋㅋ 힌우해요ㅠㅠㅋㅋㅋㅋ',
+  '이 영상을 보면서 눈물과 미소가 번갈아 오네요 ㅜㅜ 너무나 감동적이고 멋지네요',
+];
+
+const noticeCreatedAtList = [
+  '2022-01-11 12:23',
+  '2022-02-11 12:23',
+  '2022-03-11 12:23',
+  '2022-04-11 12:23',
+  '2022-05-11 12:23',
+  '2022-06-11 12:23',
+  '2022-07-11 12:23',
+  '2022-08-11 12:23',
+  '2022-09-11 12:23',
+  '2022-10-11 12:23',
+];
+
+const noticeDeadlineList = [
+  '2022-01-11 12:23',
+  '2022-02-11 12:23',
+  '2022-03-11 12:23',
+  '2022-04-11 12:23',
+  '2022-05-11 12:23',
+  '2023-06-11 12:23',
+  '2023-07-11 12:23',
+  '2023-08-11 12:23',
+  '2023-09-11 12:23',
+  '2023-10-11 12:23',
+];
+
+const getMockNoticeResponse = () => ({
+  id: Math.floor(Math.random() * 30),
+  title: noticeTitleList[Math.floor(Math.random() * 8)],
+  content: noticeContentList[Math.floor(Math.random() * 11)],
+  bannerTitle: noticeTitleList[Math.floor(Math.random() * 8)],
+  bannerSubtitle: noticeTitleList[Math.floor(Math.random() * 8)],
+  createdAt: noticeCreatedAtList[Math.floor(Math.random() * 9)],
+  deadline: noticeDeadlineList[Math.floor(Math.random() * 9)],
+});
+
+export const MOCK_NOTICE_RESPONSE: NoticeResponse = getMockNoticeResponse();
+
+export const MOCK_TRANSFORM_NOTICE: Notice = transformNotice(MOCK_NOTICE_RESPONSE);
+
+export const MOCK_NOTICE_LIST_RESPONSE: NoticeListResponse = {
+  totalPageNumber: 3,
+  currentPageNumber: 0,
+  notices: Array.from({ length: 20 }, () => getMockNoticeResponse()),
+};
+
+export const MOCK_TRANSFORM_NOTICE_LIST: NoticeList = {
+  totalPageNumber: 3,
+  currentPageNumber: 0,
+  noticeList: MOCK_NOTICE_LIST_RESPONSE.notices.map(item => transformNotice(item)),
+};

--- a/frontend/src/mocks/notice.ts
+++ b/frontend/src/mocks/notice.ts
@@ -1,0 +1,41 @@
+import { rest } from 'msw';
+
+import { MOCK_NOTICE_LIST_RESPONSE, MOCK_NOTICE_RESPONSE } from './mockData/notice';
+
+export let MOCK_NOTICE_TEST = '';
+
+export const mockNotice = [
+  rest.post(`/notices`, async (req, res, ctx) => {
+    const data = await req.json();
+
+    MOCK_NOTICE_TEST = data.title;
+
+    return res(ctx.status(200));
+  }),
+
+  rest.get('/notices/progress', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(MOCK_NOTICE_RESPONSE));
+  }),
+
+  rest.get(`/notices`, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(MOCK_NOTICE_LIST_RESPONSE));
+  }),
+
+  rest.get(`/notices/:id`, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(MOCK_NOTICE_RESPONSE));
+  }),
+
+  rest.patch(`/notices/:id`, async (req, res, ctx) => {
+    const data = await req.json();
+
+    MOCK_NOTICE_TEST = data.title;
+
+    return res(ctx.status(200));
+  }),
+
+  rest.delete(`/notices/:id`, (req, res, ctx) => {
+    MOCK_NOTICE_TEST = '삭제된 공지사항';
+
+    return res(ctx.status(204));
+  }),
+];

--- a/frontend/src/types/notice.ts
+++ b/frontend/src/types/notice.ts
@@ -1,3 +1,5 @@
+import { NoticeListResponse } from '@api/notice';
+
 export interface Notice {
   id: number;
   title: string;
@@ -8,8 +10,4 @@ export interface Notice {
   bannerSubtitle: string;
 }
 
-export interface NoticeList {
-  totalPageNumber: number;
-  currentPageNumber: number;
-  noticeList: Notice[];
-}
+export type NoticeList = Omit<NoticeListResponse, 'notices'> & { noticeList: Notice[] };

--- a/frontend/src/types/notice.ts
+++ b/frontend/src/types/notice.ts
@@ -1,0 +1,15 @@
+export interface Notice {
+  id: number;
+  title: string;
+  content: string;
+  createdAt: string;
+  deadline: string;
+  bannerTitle: string;
+  bannerSubtitle: string;
+}
+
+export interface NoticeList {
+  totalPageNumber: number;
+  currentPageNumber: number;
+  noticeList: Notice[];
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #737 

## 📝 작업 요약

- 배너 공지사항 조회 / 공지사항 목록 조회 / 공지사항 상세 조회 / 공지사항 수정 / 공지사항 삭제 / 공지사항 생성 api 구현 및 query hook 구현

## ⏰ 소요 시간

2시간 45분 api가 많아서 단순 코드 작성만 하는데 생각보다 시간이 더 걸렸어요

## 🔎 작업 상세 설명

- 공지사항 목록 조회를 할 때 useInfinitedQuery를 사용하였는데요. 그 이유는 더보기를 눌렀을 때 useState로 데이터를 한곳에 모아서 관리해야하는데 useInfinifyQuery에 이미 편하게 구현이 되어있어서 사용했습니다. 그래서 더보기를 사용해도 되고, 무한 스크롤을 사용해도 되는 코드로 구현해놓았습니다

### 캐시타임, 스테일타임을 건드렸습니다

- 배너 공지 사항 : 30분 / 이유 :  배너 공지사항이 바뀌는 일이 적다고 생각하였지만 혹시 공지사항이 바뀌었을 때 캐싱되어 있어서 공지사항을 못보는 상황까지 고려해서 1시간은 길다고 생각했고, 30분으로 하였습니다. 기본값으로 하기엔 너무 안변하는 데이터라서요

- 공지 상세 정보 : 1시간 / 이유 : 공지사항 상세 정보는 더더욱 바뀔 일이 적다고 생각하여 1시간으로 설정했습니다

- 공지 목록 : 30분 / 이유 : 공지 사항 목록이 바뀌는 일이 적다고 생각했지만, 목록이다 보니 배너 공지사항이 바뀐다면 목록도 바뀌어야 하기에 배너 공지 사항 시간과 일치시켰습니다.

### 에러

현재 토스트 PR이 올라와있는 상태여서 우선 콘솔에러로 하였는데요. 추후 토스트 코드를 통해 에러나 성공을 보여주면 좋겠다고 생각했습니다

### api 감싸기

api가 변하진 않았지만 한번 감싸주었는데요. 이렇게 하는 편이 나중에 쉽게 코드를 고칠 수 있을거라고 생각해서 감싸줘보았습니다

