### PR TITLE
커넥션풀 관련 설정 추가 + 회원탈퇴시 fk 관련 삭제 로직 추가

### DIFF
--- a/backend/src/main/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepository.java
+++ b/backend/src/main/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportActionAlarmRepository extends JpaRepository<ReportActionAlarm, Long> {
 
-    List<ReportActionAlarm> findByMemberOrderByCreatedAtDesc(final Member member, final Pageable pageable);
+    List<ReportActionAlarm> findByMemberOrderByIdDesc(final Member member, final Pageable pageable);
 
     Optional<ReportActionAlarm> findByIdAndMember(final Long Id, final Member member);
 

--- a/backend/src/main/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepository.java
+++ b/backend/src/main/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportActionAlarmRepository extends JpaRepository<ReportActionAlarm, Long> {
 
-    List<ReportActionAlarm> findByMember(final Member member, final Pageable pageable);
+    List<ReportActionAlarm> findByMemberOrderByCreatedAtDesc(final Member member, final Pageable pageable);
 
     Optional<ReportActionAlarm> findByIdAndMember(final Long Id, final Member member);
 

--- a/backend/src/main/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepository.java
+++ b/backend/src/main/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepository.java
@@ -13,4 +13,6 @@ public interface ReportActionAlarmRepository extends JpaRepository<ReportActionA
 
     Optional<ReportActionAlarm> findByIdAndMember(final Long Id, final Member member);
 
+    List<ReportActionAlarm> findAllByMember(final Member member);
+
 }

--- a/backend/src/main/java/com/votogether/domain/alarm/service/AlarmQueryService.java
+++ b/backend/src/main/java/com/votogether/domain/alarm/service/AlarmQueryService.java
@@ -15,7 +15,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,13 +54,9 @@ public class AlarmQueryService {
     }
 
     public List<ReportActionAlarmResponse> getReportActionAlarms(final Member member, final int page) {
-        final PageRequest pageRequest = PageRequest.of(
-                page,
-                BASIC_PAGE_SIZE,
-                Sort.by(Sort.Direction.DESC, "createdAt")
-        );
+        final PageRequest pageRequest = PageRequest.of(page, BASIC_PAGE_SIZE);
         final List<ReportActionAlarm> reportActionAlarms = reportActionAlarmRepository
-                .findByMember(member, pageRequest);
+                .findByMemberOrderByCreatedAtDesc(member, pageRequest);
 
         return reportActionAlarms.stream()
                 .map(ReportActionAlarmResponse::from)

--- a/backend/src/main/java/com/votogether/domain/alarm/service/AlarmQueryService.java
+++ b/backend/src/main/java/com/votogether/domain/alarm/service/AlarmQueryService.java
@@ -56,7 +56,7 @@ public class AlarmQueryService {
     public List<ReportActionAlarmResponse> getReportActionAlarms(final Member member, final int page) {
         final PageRequest pageRequest = PageRequest.of(page, BASIC_PAGE_SIZE);
         final List<ReportActionAlarm> reportActionAlarms = reportActionAlarmRepository
-                .findByMemberOrderByCreatedAtDesc(member, pageRequest);
+                .findByMemberOrderByIdDesc(member, pageRequest);
 
         return reportActionAlarms.stream()
                 .map(ReportActionAlarmResponse::from)

--- a/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/votogether/domain/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package com.votogether.domain.member.service;
 
 import com.votogether.domain.alarm.entity.Alarm;
+import com.votogether.domain.alarm.entity.ReportActionAlarm;
 import com.votogether.domain.alarm.repository.AlarmRepository;
+import com.votogether.domain.alarm.repository.ReportActionAlarmRepository;
 import com.votogether.domain.member.dto.request.MemberDetailRequest;
 import com.votogether.domain.member.dto.response.MemberInfoResponse;
 import com.votogether.domain.member.entity.Member;
@@ -12,6 +14,8 @@ import com.votogether.domain.member.exception.MemberExceptionType;
 import com.votogether.domain.member.repository.MemberCategoryRepository;
 import com.votogether.domain.member.repository.MemberMetricRepository;
 import com.votogether.domain.member.repository.MemberRepository;
+import com.votogether.domain.notice.entity.Notice;
+import com.votogether.domain.notice.repository.NoticeRepository;
 import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.comment.Comment;
 import com.votogether.domain.post.repository.CommentRepository;
@@ -43,6 +47,8 @@ public class MemberService {
     private final ReportRepository reportRepository;
     private final CommentRepository commentRepository;
     private final AlarmRepository alarmRepository;
+    private final ReportActionAlarmRepository reportActionAlarmRepository;
+    private final NoticeRepository noticeRepository;
 
     @Transactional
     public Member register(final Member member) {
@@ -120,6 +126,8 @@ public class MemberService {
         deleteMemberCategories(member);
         deleteReports(member, posts, comments);
         deleteAlarms(member);
+        deleteReportActionAlarms(member);
+        deleteNotices(member);
 
         memberMetricRepository.deleteByMember(member);
         memberRepository.delete(member);
@@ -214,6 +222,22 @@ public class MemberService {
                 .map(Alarm::getId)
                 .toList();
         alarmRepository.deleteAllById(alarmIds);
+    }
+
+    private void deleteReportActionAlarms(final Member member) {
+        final List<Long> reportActionAlarmIds = reportActionAlarmRepository.findAllByMember(member)
+                .stream()
+                .map(ReportActionAlarm::getId)
+                .toList();
+        reportActionAlarmRepository.deleteAllById(reportActionAlarmIds);
+    }
+
+    private void deleteNotices(final Member member) {
+        final List<Long> noticeIds = noticeRepository.findAllByMember(member)
+                .stream()
+                .map(Notice::getId)
+                .toList();
+        noticeRepository.deleteAllById(noticeIds);
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/notice/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/votogether/domain/notice/repository/NoticeRepository.java
@@ -1,5 +1,6 @@
 package com.votogether.domain.notice.repository;
 
+import com.votogether.domain.member.entity.Member;
 import com.votogether.domain.notice.entity.Notice;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,5 +13,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Optional<Notice> findFirstByDeadlineAfterOrderByIdDesc(final LocalDateTime now);
 
     List<Notice> findAllByOrderByIdDesc(final Pageable pageable);
+
+    List<Notice> findAllByMember(final Member member);
 
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,6 +4,10 @@ spring:
     url: ${DATASOURCE_URL}
     username: ${DATASOURCE_USERNAME}
     password: ${DATASOURCE_PASSWORD}
+    hikari:
+      maximumPoolSize: ${MAXIMUM_POOL_SIZE}
+      connectionTimeout: ${CONNECTION_TIMEOUT}
+      maxLifetime: ${MAX_LIFETIME}
 
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect

--- a/backend/src/test/java/com/votogether/domain/alarm/controller/AlarmQueryControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/alarm/controller/AlarmQueryControllerTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
@@ -90,12 +89,14 @@ class AlarmQueryControllerTest extends ControllerTest {
 
         // when
         List<ReportActionAlarmResponse> results = RestAssuredMockMvc
+                .given().log().all()
+                .queryParam("page", 0)
                 .when().get("/alarms/report?page=0")
                 .then().log().all()
                 .status(HttpStatus.OK)
                 .extract()
-                .as(new ParameterizedTypeReference<List<ReportActionAlarmResponse>>() {
-                }.getType());
+                .as(new TypeRef<>() {
+                });
 
         // then
         assertThat(results.get(0)).isEqualTo(response);
@@ -117,6 +118,7 @@ class AlarmQueryControllerTest extends ControllerTest {
 
         // when
         ReportActionResponse result = RestAssuredMockMvc
+                .given().log().all()
                 .when().get("/alarms/report/{id}", 1)
                 .then().log().all()
                 .status(HttpStatus.OK)

--- a/backend/src/test/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepositoryTest.java
@@ -22,7 +22,7 @@ class ReportActionAlarmRepositoryTest extends RepositoryTest {
     void getInLatestOrder() {
         // given
         Member member = memberTestPersister.builder().save();
-        
+
         ReportActionAlarm reportActionAlarmA = ReportActionAlarm.builder()
                 .reportType(ReportType.POST)
                 .member(member)
@@ -54,7 +54,7 @@ class ReportActionAlarmRepositoryTest extends RepositoryTest {
         // when
         PageRequest pageRequest = PageRequest.of(0, 10);
         List<ReportActionAlarm> reportActionAlarms = reportActionAlarmRepository
-                .findByMemberOrderByCreatedAtDesc(member, pageRequest);
+                .findByMemberOrderByIdDesc(member, pageRequest);
 
         // then
         assertSoftly(softly -> {
@@ -88,11 +88,11 @@ class ReportActionAlarmRepositoryTest extends RepositoryTest {
         // when
         PageRequest pageRequestA = PageRequest.of(0, 10);
         List<ReportActionAlarm> reportActionAlarmsA = reportActionAlarmRepository
-                .findByMemberOrderByCreatedAtDesc(member, pageRequestA);
+                .findByMemberOrderByIdDesc(member, pageRequestA);
 
         PageRequest pageRequestB = PageRequest.of(1, 10);
         List<ReportActionAlarm> reportActionAlarmsB = reportActionAlarmRepository
-                .findByMemberOrderByCreatedAtDesc(member, pageRequestB);
+                .findByMemberOrderByIdDesc(member, pageRequestB);
 
         // then
         assertSoftly(softly -> {

--- a/backend/src/test/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepositoryTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 
 class ReportActionAlarmRepositoryTest extends RepositoryTest {
 
@@ -54,8 +53,9 @@ class ReportActionAlarmRepositoryTest extends RepositoryTest {
         reportActionAlarmRepository.save(reportActionAlarmC);
 
         // when
-        PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-        List<ReportActionAlarm> reportActionAlarms = reportActionAlarmRepository.findByMember(member, pageRequest);
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        List<ReportActionAlarm> reportActionAlarms = reportActionAlarmRepository.findByMemberOrderByCreatedAtDesc(
+                member, pageRequest);
 
         // then
         assertAll(
@@ -87,11 +87,13 @@ class ReportActionAlarmRepositoryTest extends RepositoryTest {
         }
 
         // when
-        PageRequest pageRequestA = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-        List<ReportActionAlarm> reportActionAlarmsA = reportActionAlarmRepository.findByMember(member, pageRequestA);
+        PageRequest pageRequestA = PageRequest.of(0, 10);
+        List<ReportActionAlarm> reportActionAlarmsA = reportActionAlarmRepository.findByMemberOrderByCreatedAtDesc(
+                member, pageRequestA);
 
-        PageRequest pageRequestB = PageRequest.of(1, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-        List<ReportActionAlarm> reportActionAlarmsB = reportActionAlarmRepository.findByMember(member, pageRequestB);
+        PageRequest pageRequestB = PageRequest.of(1, 10);
+        List<ReportActionAlarm> reportActionAlarmsB = reportActionAlarmRepository.findByMemberOrderByCreatedAtDesc(
+                member, pageRequestB);
 
         // then
         assertAll(

--- a/backend/src/test/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepositoryTest.java
+++ b/backend/src/test/java/com/votogether/domain/alarm/repository/ReportActionAlarmRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.votogether.domain.alarm.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.votogether.domain.alarm.entity.ReportActionAlarm;
 import com.votogether.domain.member.entity.Member;
@@ -23,7 +22,7 @@ class ReportActionAlarmRepositoryTest extends RepositoryTest {
     void getInLatestOrder() {
         // given
         Member member = memberTestPersister.builder().save();
-
+        
         ReportActionAlarm reportActionAlarmA = ReportActionAlarm.builder()
                 .reportType(ReportType.POST)
                 .member(member)
@@ -54,19 +53,19 @@ class ReportActionAlarmRepositoryTest extends RepositoryTest {
 
         // when
         PageRequest pageRequest = PageRequest.of(0, 10);
-        List<ReportActionAlarm> reportActionAlarms = reportActionAlarmRepository.findByMemberOrderByCreatedAtDesc(
-                member, pageRequest);
+        List<ReportActionAlarm> reportActionAlarms = reportActionAlarmRepository
+                .findByMemberOrderByCreatedAtDesc(member, pageRequest);
 
         // then
-        assertAll(
-                () -> assertThat(reportActionAlarms).hasSize(3),
-                () -> assertThat(reportActionAlarms.get(0).getReportType()).isEqualTo(
-                        reportActionAlarmC.getReportType()),
-                () -> assertThat(reportActionAlarms.get(1).getReportType()).isEqualTo(
-                        reportActionAlarmB.getReportType()),
-                () -> assertThat(reportActionAlarms.get(2).getReportType()).isEqualTo(
-                        reportActionAlarmA.getReportType())
-        );
+        assertSoftly(softly -> {
+            softly.assertThat(reportActionAlarms).hasSize(3);
+            softly.assertThat(reportActionAlarms.get(0).getReportType()).isEqualTo(
+                    reportActionAlarmC.getReportType());
+            softly.assertThat(reportActionAlarms.get(1).getReportType()).isEqualTo(
+                    reportActionAlarmB.getReportType());
+            softly.assertThat(reportActionAlarms.get(2).getReportType()).isEqualTo(
+                    reportActionAlarmA.getReportType());
+        });
     }
 
     @Test
@@ -88,17 +87,18 @@ class ReportActionAlarmRepositoryTest extends RepositoryTest {
 
         // when
         PageRequest pageRequestA = PageRequest.of(0, 10);
-        List<ReportActionAlarm> reportActionAlarmsA = reportActionAlarmRepository.findByMemberOrderByCreatedAtDesc(
-                member, pageRequestA);
+        List<ReportActionAlarm> reportActionAlarmsA = reportActionAlarmRepository
+                .findByMemberOrderByCreatedAtDesc(member, pageRequestA);
 
         PageRequest pageRequestB = PageRequest.of(1, 10);
-        List<ReportActionAlarm> reportActionAlarmsB = reportActionAlarmRepository.findByMemberOrderByCreatedAtDesc(
-                member, pageRequestB);
+        List<ReportActionAlarm> reportActionAlarmsB = reportActionAlarmRepository
+                .findByMemberOrderByCreatedAtDesc(member, pageRequestB);
 
         // then
-        assertAll(
-                () -> assertThat(reportActionAlarmsA).hasSize(10),
-                () -> assertThat(reportActionAlarmsB).hasSize(1)
+        assertSoftly(softly -> {
+                    softly.assertThat(reportActionAlarmsA).hasSize(10);
+                    softly.assertThat(reportActionAlarmsB).hasSize(1);
+                }
         );
     }
 

--- a/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/service/MemberServiceTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.votogether.domain.alarm.entity.ReportActionAlarm;
+import com.votogether.domain.alarm.repository.ReportActionAlarmRepository;
 import com.votogether.domain.category.entity.Category;
 import com.votogether.domain.category.repository.CategoryRepository;
 import com.votogether.domain.member.dto.request.MemberDetailRequest;
@@ -16,6 +18,8 @@ import com.votogether.domain.member.entity.vo.SocialType;
 import com.votogether.domain.member.repository.MemberCategoryRepository;
 import com.votogether.domain.member.repository.MemberMetricRepository;
 import com.votogether.domain.member.repository.MemberRepository;
+import com.votogether.domain.notice.entity.Notice;
+import com.votogether.domain.notice.repository.NoticeRepository;
 import com.votogether.domain.post.entity.Post;
 import com.votogether.domain.post.entity.comment.Comment;
 import com.votogether.domain.post.repository.CommentRepository;
@@ -66,6 +70,12 @@ class MemberServiceTest extends ServiceTest {
 
     @Autowired
     PostTestPersister postTestPersister;
+
+    @Autowired
+    ReportActionAlarmRepository reportActionAlarmRepository;
+
+    @Autowired
+    NoticeRepository noticeRepository;
 
     @Autowired
     EntityManager em;
@@ -478,6 +488,55 @@ class MemberServiceTest extends ServiceTest {
             assertAll(
                     () -> assertThat(memberRepository.findAll()).hasSize(1),
                     () -> assertThat(reportRepository.findAll()).isEmpty()
+            );
+        }
+
+        @Test
+        @DisplayName("회원과 신고조치알림 모두 삭제된다.")
+        void deleteWithReportActionAlarms() {
+            // given
+            Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+
+            ReportActionAlarm reportActionAlarm = ReportActionAlarm.builder()
+                    .reportType(ReportType.POST)
+                    .member(member)
+                    .isChecked(false)
+                    .target("1")
+                    .reasons("광고성, 부적합성")
+                    .build();
+            reportActionAlarmRepository.save(reportActionAlarm);
+
+            // when
+            memberService.deleteMember(member);
+
+            // then
+            assertAll(
+                    () -> assertThat(memberRepository.findAll()).isEmpty(),
+                    () -> assertThat(reportActionAlarmRepository.findAll()).isEmpty()
+            );
+        }
+
+        @Test
+        @DisplayName("회원과 작성한 공지사항 모두 삭제된다.")
+        void deleteWithNotices() {
+            // given
+            Member member = memberRepository.save(MemberFixtures.MALE_20.get());
+
+            Notice notice = Notice.builder()
+                    .member(member)
+                    .title("title")
+                    .content("content")
+                    .deadline(LocalDateTime.now().plusDays(1))
+                    .build();
+            noticeRepository.save(notice);
+
+            // when
+            memberService.deleteMember(member);
+
+            // then
+            assertAll(
+                    () -> assertThat(memberRepository.findAll()).isEmpty(),
+                    () -> assertThat(noticeRepository.findAll()).isEmpty()
             );
         }
 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -45,6 +45,10 @@ server:
     max-connections: 8192
     threads:
       max: 200
+    hikari:
+      maximumPoolSize: 10
+      connectionTimeout: 30000
+      maxLifetime: 180000
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 🔥 연관 이슈

close: #767 

## 📝 작업 요약

- 신고 조치 관련 추가 피드백을 반영했습니다. (https://github.com/woowacourse-teams/2023-votogether/pull/756)
- 회원탈퇴시 신고조치알림과 공지사항을 삭제하는 로직을 추가하였습니다.
- 커넥션풀 관련 환경변수 추가하였습니다.

## ⏰ 소요 시간

30분

## 🔎 작업 상세 설명


## 🌟 논의 사항

Q. 이벤트리스너 테스트에서 @Disable 을 붙인 이유는 깃허브 액션때문에 추가하신건가요?
