### PR TITLE
홈 화면 서스펜스 범위 재지정 및 셀렉트 컴포넌트 리팩터링

### DIFF
--- a/frontend/src/api/userInfo.ts
+++ b/frontend/src/api/userInfo.ts
@@ -50,7 +50,7 @@ export const modifyNickname = async (nickname: string) => {
 };
 
 export const withdrawalMembership = async () => {
-  await deleteFetch(`${BASE_URL}/members/me/delete`);
+  await deleteFetch(`${BASE_URL}/auth/members/me/delete`);
 };
 
 export const updateUserInfo = async (userInfo: UpdateUserInfoRequest) => {

--- a/frontend/src/components/ReportModal/index.tsx
+++ b/frontend/src/components/ReportModal/index.tsx
@@ -24,7 +24,8 @@ export default function ReportModal({
 }: UserReportModalProps) {
   const { name, reportMessageList } = REPORT_TYPE[reportType];
   const defaultReportMessage = Object.keys(reportMessageList)[0] as ReportMessage;
-  const { selectedOption, handleOptionChange } = useSelect<ReportMessage>(defaultReportMessage);
+  const { selectedOption, handleOptionChange, isSelectOpen, toggleSelect } =
+    useSelect<ReportMessage>(defaultReportMessage);
 
   const handlePrimaryButtonClick = () => {
     if (isReportLoading) return;
@@ -49,6 +50,8 @@ export default function ReportModal({
     >
       <S.ModalBody>
         <Select
+          isOpen={isSelectOpen}
+          toggleSelect={toggleSelect}
           aria-label={`${name} 방법 선택`}
           optionList={reportMessageList}
           handleOptionChange={handleOptionChange}

--- a/frontend/src/components/common/Select/Select.stories.tsx
+++ b/frontend/src/components/common/Select/Select.stories.tsx
@@ -37,7 +37,7 @@ export const SelectExample = () => {
   );
 };
 
-export const Disable = () => {
+export const Disabled = () => {
   const { handleOptionChange, isSelectOpen, selectedOption, toggleSelect } =
     useSelect<SortingOptionType>('popular');
 

--- a/frontend/src/components/common/Select/Select.stories.tsx
+++ b/frontend/src/components/common/Select/Select.stories.tsx
@@ -1,6 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta } from '@storybook/react';
 
-import { useState } from 'react';
+import { useSelect } from '@hooks';
 
 import Select from '.';
 
@@ -10,19 +10,10 @@ const meta: Meta<typeof Select> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof Select>;
 
-const postStatus = ['all', 'progress', 'closed'] as const;
 const sortingOption = ['popular', 'latest', 'longLong'] as const;
 
-type PostStatusType = (typeof postStatus)[number];
 type SortingOptionType = (typeof sortingOption)[number];
-
-const MOCK_STATUS_OPTION: Record<PostStatusType, string> = {
-  all: '전체',
-  progress: '진행중',
-  closed: '마감완료',
-};
 
 const MOCK_SORTING_OPTION: Record<SortingOptionType, string> = {
   popular: '인기순',
@@ -30,53 +21,35 @@ const MOCK_SORTING_OPTION: Record<SortingOptionType, string> = {
   longLong: '엄청나게 긴 옵션',
 };
 
-export const PostStatus: Story = {
-  render: () => (
-    <Select<PostStatusType>
-      aria-label="게시글 진행 상태 선택"
-      selectedOption="진행중"
-      optionList={MOCK_STATUS_OPTION}
-      handleOptionChange={() => {}}
-    />
-  ),
-};
-
-export const Sorting: Story = {
-  render: () => (
-    <Select
-      aria-label="게시글 정렬 방법 선택"
-      selectedOption="최신순"
-      optionList={MOCK_SORTING_OPTION}
-      handleOptionChange={() => {}}
-    />
-  ),
-};
-
-export const Disabled: Story = {
-  render: () => (
-    <Select
-      aria-label="게시글 정렬 방법 선택"
-      isDisabled={true}
-      selectedOption="최신순"
-      optionList={MOCK_SORTING_OPTION}
-      handleOptionChange={() => {}}
-    />
-  ),
-};
-
 export const SelectExample = () => {
-  const [selectedOption, setSelectedOption] = useState<SortingOptionType>('popular');
-
-  const handelOptionChange = (option: SortingOptionType) => {
-    setSelectedOption(option);
-  };
+  const { handleOptionChange, isSelectOpen, selectedOption, toggleSelect } =
+    useSelect<SortingOptionType>('popular');
 
   return (
     <Select<SortingOptionType>
+      isOpen={isSelectOpen}
+      toggleSelect={toggleSelect}
       aria-label="게시글 정렬 방법 선택"
       selectedOption={MOCK_SORTING_OPTION[selectedOption]}
       optionList={MOCK_SORTING_OPTION}
-      handleOptionChange={handelOptionChange}
+      handleOptionChange={handleOptionChange}
+    />
+  );
+};
+
+export const Disable = () => {
+  const { handleOptionChange, isSelectOpen, selectedOption, toggleSelect } =
+    useSelect<SortingOptionType>('popular');
+
+  return (
+    <Select
+      isOpen={isSelectOpen}
+      toggleSelect={toggleSelect}
+      aria-label="게시글 정렬 방법 선택"
+      isDisabled={true}
+      selectedOption={selectedOption}
+      optionList={MOCK_SORTING_OPTION}
+      handleOptionChange={handleOptionChange}
     />
   );
 };

--- a/frontend/src/components/common/Select/index.tsx
+++ b/frontend/src/components/common/Select/index.tsx
@@ -27,7 +27,7 @@ export default function Select<T extends string>({
 }: SelectProps<T>) {
   const optionKeyList = Object.keys(optionList) as T[];
 
-  const toggleOpen = () => {
+  const handleToggleOpen = () => {
     if (isDisabled) return;
     toggleSelect();
   };
@@ -46,7 +46,7 @@ export default function Select<T extends string>({
 
   return (
     <S.Container>
-      <S.SelectedContainer onClick={toggleOpen} $status={getSelectStatus()} {...rest}>
+      <S.SelectedContainer onClick={handleToggleOpen} $status={getSelectStatus()} {...rest}>
         <span>{selectedOption}</span>
         <S.Image src={isOpen ? chevronUp : chevronDown} alt="" $isSelected={isOpen} />
       </S.SelectedContainer>

--- a/frontend/src/components/common/Select/index.tsx
+++ b/frontend/src/components/common/Select/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import chevronDown from '@assets/chevron-down.svg';
 import chevronUp from '@assets/chevron-up.svg';
@@ -10,6 +10,8 @@ export interface SelectProps<T extends string>
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   selectedOption: string;
   optionList: Record<T, string>;
+  isOpen: boolean;
+  toggleSelect: () => void;
   handleOptionChange: (option: T) => void;
   isDisabled?: boolean;
 }
@@ -18,20 +20,16 @@ export default function Select<T extends string>({
   selectedOption,
   optionList,
   handleOptionChange,
+  isOpen,
+  toggleSelect,
   isDisabled = false,
   ...rest
 }: SelectProps<T>) {
   const optionKeyList = Object.keys(optionList) as T[];
-  const [isOpen, setIsOpen] = useState(false);
 
   const toggleOpen = () => {
     if (isDisabled) return;
-    setIsOpen(prev => !prev);
-  };
-
-  const handleSelectClick = (option: T) => {
-    handleOptionChange(option);
-    setIsOpen(false);
+    toggleSelect();
   };
 
   const getSelectStatus = () => {
@@ -64,7 +62,7 @@ export default function Select<T extends string>({
               <S.OptionContainer
                 tabIndex={0}
                 key={optionKey}
-                onClick={() => handleSelectClick(optionKey)}
+                onClick={() => handleOptionChange(optionKey)}
               >
                 {optionList[optionKey]}
               </S.OptionContainer>

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useContext, useRef } from 'react';
+import React, { MouseEvent, Suspense, useContext, useRef } from 'react';
 
 import { useSelect } from '@hooks';
 
@@ -22,10 +22,22 @@ export default function PostList() {
 
   const { postOption, setPostOption } = useContext(PostOptionContext);
 
-  const { selectedOption: selectedStatusOption, handleOptionChange: handleStatusOptionChange } =
-    useSelect<PostStatus>(postOption.status);
-  const { selectedOption: selectedSortingOption, handleOptionChange: handleSortingOptionChange } =
-    useSelect<PostSorting>(postOption.sorting);
+  const {
+    selectedOption: selectedStatusOption,
+    handleOptionChange: handleStatusOptionChange,
+    isSelectOpen: isStatusSelectOpen,
+    toggleSelect: toggleStatusSelect,
+    selectRef: statusSelectRef,
+    handleCloseClick: handleStatusClose,
+  } = useSelect<PostStatus>(postOption.status);
+  const {
+    selectedOption: selectedSortingOption,
+    handleOptionChange: handleSortingOptionChange,
+    isSelectOpen: isSortingSelectOpen,
+    toggleSelect: toggleSortingSelect,
+    selectRef: sortingSelectRef,
+    handleCloseClick: handleSortingClose,
+  } = useSelect<PostSorting>(postOption.sorting);
 
   const focusTopContent = () => {
     if (!topButtonRef.current) return;
@@ -34,11 +46,18 @@ export default function PostList() {
   };
 
   return (
-    <S.Container>
+    <S.Container
+      onClick={(event: MouseEvent<HTMLDivElement>) => {
+        handleStatusClose(event);
+        handleSortingClose(event);
+      }}
+    >
       <button ref={topButtonRef} role="contentinfo" aria-label="최상단입니다" />
       <S.SelectContainer>
-        <S.SelectWrapper>
+        <S.SelectWrapper ref={statusSelectRef}>
           <Select<PostStatus>
+            isOpen={isStatusSelectOpen}
+            toggleSelect={toggleStatusSelect}
             aria-label={`마감 여부로 게시글 정렬 선택, 현재 옵션은 ${STATUS_OPTION[selectedStatusOption]}`}
             handleOptionChange={async (value: PostStatus) => {
               if (value === selectedStatusOption) return;
@@ -54,8 +73,10 @@ export default function PostList() {
             selectedOption={STATUS_OPTION[selectedStatusOption]}
           />
         </S.SelectWrapper>
-        <S.SelectWrapper>
+        <S.SelectWrapper ref={sortingSelectRef}>
           <Select<PostSorting>
+            isOpen={isSortingSelectOpen}
+            toggleSelect={toggleSortingSelect}
             aria-label={`인기순/최신순으로 게시글 정렬 선택, 현재 옵션은 ${SORTING_OPTION[selectedSortingOption]}`}
             handleOptionChange={(value: PostSorting) => {
               if (value === selectedSortingOption) return;

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -39,7 +39,7 @@ export default function PostList() {
     handleCloseClick: handleSortingClose,
   } = useSelect<PostSorting>(postOption.sorting);
 
-  const focusTopContent = () => {
+  const handleFocusTopContent = () => {
     if (!topButtonRef.current) return;
 
     topButtonRef.current.focus();
@@ -100,7 +100,7 @@ export default function PostList() {
             </S.SkeletonWrapper>
           }
         >
-          <PostListFetcher focusTopContent={focusTopContent} />
+          <PostListFetcher handleFocusTopContent={handleFocusTopContent} />
         </Suspense>
       </ErrorBoundary>
       <S.HiddenLink aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE} />

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -1,35 +1,24 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { Suspense, useContext, useRef } from 'react';
 
 import { useSelect } from '@hooks';
 
-import { AuthContext } from '@hooks/context/auth';
 import { PostOptionContext } from '@hooks/context/postOption';
-import { usePostList } from '@hooks/query/usePostList';
-import { useIntersectionObserver } from '@hooks/useIntersectionObserver';
-import { usePostRequestInfo } from '@hooks/usePostRequestInfo';
 
+import ErrorBoundary from '@pages/ErrorBoundary';
 import { SORTING_OPTION, STATUS_OPTION } from '@pages/HomePage/constants';
 import { PostSorting, PostStatus } from '@pages/HomePage/types';
 
 import Select from '@components/common/Select';
 import Skeleton from '@components/common/Skeleton';
-import Post from '@components/post/Post';
 
 import { PATH } from '@constants/path';
 
-import EmptyPostList from '../EmptyPostList';
+import PostListFetcher from '../PostListFetcher';
 
 import * as S from './style';
 
 export default function PostList() {
   const topButtonRef = useRef<HTMLButtonElement>(null);
-  const { postType, postOptionalOption } = usePostRequestInfo();
-  const { loggedInfo } = useContext(AuthContext);
-  const { targetRef, isIntersecting } = useIntersectionObserver({
-    root: null,
-    rootMargin: '',
-    thresholds: 0.1,
-  });
 
   const { postOption, setPostOption } = useContext(PostOptionContext);
 
@@ -38,27 +27,11 @@ export default function PostList() {
   const { selectedOption: selectedSortingOption, handleOptionChange: handleSortingOptionChange } =
     useSelect<PostSorting>(postOption.sorting);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPostListEmpty } = usePostList(
-    {
-      postType,
-      postSorting: selectedSortingOption,
-      postStatus: selectedStatusOption,
-      isLoggedIn: loggedInfo.isLoggedIn,
-    },
-    postOptionalOption
-  );
-
   const focusTopContent = () => {
     if (!topButtonRef.current) return;
 
     topButtonRef.current.focus();
   };
-
-  useEffect(() => {
-    if (isIntersecting && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [isIntersecting, fetchNextPage, hasNextPage]);
 
   return (
     <S.Container>
@@ -67,11 +40,14 @@ export default function PostList() {
         <S.SelectWrapper>
           <Select<PostStatus>
             aria-label={`마감 여부로 게시글 정렬 선택, 현재 옵션은 ${STATUS_OPTION[selectedStatusOption]}`}
-            handleOptionChange={(value: PostStatus) => {
+            handleOptionChange={async (value: PostStatus) => {
+              if (value === selectedStatusOption) return;
+
               setPostOption({
                 ...postOption,
                 status: value,
               });
+
               handleStatusOptionChange(value);
             }}
             optionList={STATUS_OPTION}
@@ -82,6 +58,8 @@ export default function PostList() {
           <Select<PostSorting>
             aria-label={`인기순/최신순으로 게시글 정렬 선택, 현재 옵션은 ${SORTING_OPTION[selectedSortingOption]}`}
             handleOptionChange={(value: PostSorting) => {
+              if (value === selectedSortingOption) return;
+
               setPostOption({
                 ...postOption,
                 sorting: value,
@@ -93,28 +71,12 @@ export default function PostList() {
           />
         </S.SelectWrapper>
       </S.SelectContainer>
+      <ErrorBoundary hasIcon={true} hasRetryInteraction={true}>
+        <Suspense fallback={<Skeleton isLarge={true} />}>
+          <PostListFetcher focusTopContent={focusTopContent} />
+        </Suspense>
+      </ErrorBoundary>
       <S.HiddenLink aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE} />
-      <S.PostListContainer>
-        {isPostListEmpty && (
-          <EmptyPostList status={selectedStatusOption} keyword={postOptionalOption.keyword} />
-        )}
-        {data?.pages.map((postListInfo, pageIndex) => (
-          <React.Fragment key={pageIndex}>
-            {postListInfo.postList.map((post, index) => {
-              if (index === 7) {
-                return <Post key={post.postId} ref={targetRef} isPreview={true} postInfo={post} />;
-              }
-
-              return <Post key={post.postId} isPreview={true} postInfo={post} />;
-            })}
-            <li key={`${pageIndex}UserButton`}>
-              <S.HiddenButton onClick={focusTopContent} aria-label="스크롤 맨 위로가기" />
-              <S.HiddenLink aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE} />
-            </li>
-          </React.Fragment>
-        ))}
-        {isFetchingNextPage && <Skeleton isLarge={false} />}
-      </S.PostListContainer>
     </S.Container>
   );
 }

--- a/frontend/src/components/post/PostList/index.tsx
+++ b/frontend/src/components/post/PostList/index.tsx
@@ -93,7 +93,13 @@ export default function PostList() {
         </S.SelectWrapper>
       </S.SelectContainer>
       <ErrorBoundary hasIcon={true} hasRetryInteraction={true}>
-        <Suspense fallback={<Skeleton isLarge={true} />}>
+        <Suspense
+          fallback={
+            <S.SkeletonWrapper>
+              <Skeleton isLarge={true} />
+            </S.SkeletonWrapper>
+          }
+        >
           <PostListFetcher focusTopContent={focusTopContent} />
         </Suspense>
       </ErrorBoundary>

--- a/frontend/src/components/post/PostList/style.ts
+++ b/frontend/src/components/post/PostList/style.ts
@@ -48,3 +48,7 @@ export const SelectWrapper = styled.div`
 export const HiddenLink = styled(Link)`
   position: absolute;
 `;
+
+export const SkeletonWrapper = styled.div`
+  padding: 30px 20px;
+`;

--- a/frontend/src/components/post/PostList/style.ts
+++ b/frontend/src/components/post/PostList/style.ts
@@ -45,10 +45,6 @@ export const SelectWrapper = styled.div`
   }
 `;
 
-export const HiddenButton = styled.button`
-  position: absolute;
-`;
-
 export const HiddenLink = styled(Link)`
   position: absolute;
 `;

--- a/frontend/src/components/post/PostListFetcher/index.tsx
+++ b/frontend/src/components/post/PostListFetcher/index.tsx
@@ -1,0 +1,73 @@
+import React, { useContext, useEffect } from 'react';
+
+import {
+  AuthContext,
+  PostOptionContext,
+  useIntersectionObserver,
+  usePostList,
+  usePostRequestInfo,
+} from '@hooks';
+
+import Skeleton from '@components/common/Skeleton';
+
+import { PATH } from '@constants/path';
+
+import EmptyPostList from '../EmptyPostList';
+import Post from '../Post';
+
+import * as S from './style';
+
+interface PostListFetcherProps {
+  focusTopContent: () => void;
+}
+
+export default function PostListFetcher({ focusTopContent }: PostListFetcherProps) {
+  const { postOption } = useContext(PostOptionContext);
+  const { postType, postOptionalOption } = usePostRequestInfo();
+  const { loggedInfo } = useContext(AuthContext);
+  const { targetRef, isIntersecting } = useIntersectionObserver({
+    root: null,
+    rootMargin: '',
+    thresholds: 0.1,
+  });
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPostListEmpty } = usePostList(
+    {
+      postType,
+      postSorting: postOption.sorting,
+      postStatus: postOption.status,
+      isLoggedIn: loggedInfo.isLoggedIn,
+    },
+    postOptionalOption
+  );
+
+  useEffect(() => {
+    if (isIntersecting && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [isIntersecting, fetchNextPage, hasNextPage]);
+
+  return (
+    <S.PostListContainer>
+      {isPostListEmpty && (
+        <EmptyPostList status={postOption.status} keyword={postOptionalOption.keyword} />
+      )}
+      {data?.pages.map((postListInfo, pageIndex) => (
+        <React.Fragment key={pageIndex}>
+          {postListInfo.postList.map((post, index) => {
+            if (index === 7) {
+              return <Post key={post.postId} ref={targetRef} isPreview={true} postInfo={post} />;
+            }
+
+            return <Post key={post.postId} isPreview={true} postInfo={post} />;
+          })}
+          <li key={`${pageIndex}UserButton`}>
+            <S.HiddenButton onClick={focusTopContent} aria-label="스크롤 맨 위로가기" />
+            <S.HiddenLink aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE} />
+          </li>
+        </React.Fragment>
+      ))}
+      {isFetchingNextPage && <Skeleton isLarge={false} />}
+    </S.PostListContainer>
+  );
+}

--- a/frontend/src/components/post/PostListFetcher/index.tsx
+++ b/frontend/src/components/post/PostListFetcher/index.tsx
@@ -18,10 +18,10 @@ import Post from '../Post';
 import * as S from './style';
 
 interface PostListFetcherProps {
-  focusTopContent: () => void;
+  handleFocusTopContent: () => void;
 }
 
-export default function PostListFetcher({ focusTopContent }: PostListFetcherProps) {
+export default function PostListFetcher({ handleFocusTopContent }: PostListFetcherProps) {
   const { postOption } = useContext(PostOptionContext);
   const { postType, postOptionalOption } = usePostRequestInfo();
   const { loggedInfo } = useContext(AuthContext);
@@ -62,7 +62,7 @@ export default function PostListFetcher({ focusTopContent }: PostListFetcherProp
             return <Post key={post.postId} isPreview={true} postInfo={post} />;
           })}
           <li key={`${pageIndex}UserButton`}>
-            <S.HiddenButton onClick={focusTopContent} aria-label="스크롤 맨 위로가기" />
+            <S.HiddenButton onClick={handleFocusTopContent} aria-label="스크롤 맨 위로가기" />
             <S.HiddenLink aria-label="게시글 작성 페이지로 이동" to={PATH.POST_WRITE} />
           </li>
         </React.Fragment>

--- a/frontend/src/components/post/PostListFetcher/style.ts
+++ b/frontend/src/components/post/PostListFetcher/style.ts
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+
+import { styled } from 'styled-components';
+
+export const PostListContainer = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+
+  padding: 30px 20px;
+`;
+
+export const HiddenButton = styled.button`
+  position: absolute;
+`;
+
+export const HiddenLink = styled(Link)`
+  position: absolute;
+`;

--- a/frontend/src/hooks/useSelect.tsx
+++ b/frontend/src/hooks/useSelect.tsx
@@ -1,11 +1,40 @@
-import { useState } from 'react';
+import { MouseEvent, useRef, useState } from 'react';
 
 export const useSelect = <T,>(initialOption: T) => {
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const selectRef = useRef<HTMLDivElement>(null);
   const [selectedOption, setSelectedOption] = useState<T>(initialOption);
 
   const handleOptionChange = (option: T) => {
     setSelectedOption(option);
+    setIsSelectOpen(false);
   };
 
-  return { selectedOption, handleOptionChange };
+  const toggleSelect = () => {
+    setIsSelectOpen(prev => !prev);
+  };
+
+  const handleCloseClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (!selectRef.current) return;
+
+    const modalBoundary = selectRef.current.getBoundingClientRect();
+
+    if (
+      modalBoundary.left > event.clientX ||
+      modalBoundary.right < event.clientX ||
+      modalBoundary.top > event.clientY ||
+      modalBoundary.bottom < event.clientY
+    ) {
+      setIsSelectOpen(false);
+    }
+  };
+
+  return {
+    selectRef,
+    selectedOption,
+    handleOptionChange,
+    isSelectOpen,
+    toggleSelect,
+    handleCloseClick,
+  };
 };

--- a/frontend/src/mocks/userInfo.ts
+++ b/frontend/src/mocks/userInfo.ts
@@ -17,7 +17,7 @@ export const mockUserInfo = [
     return res(ctx.status(200), ctx.json({ ok: '닉네임이 성공적으로 수정되었습니다!' }));
   }),
 
-  rest.delete('/members/me/delete', (req, res, ctx) => {
+  rest.delete('/auth/members/me/delete', (req, res, ctx) => {
     MOCK_USER_INFO.nickname = 'cancel';
 
     return res(ctx.status(204));

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -6,7 +6,6 @@ import { useReadLatestAlarm } from '@hooks/query/user/useReadLatestAlarm';
 import { useBannerToggle } from '@hooks/useBannerToggle';
 import { useDrawer } from '@hooks/useDrawer';
 
-import ErrorBoundary from '@pages/ErrorBoundary';
 import NoRenderErrorBoundary from '@pages/NoRenderErrorBoundary';
 
 import AlarmContainer from '@components/AlarmContainer';
@@ -16,7 +15,6 @@ import Dashboard from '@components/common/Dashboard';
 import Drawer from '@components/common/Drawer';
 import Layout from '@components/common/Layout';
 import NarrowMainHeader from '@components/common/NarrowMainHeader';
-import Skeleton from '@components/common/Skeleton';
 import UpButton from '@components/common/UpButton';
 import BannerFetcher from '@components/notice/BannerFetcher';
 import BannerSkeleton from '@components/notice/BannerSkeleton';
@@ -97,11 +95,7 @@ export default function HomePage() {
             )}
           </Drawer>
         </S.DrawerWrapper>
-        <ErrorBoundary hasIcon={true} hasRetryInteraction={true}>
-          <Suspense fallback={<Skeleton isLarge={true} />}>
-            <PostList />
-          </Suspense>
-        </ErrorBoundary>
+        <PostList />
         <S.ButtonContainer>
           <UpButton onClick={smoothScrollToTop} />
           <S.AddButtonWrapper to={PATH.POST_WRITE}>


### PR DESCRIPTION
## 🔥 연관 이슈

close: #839 

## 📝 작업 요약

-  홈 화면에서 게시글 목록 서스펜스 범위가 게시글 정렬 옵션과 같이 렌더링 되던 것을 게시글 목록만 서스펜스로 감싸주었음
- 셀렉트 컴포넌트 내부의 isOpen 상태 값을 useSelect 커스텀 훅으로 이동
- 게시글 목록에서 셀렉트 밖을 누르면 셀렉트가 닫히도록 구현

## ⏰ 소요 시간

- 1시간 
- 생각보다 30분이 더 오래 걸렸는데 셀렉트 밖을 누를 때 select에 ref를 넘겨줘야 한다고 생각해서 진행하는데 타입 때문에 오래 걸렸음
- 셀렉트에 ref를 넘겨주지 않고 셀렉트를 감싸는 SelectWrapper에 ref를 주는 방향으로 생각을 바꿔서 진행

## 🔎 작업 상세 설명

### 이전 화면

https://github.com/woowacourse-teams/2023-votogether/assets/80146176/4658d9ba-8695-4e97-87da-060b3597f3d1

### 바꾼 화면

https://github.com/woowacourse-teams/2023-votogether/assets/80146176/5c267c46-c1be-4057-9157-3a4056403174


### 셀렉트 닫히는 모습

게시글 목록 컨테이너에 클릭 이벤트를 걸어서 게시글 목록 밖을 클릭했을 때는 닫히지 않아요. 그렇지만 저는 이 정도면 만족해서  PR 올립니다

https://github.com/woowacourse-teams/2023-votogether/assets/80146176/46ad9bce-cb94-42f2-85f6-ca04bb4a6a43



