### PR TITLE
[BUG] 알림이 비회원일때도 api요청을 해서 에러가 뜹니다

### DIFF
--- a/frontend/src/components/AlarmContainer/ListStyle.ts
+++ b/frontend/src/components/AlarmContainer/ListStyle.ts
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
 
 export const Description = styled.p`
-  font: var(--text-default);
+  margin: 30px 0;
+
+  font: var(--text-body);
   text-align: center;
+  font-weight: 500;
 `;
 
 export const ListContainer = styled.ul`
@@ -15,7 +18,7 @@ export const ListItem = styled.li<{ $isRead: boolean }>`
   border: 1px solid var(--gray);
   align-items: center;
   min-height: 60px;
-  margin: 2px 0;
+  margin: 5px 0;
 
   background-color: ${props => props.$isRead && 'var(--bright-gray)'};
 `;

--- a/frontend/src/components/common/NarrowMainHeader/style.ts
+++ b/frontend/src/components/common/NarrowMainHeader/style.ts
@@ -12,6 +12,7 @@ export const Container = styled.header`
 
   position: fixed;
   top: 0;
+  left: 0;
 
   background-color: var(--header);
 

--- a/frontend/src/components/common/WideHeader/index.tsx
+++ b/frontend/src/components/common/WideHeader/index.tsx
@@ -1,7 +1,7 @@
 import { CSSProperties, MouseEvent, useContext, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { AuthContext, useToggle } from '@hooks';
+import { AuthContext, ToastContext, useToggle } from '@hooks';
 
 import { useReadLatestAlarm } from '@hooks/query/user/useReadLatestAlarm';
 
@@ -26,6 +26,8 @@ export default function WideHeader() {
   const navigate = useNavigate();
   const { isOpen, openComponent, closeComponent } = useToggle();
   const toolTipRef = useRef<HTMLDivElement | null>(null);
+
+  const { addMessage } = useContext(ToastContext);
   const loggedInfo = useContext(AuthContext).loggedInfo;
   const isAlarmActive = loggedInfo.userInfo?.hasLatestAlarm;
 
@@ -40,8 +42,7 @@ export default function WideHeader() {
   };
 
   const handleToolTipOpen = () => {
-    //추후 토스트 처리
-    if (!loggedInfo.isLoggedIn) return;
+    if (!loggedInfo.isLoggedIn) return addMessage('알림은 로그인 후 이용할 수 있습니다.');
 
     openComponent();
     mutate();

--- a/frontend/src/hooks/query/alarm/useReadAlarm.ts
+++ b/frontend/src/hooks/query/alarm/useReadAlarm.ts
@@ -15,9 +15,6 @@ export const useReadAlarm = (type: AlarmType) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [alarmQueryKey] });
     },
-    onError: () => {
-      //추후 토스트 처리
-    },
   });
 
   return { mutate };

--- a/frontend/src/hooks/query/user/useReadLatestAlarm.ts
+++ b/frontend/src/hooks/query/user/useReadLatestAlarm.ts
@@ -12,9 +12,6 @@ export const useReadLatestAlarm = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER_INFO] });
     },
-    onError: () => {
-      //추후 토스트 처리
-    },
   });
 
   return { mutate };

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, Suspense, useContext } from 'react';
 
-import { AuthContext, useToggle } from '@hooks';
+import { AuthContext, ToastContext, useToggle } from '@hooks';
 
 import { useReadLatestAlarm } from '@hooks/query/user/useReadLatestAlarm';
 import { useDrawer } from '@hooks/useDrawer';
@@ -46,13 +46,13 @@ export default function HomePage() {
 
   const { isOpen: isBannerOpen, closeComponent: closeBanner } = useToggle(true);
 
+  const { addMessage } = useContext(ToastContext);
   const loggedInfo = useContext(AuthContext).loggedInfo;
   const isAlarmActive = loggedInfo.userInfo?.hasLatestAlarm;
   const { mutate } = useReadLatestAlarm();
 
   const handleToolTipOpen = () => {
-    //추후 토스트 처리
-    if (!loggedInfo.isLoggedIn) return;
+    if (!loggedInfo.isLoggedIn) return addMessage('알림은 로그인 후 이용할 수 있습니다.');
 
     openAlarmDrawer();
     mutate();

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -93,7 +93,9 @@ export default function HomePage() {
             width="310px"
             ref={alarmDrawerRef}
           >
-            <AlarmContainer closeToolTip={closeAlarmDrawer} style={alarmDrawerStyle} />
+            {loggedInfo.isLoggedIn && (
+              <AlarmContainer closeToolTip={closeAlarmDrawer} style={alarmDrawerStyle} />
+            )}
           </Drawer>
         </S.DrawerWrapper>
         <ErrorBoundary hasIcon={true} hasRetryInteraction={true}>


### PR DESCRIPTION
## 🔥 연관 이슈

close: #772

## 📝 작업 요약
- 비회원일때는 알람을 요청하지 않음
- 비회원일 때 알람 버튼을 누르면 "로그인 하라는" 토스트 띄우기
- 모바일 홈 헤더 제위치로 돌려놓기

## ⏰ 소요 시간
30분

## 🔎 작업 상세 설명
- 비회원일때는 알람을 요청하지 않음
    - 기존 코드: drawer 안에 알람 컨테이너가 있어 content 알림이 불림
    - 수정 코드: drawer 안에서 로그인 여부를 확인해 비회원인 경우 알람 컨테이너를 그리지 않음
    - 알람 컨테이너 안 리스트에 api 통신하는 로직 포함됨
- 비회원일 때 알람 버튼을 누르면 "로그인 하라는" 토스트 띄우기
    - 알림을 읽는 patch api가 실패했을 때 토스트 안내 X
    - 비회원일때 알림 버튼을 누르면 토스트 안내 O
- 모바일 홈 헤더 제위치로 돌려놓기

