### PR TITLE
인기순 전체 게시글 목록 조회 기능의 성능 개선을 위한 QueryDsl 코드 수정

### DIFF
--- a/backend/src/main/java/com/votogether/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/votogether/domain/post/repository/PostCustomRepositoryImpl.java
@@ -51,10 +51,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
             final Long categoryId,
             final Pageable pageable
     ) {
-        return jpaQueryFactory
-                .selectDistinct(post)
+        List<Long> postIds = jpaQueryFactory
+                .select(post.id)
                 .from(post)
-                .join(post.writer).fetchJoin()
                 .leftJoin(post.postCategories, postCategory)
                 .where(
                         categoryIdEq(categoryId),
@@ -64,6 +63,14 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .orderBy(orderBy(postSortType))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .fetch();
+
+        return jpaQueryFactory
+                .selectDistinct(post)
+                .from(post)
+                .join(post.writer).fetchJoin()
+                .where(post.id.in(postIds))
+                .orderBy(orderBy(postSortType))
                 .fetch();
     }
 


### PR DESCRIPTION
## 🔥 연관 이슈

close: #833 

## 📝 작업 요약

인기순 전체 게시글 목록 조회 기능의 성능 개선을 위한 QueryDsl 코드 수정

## ⏰ 소요 시간

2일 (자세히 학습하는 시간이 좀 걸림)

## 🔎 작업 상세 설명

QueryDsl에서 시간이 많이 드는 부분을 서브쿼리로 추출한 후 그 쿼리에 커버링 인덱스를 적용합니다.