### PR TITLE
알림 읽기 api를 content와 report로 분리함에 따라 코드 수정

### DIFF
--- a/frontend/src/api/alarm.ts
+++ b/frontend/src/api/alarm.ts
@@ -88,6 +88,8 @@ export const getReportApproveResult = async (reportId: number): Promise<ReportAp
   return transformReportApproveResultResponse(reportApproveResult);
 };
 
-export const readAlarm = async (alarmId: number) => {
-  await patchFetch(`${BASE_URL}/alarms/${alarmId}`);
+export type AlarmType = 'CONTENT' | 'REPORT';
+
+export const readAlarm = async (alarmId: number, type: AlarmType) => {
+  await patchFetch(`${BASE_URL}/alarms/${alarmId}?type=${type}`);
 };

--- a/frontend/src/api/alarm.ts
+++ b/frontend/src/api/alarm.ts
@@ -1,3 +1,4 @@
+import { AlarmType } from '@type/alarm';
 import { ReportMessage, ReportType } from '@type/report';
 import { StringDate } from '@type/time';
 
@@ -87,8 +88,6 @@ export const getReportApproveResult = async (reportId: number): Promise<ReportAp
 
   return transformReportApproveResultResponse(reportApproveResult);
 };
-
-export type AlarmType = 'CONTENT' | 'REPORT';
 
 export const readAlarm = async (alarmId: number, type: AlarmType) => {
   await patchFetch(`${BASE_URL}/alarms/${alarmId}?type=${type}`);

--- a/frontend/src/components/AlarmContainer/ContentAlarmList/index.tsx
+++ b/frontend/src/components/AlarmContainer/ContentAlarmList/index.tsx
@@ -24,8 +24,8 @@ export default function ContentAlarmList({ closeToolTip }: { closeToolTip: () =>
     return <LS.Description>현재 도착한 알림이 없습니다!</LS.Description>;
   }
 
-  const handleAlarmClick = (alarmId: number, postId: number) => {
-    mutate(alarmId);
+  const handleAlarmClick = (alarmId: number, isChecked: boolean, postId: number) => {
+    if (!isChecked) mutate(alarmId);
 
     navigation(`${PATH.POST}/${postId}`);
     closeToolTip();
@@ -50,7 +50,7 @@ export default function ContentAlarmList({ closeToolTip }: { closeToolTip: () =>
               <LS.ListItem key={alarm.alarmId} $isRead={alarm.isChecked}>
                 <LS.LinkButton
                   onClick={() => {
-                    handleAlarmClick(alarm.alarmId, postId);
+                    handleAlarmClick(alarm.alarmId, alarm.isChecked, postId);
                   }}
                 >
                   <p>

--- a/frontend/src/components/AlarmContainer/ReportAlarmList/index.tsx
+++ b/frontend/src/components/AlarmContainer/ReportAlarmList/index.tsx
@@ -25,8 +25,8 @@ export default function ReportAlarmList({ closeToolTip }: { closeToolTip: () => 
     return <LS.Description>현재 도착한 알림이 없습니다!</LS.Description>;
   }
 
-  const handleAlarmClick = (alarmId: number, reportId: number) => {
-    mutate(alarmId);
+  const handleAlarmClick = (alarmId: number, isChecked: boolean, reportId: number) => {
+    if (!isChecked) mutate(alarmId);
 
     navigation(`${PATH.REPORT_ALARM}/${reportId}`);
     closeToolTip();
@@ -47,7 +47,7 @@ export default function ReportAlarmList({ closeToolTip }: { closeToolTip: () => 
               <LS.ListItem key={alarm.alarmId} $isRead={alarm.isChecked}>
                 <LS.LinkButton
                   onClick={() => {
-                    handleAlarmClick(alarm.alarmId, reportId);
+                    handleAlarmClick(alarm.alarmId, alarm.isChecked, reportId);
                   }}
                 >
                   <p>{`신고를 받아 "${shortContent}" ${REPORT_TYPE[type].actionMessage}`}</p>

--- a/frontend/src/hooks/query/alarm/useReadAlarm.ts
+++ b/frontend/src/hooks/query/alarm/useReadAlarm.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { AlarmType, readAlarm } from '@api/alarm';
+import { AlarmType } from '@type/alarm';
+
+import { readAlarm } from '@api/alarm';
 
 import { QUERY_KEY } from '@constants/queryKey';
 

--- a/frontend/src/hooks/query/alarm/useReadAlarm.ts
+++ b/frontend/src/hooks/query/alarm/useReadAlarm.ts
@@ -1,17 +1,15 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { readAlarm } from '@api/alarm';
+import { AlarmType, readAlarm } from '@api/alarm';
 
 import { QUERY_KEY } from '@constants/queryKey';
-
-type AlarmType = 'CONTENT' | 'REPORT';
 
 export const useReadAlarm = (type: AlarmType) => {
   const queryClient = useQueryClient();
   const alarmQueryKey = type === 'CONTENT' ? QUERY_KEY.ALARM_CONTENT : QUERY_KEY.ALARM_REPORT;
 
   const { mutate } = useMutation({
-    mutationFn: async (alarmId: number) => await readAlarm(alarmId),
+    mutationFn: async (alarmId: number) => await readAlarm(alarmId, type),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [alarmQueryKey] });
     },

--- a/frontend/src/mocks/mockData/alarm.ts
+++ b/frontend/src/mocks/mockData/alarm.ts
@@ -38,7 +38,8 @@ const reportAlarmAtPost = () => ({
   isChecked: randomBoolean(),
   detail: {
     createdAt: `201${randomNum()}-0${randomNum()}-1${randomNum()} 11:34`,
-    reportActionId: Math.round(Math.random() * 1000),
+    reportId: Math.round(Math.random() * 1000),
+    reasons: [],
     type: 'POST',
     content: '신고되어 삭제된 게시물',
   },
@@ -49,7 +50,8 @@ const reportAlarmAtComment = () => ({
   isChecked: randomBoolean(),
   detail: {
     createdAt: `201${randomNum()}-0${randomNum()}-1${randomNum()} 11:34`,
-    reportActionId: Math.round(Math.random() * 1000),
+    reportId: Math.round(Math.random() * 1000),
+    reasons: [],
     type: 'COMMENT',
     content: '삭제된 댓글 내용',
   },
@@ -60,7 +62,8 @@ const reportAlarmAtNickName = () => ({
   isChecked: randomBoolean(),
   detail: {
     createdAt: `201${randomNum()}-0${randomNum()}-1${randomNum()} 11:34`,
-    reportActionId: Math.round(Math.random() * 1000),
+    reportId: Math.round(Math.random() * 1000),
+    reasons: [],
     type: 'NICKNAME',
     content: '변경처리된 닉네임',
   },

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -25,13 +25,13 @@ export const GlobalStyle = createGlobalStyle`
 
   :root {
     /* Colors *****************************************/
+    --red: #F51A18;
     --primary-color: #F85554;
     --white: #ffffff;
-    --slate: #94a3b8;
-    --gray: #ced4da;
     --bright-gray: #F4F4F4;
-    --red: #F51A18;
+    --gray: #cccccc;
     --dark-gray: #929292;
+    --slate: #94a3b8;
     --header: #1f1f1f;
     --graph-color-purple:#853DE1;
     --graph-color-green:#5AEAA5;

--- a/frontend/src/types/alarm.ts
+++ b/frontend/src/types/alarm.ts
@@ -1,0 +1,1 @@
+export type AlarmType = 'CONTENT' | 'REPORT';


### PR DESCRIPTION
## 🔥 연관 이슈

close: #778

## 📝 작업 요약
알림 읽기 api를 content와 report로 나눠서 보내야 해서 코드 수정
한번 읽은 알림은 다시 해당 api 안보내도록 처리

## ⏰ 소요 시간
10분

## 🔎 작업 상세 설명
- 알림 읽기 api를 content와 report로 나눠서 보내야 해서 코드 수정
    -  기존 api
        > /alarms/{id}

    - 수정 api
        > alarmType = “CONTENT” | “REPORT”
        > /alarms/{id}?type={alarmType} 


## 🌟 논의 사항
아직 서버의 알림 api가 완성되지 않아서 api 완성되면 연결확인 되는 것까지 확인하고 머지하겠습니다!
