### PR TITLE
동시 로그인 시 같은 인가코드가 사용되는 문제 해결 및 카카오 회원 탈퇴 기능 보완

### DIFF
--- a/backend/src/main/java/com/votogether/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/votogether/domain/auth/controller/AuthController.java
@@ -7,7 +7,9 @@ import com.votogether.domain.auth.exception.AuthExceptionType;
 import com.votogether.domain.auth.service.AuthService;
 import com.votogether.domain.auth.service.dto.LoginTokenDto;
 import com.votogether.domain.auth.service.dto.ReissuedTokenDto;
+import com.votogether.domain.member.entity.Member;
 import com.votogether.global.exception.BadRequestException;
+import com.votogether.global.jwt.Auth;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -68,6 +70,12 @@ public class AuthController implements AuthControllerDocs {
         authService.deleteRefreshToken(refreshToken);
 
         expireCookie(httpServletResponse, refreshToken);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/member/delete")
+    public ResponseEntity<Void> disconnectFromKakao(@Auth final Member loginMember) {
+        authService.deleteMember(loginMember);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/com/votogether/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/votogether/domain/auth/controller/AuthController.java
@@ -73,8 +73,8 @@ public class AuthController implements AuthControllerDocs {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/member/delete")
-    public ResponseEntity<Void> disconnectFromKakao(@Auth final Member loginMember) {
+    @DeleteMapping("/members/me/delete")
+    public ResponseEntity<Void> deleteMember(@Auth final Member loginMember) {
         authService.deleteMember(loginMember);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/votogether/domain/auth/controller/AuthControllerDocs.java
+++ b/backend/src/main/java/com/votogether/domain/auth/controller/AuthControllerDocs.java
@@ -3,6 +3,7 @@ package com.votogether.domain.auth.controller;
 import com.votogether.domain.auth.dto.request.AccessTokenRequest;
 import com.votogether.domain.auth.dto.response.LoginResponse;
 import com.votogether.domain.auth.dto.response.ReissuedAccessTokenResponse;
+import com.votogether.domain.member.entity.Member;
 import com.votogether.global.exception.ExceptionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -57,5 +58,9 @@ public interface AuthControllerDocs {
             final HttpServletRequest httpServletRequest,
             final HttpServletResponse httpServletResponse
     );
+
+    @Operation(summary = "회원 탈퇴 하기", description = "회원 탈퇴를 한다.")
+    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")
+    ResponseEntity<Void> disconnectFromKakao(final Member loginMember);
 
 }

--- a/backend/src/main/java/com/votogether/domain/auth/controller/AuthControllerDocs.java
+++ b/backend/src/main/java/com/votogether/domain/auth/controller/AuthControllerDocs.java
@@ -60,7 +60,7 @@ public interface AuthControllerDocs {
     );
 
     @Operation(summary = "회원 탈퇴 하기", description = "회원 탈퇴를 한다.")
-    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")
-    ResponseEntity<Void> disconnectFromKakao(final Member loginMember);
+    @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
+    ResponseEntity<Void> deleteMember(final Member loginMember);
 
 }

--- a/backend/src/main/java/com/votogether/domain/auth/dto/response/OAuthDisconnectResponse.java
+++ b/backend/src/main/java/com/votogether/domain/auth/dto/response/OAuthDisconnectResponse.java
@@ -1,0 +1,6 @@
+package com.votogether.domain.auth.dto.response;
+
+public record OAuthDisconnectResponse(
+        Long id
+) {
+}

--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -86,4 +86,10 @@ public class AuthService {
         redisTemplate.delete(refreshTokenByRequest);
     }
 
+    @Transactional
+    public void deleteMember(final Member member) {
+        memberService.deleteMember(member);
+        kakaoOAuthClient.disconnectFromKakao(member);
+    }
+
 }

--- a/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/AuthService.java
@@ -88,8 +88,8 @@ public class AuthService {
 
     @Transactional
     public void deleteMember(final Member member) {
-        memberService.deleteMember(member);
         kakaoOAuthClient.disconnectFromKakao(member);
+        memberService.deleteMember(member);
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthClient.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthClient.java
@@ -34,7 +34,7 @@ public class KakaoOAuthClient {
     }
 
     public String getAccessToken(final String code) {
-        final MultiValueMap<String, String> loginInfoRequest = makeKakaoInfo(code);
+        final MultiValueMap<String, String> loginInfoRequest = makeKakaoLoginInfo(code);
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
@@ -48,7 +48,7 @@ public class KakaoOAuthClient {
         return response.accessToken();
     }
 
-    private MultiValueMap<String, String> makeKakaoInfo(final String code) {
+    private MultiValueMap<String, String> makeKakaoLoginInfo(final String code) {
         final MultiValueMap<String, String> loginInfoRequest = new LinkedMultiValueMap<>();
         loginInfoRequest.add("grant_type", kakaoOAuthLoginInfo.grantType());
         loginInfoRequest.add("client_id", kakaoOAuthLoginInfo.clientId());

--- a/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthClient.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthClient.java
@@ -3,7 +3,7 @@ package com.votogether.domain.auth.service.oauth;
 import com.votogether.domain.auth.dto.response.KakaoMemberResponse;
 import com.votogether.domain.auth.dto.response.OAuthAccessTokenResponse;
 import lombok.Getter;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -14,18 +14,16 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Getter
-@ConfigurationProperties(prefix = "oauth.kakao")
+@RequiredArgsConstructor
 @Component
 public class KakaoOAuthClient {
 
     private static final RestTemplate restTemplate = new RestTemplate();
 
-    private final MultiValueMap<String, String> info = new LinkedMultiValueMap<>();
+    private final KakaoOAuthConfig kakaoOAuthConfig;
 
     public String getAccessToken(final String code) {
-        info.remove("code");
-        info.add("code", code);
-
+        final MultiValueMap<String, String> info = makeKakaoInfo(code);
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
@@ -37,6 +35,16 @@ public class KakaoOAuthClient {
                 OAuthAccessTokenResponse.class
         ).getBody();
         return response.accessToken();
+    }
+
+    private MultiValueMap<String, String> makeKakaoInfo(final String code) {
+        final MultiValueMap<String, String> info = new LinkedMultiValueMap<>();
+        info.add("grant_type", kakaoOAuthConfig.grantType());
+        info.add("client_id", kakaoOAuthConfig.clientId());
+        info.add("client_secret", kakaoOAuthConfig.clientSecret());
+        info.add("redirect_uri", kakaoOAuthConfig.redirectUri());
+        info.add("code", code);
+        return info;
     }
 
     public KakaoMemberResponse getMemberInfo(final String accessToken) {

--- a/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthClient.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthClient.java
@@ -2,8 +2,10 @@ package com.votogether.domain.auth.service.oauth;
 
 import com.votogether.domain.auth.dto.response.KakaoMemberResponse;
 import com.votogether.domain.auth.dto.response.OAuthAccessTokenResponse;
+import com.votogether.domain.auth.dto.response.OAuthDisconnectResponse;
+import com.votogether.domain.member.entity.Member;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -14,20 +16,29 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 @Getter
-@RequiredArgsConstructor
 @Component
 public class KakaoOAuthClient {
 
     private static final RestTemplate restTemplate = new RestTemplate();
 
-    private final KakaoOAuthConfig kakaoOAuthConfig;
+    private final KakaoOAuthLoginInfo kakaoOAuthLoginInfo;
+
+    private final String appAdminKey;
+
+    public KakaoOAuthClient(
+            final KakaoOAuthLoginInfo kakaoOAuthLoginInfo,
+            @Value("${oauth.kakao.disconnect.admin-key}") final String appAdminKey
+    ) {
+        this.kakaoOAuthLoginInfo = kakaoOAuthLoginInfo;
+        this.appAdminKey = appAdminKey;
+    }
 
     public String getAccessToken(final String code) {
-        final MultiValueMap<String, String> info = makeKakaoInfo(code);
+        final MultiValueMap<String, String> loginInfoRequest = makeKakaoInfo(code);
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        final HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(info, headers);
+        final HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(loginInfoRequest, headers);
 
         final OAuthAccessTokenResponse response = restTemplate.postForEntity(
                 "https://kauth.kakao.com/oauth/token",
@@ -38,13 +49,13 @@ public class KakaoOAuthClient {
     }
 
     private MultiValueMap<String, String> makeKakaoInfo(final String code) {
-        final MultiValueMap<String, String> info = new LinkedMultiValueMap<>();
-        info.add("grant_type", kakaoOAuthConfig.grantType());
-        info.add("client_id", kakaoOAuthConfig.clientId());
-        info.add("client_secret", kakaoOAuthConfig.clientSecret());
-        info.add("redirect_uri", kakaoOAuthConfig.redirectUri());
-        info.add("code", code);
-        return info;
+        final MultiValueMap<String, String> loginInfoRequest = new LinkedMultiValueMap<>();
+        loginInfoRequest.add("grant_type", kakaoOAuthLoginInfo.grantType());
+        loginInfoRequest.add("client_id", kakaoOAuthLoginInfo.clientId());
+        loginInfoRequest.add("client_secret", kakaoOAuthLoginInfo.clientSecret());
+        loginInfoRequest.add("redirect_uri", kakaoOAuthLoginInfo.redirectUri());
+        loginInfoRequest.add("code", code);
+        return loginInfoRequest;
     }
 
     public KakaoMemberResponse getMemberInfo(final String accessToken) {
@@ -59,6 +70,24 @@ public class KakaoOAuthClient {
                 HttpMethod.GET,
                 request,
                 KakaoMemberResponse.class
+        ).getBody();
+        return response;
+    }
+
+    public OAuthDisconnectResponse disconnectFromKakao(final Member member) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + appAdminKey);
+
+        final MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("target_id_type", "user_id");
+        requestBody.add("target_id", member.getSocialId());
+
+        final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(requestBody, headers);
+
+        final OAuthDisconnectResponse response = restTemplate.postForEntity(
+                "https://kapi.kakao.com/v1/user/unlink",
+                request,
+                OAuthDisconnectResponse.class
         ).getBody();
         return response;
     }

--- a/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthConfig.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthConfig.java
@@ -1,0 +1,12 @@
+package com.votogether.domain.auth.service.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoOAuthConfig(
+        String grantType,
+        String clientId,
+        String clientSecret,
+        String redirectUri
+) {
+}

--- a/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthLoginInfo.java
+++ b/backend/src/main/java/com/votogether/domain/auth/service/oauth/KakaoOAuthLoginInfo.java
@@ -2,8 +2,8 @@ package com.votogether.domain.auth.service.oauth;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "oauth.kakao")
-public record KakaoOAuthConfig(
+@ConfigurationProperties(prefix = "oauth.kakao.login")
+public record KakaoOAuthLoginInfo(
         String grantType,
         String clientId,
         String clientSecret,

--- a/backend/src/main/java/com/votogether/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/votogether/domain/member/controller/MemberController.java
@@ -9,7 +9,6 @@ import com.votogether.global.jwt.Auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,12 +49,6 @@ public class MemberController implements MemberControllerDocs {
     public ResponseEntity<Void> checkLatestAlarm(@Auth final Member member) {
         memberService.checkLatestAlarm(member);
         return ResponseEntity.ok().build();
-    }
-
-    @DeleteMapping("/me/delete")
-    public ResponseEntity<Void> deleteMember(@Auth final Member member) {
-        memberService.deleteMember(member);
-        return ResponseEntity.noContent().build();
     }
 
 }

--- a/backend/src/main/java/com/votogether/domain/member/controller/MemberControllerDocs.java
+++ b/backend/src/main/java/com/votogether/domain/member/controller/MemberControllerDocs.java
@@ -5,7 +5,6 @@ import com.votogether.domain.member.dto.request.MemberNicknameUpdateRequest;
 import com.votogether.domain.member.dto.response.MemberInfoResponse;
 import com.votogether.domain.member.entity.Member;
 import com.votogether.global.exception.ExceptionResponse;
-import com.votogether.global.jwt.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -58,10 +57,6 @@ public interface MemberControllerDocs {
 
     @Operation(summary = "회원 최신 알림 확인", description = "회원의 최신 알림 읽은 시간을 수정한다.")
     @ApiResponse(responseCode = "200", description = "최신 알림 읽기 성공")
-    ResponseEntity<Void> checkLatestAlarm(@Auth final Member member);
-
-    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴한다.")
-    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")
-    ResponseEntity<Void> deleteMember(final Member member);
+    ResponseEntity<Void> checkLatestAlarm(final Member member);
 
 }

--- a/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/votogether/global/jwt/JwtAuthenticationFilter.java
@@ -20,13 +20,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final List<String> ALLOWED_URIS = List.of(
             "/health-check",
-            "/categories/guest",
+            "/auth/kakao/callback",
+            "/auth/silent-login",
+            "/auth/logout",
             "/swagger-ui.html",
             "/favicon.ico"
     );
 
     private static final List<String> ALLOWED_START_URIS = List.of(
-            "/auth",
             "/v3/api-docs",
             "/swagger-ui",
             "/h2-console"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -60,11 +60,10 @@ votogether:
 
 oauth:
   kakao:
-    info:
-      grant_type: ${GRANT_TYPE}
-      client_id: ${CLIENT_ID}
-      client_secret: ${CLIENT_SECRET}
-      redirect_uri: ${REDIRECT_URI}
+    grant_type: ${GRANT_TYPE}
+    client_id: ${CLIENT_ID}
+    client_secret: ${CLIENT_SECRET}
+    redirect_uri: ${REDIRECT_URI}
 
 jwt:
   token:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -60,10 +60,13 @@ votogether:
 
 oauth:
   kakao:
-    grant_type: ${GRANT_TYPE}
-    client_id: ${CLIENT_ID}
-    client_secret: ${CLIENT_SECRET}
-    redirect_uri: ${REDIRECT_URI}
+    login:
+      grant-type: ${GRANT_TYPE}
+      client-id: ${CLIENT_ID}
+      client-secret: ${CLIENT_SECRET}
+      redirect-uri: ${REDIRECT_URI}
+    disconnect:
+      admin-key: ${ADMIN_KEY}
 
 jwt:
   token:

--- a/backend/src/test/java/com/votogether/domain/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/auth/controller/AuthControllerTest.java
@@ -164,7 +164,7 @@ class AuthControllerTest extends ControllerTest {
         RestAssuredMockMvc
                 .given().log().all()
                 .headers(HttpHeaders.AUTHORIZATION, "Bearer token")
-                .when().delete("/auth/member/delete")
+                .when().delete("/auth/members/me/delete")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }

--- a/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/votogether/domain/member/controller/MemberControllerTest.java
@@ -240,24 +240,4 @@ class MemberControllerTest extends ControllerTest {
                 .statusCode(HttpStatus.OK.value());
     }
 
-    @Test
-    @DisplayName("회원 탈퇴에 성공하면 204를 반환한다.")
-    void deleteMember() throws Exception {
-        // given
-        TokenPayload tokenPayload = new TokenPayload(1L, 1L, 1L);
-
-        given(tokenProcessor.resolveToken(anyString())).willReturn("token");
-        given(tokenProcessor.parseToken(anyString())).willReturn(tokenPayload);
-        given(memberService.findById(anyLong())).willReturn(MemberFixtures.FEMALE_20.get());
-        willDoNothing().given(memberService).deleteMember(MemberFixtures.FEMALE_20.get());
-
-        // when, then
-        RestAssuredMockMvc
-                .given().log().all()
-                .headers(HttpHeaders.AUTHORIZATION, "Bearer token")
-                .when().delete("/members/me/delete")
-                .then().log().all()
-                .statusCode(HttpStatus.NO_CONTENT.value());
-    }
-
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -65,6 +65,8 @@ oauth:
       client_id: bbbbbbbbbbbbbbbbbbbbbbbbbbbb
       client_secret: cccccccccccccccccccccccccccccccccccccc
       redirect_uri: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    disconnect:
+      admin-key: dddddddddddvavaav213
 
 jwt:
   token:


### PR DESCRIPTION
## 🔥 연관 이슈

close: #827 #829 

## 📝 작업 요약

- 빈으로 등록된 클래스에서 상태로 가지고 있던 MultiValueMap을 메서드 내부로 이동시켰습니다.
- 회원탈퇴 시 카카오에 연결끊기 API요청을 통해 카카오 서버에 저장된 정보도 지워주도록 했습니다.

## ⏰ 소요 시간

- 객체지향적으로 코드를 작성하기 위해 학습한 시간까지 포함하여 1시간!
- 회원 탈퇴 기능 3시간

## 🔎 작업 상세 설명

build.gradle의 환경변수 계층을 수정했습니다. (++ ADMIN KEY가 추가되면서 환경변수 변경이 필요합니다.)
상태로 가지고 있던 MultiValueMap을 메서드 내부로 이동
카카오에 연결끊기 API를 요청하여 정보를 확실하게 삭제합니다.


## 🌟 논의 사항

현재 구조상 AuthService가 MemberService를 상태로 가지고 있기 때문에
기존에 MemberController에 있던 회원탈퇴를 AuthController에서 처리해야할 것 같습니다.
이렇게 되면 uri가 변경될 것 같은데 괜찮을까요?
