### PR TITLE
[BUG] 모바일 비회원일 때 신고 버튼을 눌르면 알 수 없는 에러 메세지입니다라고 떠요

### DIFF
--- a/frontend/src/components/ReportModal/index.tsx
+++ b/frontend/src/components/ReportModal/index.tsx
@@ -25,7 +25,9 @@ export default function ReportModal({
   const { selectedOption, handleOptionChange } = useSelect<ReportMessage>(defaultReportMessage);
 
   const handlePrimaryButtonClick = () => {
-    !isReportLoading && handleReportClick(selectedOption);
+    if (isReportLoading) return;
+
+    handleReportClick(selectedOption);
     handleCancelClick();
   };
 

--- a/frontend/src/hooks/query/report/useReportAction.ts
+++ b/frontend/src/hooks/query/report/useReportAction.ts
@@ -21,7 +21,7 @@ export const useReportAction = () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.REPORT] });
     },
     onError: () => {
-      const message = error instanceof Error ? error.message : '투표를 실패했습니다.';
+      const message = error instanceof Error ? error.message : '신고 조치를 실패했습니다.';
       addMessage(message);
     },
   });

--- a/frontend/src/hooks/query/report/useReportAction.ts
+++ b/frontend/src/hooks/query/report/useReportAction.ts
@@ -1,6 +1,10 @@
+import { useContext } from 'react';
+
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { ReportActionRequest } from '@type/report';
+
+import { ToastContext } from '@hooks/context/toast';
 
 import { reportAction } from '@api/report';
 
@@ -8,6 +12,7 @@ import { QUERY_KEY } from '@constants/queryKey';
 
 export const useReportAction = () => {
   const queryClient = useQueryClient();
+  const { addMessage } = useContext(ToastContext);
 
   const { mutate, isLoading, isSuccess, isError, error } = useMutation({
     mutationFn: async (reportActionData: ReportActionRequest) =>
@@ -16,7 +21,8 @@ export const useReportAction = () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.REPORT] });
     },
     onError: () => {
-      window.console.error('신고 조치를 실패했습니다.');
+      const message = error instanceof Error ? error.message : '투표를 실패했습니다.';
+      addMessage(message);
     },
   });
 

--- a/frontend/src/hooks/query/report/useReportContent.ts
+++ b/frontend/src/hooks/query/report/useReportContent.ts
@@ -1,0 +1,30 @@
+import { useContext } from 'react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { ReportRequest } from '@type/report';
+
+import { ToastContext } from '@hooks/context/toast';
+
+import { reportContent } from '@api/report';
+
+import { QUERY_KEY } from '@constants/queryKey';
+
+export const useReportContent = () => {
+  const queryClient = useQueryClient();
+  const { addMessage } = useContext(ToastContext);
+
+  const { mutate, isLoading } = useMutation({
+    mutationFn: async (reportData: ReportRequest) => await reportContent(reportData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.REPORT] });
+      addMessage('신고를 완료하였습니다.');
+    },
+    onError: error => {
+      const message = error instanceof Error ? error.message : '개인정보 등록을 실패했습니다.';
+      addMessage(message);
+    },
+  });
+
+  return { mutate, isLoading };
+};

--- a/frontend/src/pages/post/PostDetailPage/BottomButtonPart/index.tsx
+++ b/frontend/src/pages/post/PostDetailPage/BottomButtonPart/index.tsx
@@ -2,6 +2,7 @@ import type { LoadingType } from '../types';
 
 import { useContext, useState } from 'react';
 
+import { PostAction } from '@type/menu';
 import { ReportMessage } from '@type/report';
 
 import { AuthContext } from '@hooks/context/auth';
@@ -39,9 +40,9 @@ export default function BottomButtonPart({
   const { moveWritePostPage, moveVoteStatisticsPage } = movePage;
   const { setEarlyClosePost, deletePost, reportPost, reportNickname } = controlPost;
   const { isDeletePostLoading, isReportPostLoading, isReportNicknameLoading } = isEventLoading;
-  const [action, setAction] = useState<string | null>(null);
+  const [action, setAction] = useState<PostAction | null>(null);
 
-  const handleActionButtonClick = (action: string) => {
+  const handleActionButtonClick = (action: PostAction) => {
     if (!loggedInfo.isLoggedIn) {
       openToast('로그인 후에 기능을 이용해주세요.');
       return;

--- a/frontend/src/pages/post/PostDetailPage/InnerHeaderPart/InnerHeaderPart.stories.tsx
+++ b/frontend/src/pages/post/PostDetailPage/InnerHeaderPart/InnerHeaderPart.stories.tsx
@@ -32,6 +32,7 @@ const handleEvent = {
     reportPost: (reason: string) => {},
     reportNickname: (reason: string) => {},
   },
+  openToast: () => {},
 };
 
 export const isWriterAndIsClosedCase: Story = {

--- a/frontend/src/pages/post/PostDetailPage/InnerHeaderPart/index.tsx
+++ b/frontend/src/pages/post/PostDetailPage/InnerHeaderPart/index.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { PostAction, MenuItem } from '@type/menu';
 import { ReportMessage } from '@type/report';
 
-import { useToggle } from '@hooks';
+import { AuthContext, useToggle } from '@hooks';
 
 import DeleteModal from '@components/common/DeleteModal';
 import HeaderTextButton from '@components/common/HeaderTextButton';
@@ -32,6 +32,7 @@ interface PostDetailPageChildProps {
       reportPost: (reason: ReportMessage) => void;
       reportNickname: (reason: ReportMessage) => void;
     };
+    openToast: (text: string) => void;
   };
   isEventLoading: Record<LoadingType, boolean>;
 }
@@ -44,20 +45,25 @@ const menuList: MenuItem<PostAction>[] = [
 export default function InnerHeaderPart({
   isWriter,
   isClosed,
-  handleEvent: { movePage, controlPost },
+  handleEvent: { movePage, controlPost, openToast },
   isEventLoading,
 }: PostDetailPageChildProps) {
   const navigate = useNavigate();
-
+  const { loggedInfo } = useContext(AuthContext);
   const { moveWritePostPage, moveVoteStatisticsPage } = movePage;
   const { setEarlyClosePost, deletePost, reportPost, reportNickname } = controlPost;
-  const { isOpen, toggleComponent, closeComponent } = useToggle();
-  const [action, setAction] = useState<PostAction | null>(null);
-
   const { isDeletePostLoading, isReportNicknameLoading, isReportPostLoading } = isEventLoading;
+  const { isOpen: isMenuOpen, toggleComponent, closeComponent } = useToggle();
+  const [action, setAction] = useState<PostAction | null>(null);
 
   const handleMenuClick = (action: PostAction) => {
     closeComponent();
+
+    if (!loggedInfo.isLoggedIn) {
+      openToast('로그인 후에 기능을 이용해주세요.');
+      return;
+    }
+
     setAction(action);
   };
 
@@ -80,12 +86,12 @@ export default function InnerHeaderPart({
         {!isWriter ? (
           <>
             <HeaderTextButton
-              aria-label={isOpen ? '게시글 신고 메뉴 닫기' : '게시글 신고 메뉴 열기'}
+              aria-label={isMenuOpen ? '게시글 신고 메뉴 닫기' : '게시글 신고 메뉴 열기'}
               onClick={toggleComponent}
             >
               신고
             </HeaderTextButton>
-            {isOpen && (
+            {isMenuOpen && (
               <S.MenuWrapper>
                 <Menu menuList={menuList} handleMenuClick={handleMenuClick} />
               </S.MenuWrapper>

--- a/frontend/src/pages/post/PostDetailPage/PostDetail/index.tsx
+++ b/frontend/src/pages/post/PostDetailPage/PostDetail/index.tsx
@@ -115,7 +115,7 @@ export default function PostDetail() {
           <InnerHeaderPart
             isClosed={isClosed}
             isWriter={isWriter}
-            handleEvent={{ movePage, controlPost }}
+            handleEvent={{ movePage, controlPost, openToast: addMessage }}
             isEventLoading={{
               isDeletePostLoading,
               isReportPostLoading: isContentReporting,


### PR DESCRIPTION
## 🔥 연관 이슈

close: #734

## 📝 작업 요약
- 모바일에서 신고하려고 하면 로그인 후 이용하라고 안내 메세지 보이기
- 신고하기 api를 쿼리 훅으로 만들기

## ⏰ 소요 시간
1시간

## 🔎 작업 상세 설명
- 모바일에서 신고하려고 하면 로그인 후 이용하라고 안내 메세지 보이기
     - 원래는 포스트 디테일 페이지에서 해주려고 했는데, 그럼 모달까지 다 선택하고 나서 요청을 거절하는 토스트가 나오게 되어 사용성을 저해한다고 생각
     - 때문에 innerHeaderPart/bottomPart에서 action을 취하려고 할때 1차적으로 확인 후 토스트 안내를 내보내기로 결정
- 신고하기 api를 쿼리 훅으로 만들기

## 🌟 논의 사항
신고하기 mutate를 게시글/닉네임 같이 사용하는데 문제가 되진 않겠죠?
