### PR TITLE
공지사항 생성, 수정, 삭제 시 캐시 초기화 로직 변경

### DIFF
--- a/frontend/src/api/notice.ts
+++ b/frontend/src/api/notice.ts
@@ -7,7 +7,7 @@ import {
 } from '@type/notice';
 import { StringDateUpToDay } from '@type/time';
 
-import { deleteFetch, getFetch, patchFetch, postFetch } from '@utils/fetch';
+import { deleteFetch, getFetch, postFetch, putFetch } from '@utils/fetch';
 
 export const transformNotice = ({
   id,
@@ -66,7 +66,7 @@ export const modifyNotice = async ({
   noticeId: number;
   notice: NoticeRequest;
 }) => {
-  return await patchFetch(`${BASE_URL}/notices/${noticeId}`, notice);
+  return await putFetch(`${BASE_URL}/notices/${noticeId}`, notice);
 };
 
 export const deleteNotice = async (noticeId: number) => {

--- a/frontend/src/hooks/query/notice/useCreateNotice.tsx
+++ b/frontend/src/hooks/query/notice/useCreateNotice.tsx
@@ -17,7 +17,9 @@ export const useCreateNotice = () => {
     (notice: NoticeRequest) => createNotice(notice),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries([QUERY_KEY.NOTICE]);
+        queryClient.invalidateQueries({
+          predicate: ({ queryKey }) => queryKey[0] === QUERY_KEY.NOTICE,
+        });
       },
       onError: error => {
         const errorMessage =

--- a/frontend/src/hooks/query/notice/useDeleteNotice.tsx
+++ b/frontend/src/hooks/query/notice/useDeleteNotice.tsx
@@ -15,7 +15,9 @@ export const useDeleteNotice = () => {
     (noticeId: number) => deleteNotice(noticeId),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries([QUERY_KEY.NOTICE]);
+        queryClient.invalidateQueries({
+          predicate: ({ queryKey }) => queryKey[0] === QUERY_KEY.NOTICE,
+        });
       },
       onError: error => {
         const errorMessage =

--- a/frontend/src/hooks/query/notice/useModifyNotice.tsx
+++ b/frontend/src/hooks/query/notice/useModifyNotice.tsx
@@ -18,7 +18,9 @@ export const useModifyNotice = () => {
       modifyNotice({ notice, noticeId }),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries([QUERY_KEY.NOTICE]);
+        queryClient.invalidateQueries({
+          predicate: ({ queryKey }) => queryKey[0] === QUERY_KEY.NOTICE,
+        });
       },
       onError: error => {
         const errorMessage =

--- a/frontend/src/mocks/notice.ts
+++ b/frontend/src/mocks/notice.ts
@@ -25,7 +25,7 @@ export const mockNotice = [
     return res(ctx.status(200), ctx.json(MOCK_NOTICE_RESPONSE));
   }),
 
-  rest.patch(`/notices/:id`, async (req, res, ctx) => {
+  rest.put(`/notices/:id`, async (req, res, ctx) => {
     const data = await req.json();
 
     MOCK_NOTICE_TEST = data.title;


### PR DESCRIPTION
## 🔥 연관 이슈

close: #801 

## 📝 작업 요약


- 공지사항 생성, 수정, 삭제 후 캐시 초기화 로직 변경

## 📆 소요시간

5분

## 📃 세부 사항

쿼리키의 첫번째 값이 공지사항이라면 전부 초기화하도록 했습니다

그 이유는 notice만 초기화 했을 때 수정,삭제 시 배너, 페이지를 사용하는 공지사항 리스트가 변하지 않을것 같아서요




